### PR TITLE
Refactor rendering system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
 name = "hurban_selector"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "imgui 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ log = "0.4.7"
 nalgebra = "0.18.0"
 env_logger = "0.6.2"
 png = "0.15.0"
+bitflags = "1.1.0"
 
 [build-dependencies]
 shaderc = "0.6.0"

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::f32;
 
 use nalgebra::{Matrix4, Point3, Rotation3, Vector3};
+use wgpu::winit;
 
 const TWO_PI: f32 = f32::consts::PI * 2.0;
 const ZOOM_SPEED_BASE: f32 = 0.95;
@@ -33,14 +34,14 @@ pub struct Camera {
 
 impl Camera {
     pub fn new(
-        screen_size: [f32; 2],
+        window_size: [f32; 2],
         radius: f32,
         azimuthal_angle: f32,
         polar_angle: f32,
         options: CameraOptions,
     ) -> Camera {
         Camera {
-            aspect_ratio: screen_size[0] / screen_size[1],
+            aspect_ratio: window_size[0] / window_size[1],
             radius: clamp(radius, options.radius_min, options.radius_max),
             azimuthal_angle: azimuthal_angle % TWO_PI,
             polar_angle: clamp(
@@ -54,8 +55,8 @@ impl Camera {
         }
     }
 
-    pub fn set_screen_size(&mut self, screen_size: [f32; 2]) {
-        self.aspect_ratio = screen_size[0] / screen_size[1];
+    pub fn set_window_size(&mut self, window_size: winit::dpi::PhysicalSize) {
+        self.aspect_ratio = (window_size.width / window_size.height) as f32;
     }
 
     pub fn reset_origin(&mut self) {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -34,14 +34,14 @@ pub struct Camera {
 
 impl Camera {
     pub fn new(
-        window_size: [f32; 2],
+        window_size: winit::dpi::PhysicalSize,
         radius: f32,
         azimuthal_angle: f32,
         polar_angle: f32,
         options: CameraOptions,
     ) -> Camera {
         Camera {
-            aspect_ratio: window_size[0] / window_size[1],
+            aspect_ratio: (window_size.width / window_size.height) as f32,
             radius: clamp(radius, options.radius_min, options.radius_max),
             azimuthal_angle: azimuthal_angle % TWO_PI,
             polar_angle: clamp(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
 pub mod camera;
 pub mod geometry;
-pub mod imgui_renderer;
 pub mod importer;
 pub mod input;
-pub mod shader;
+pub mod renderer;
 pub mod ui;
-pub mod viewport_renderer;
 
 mod convert;

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,12 +284,12 @@ fn main() {
         imgui_winit_platform.prepare_render(&imgui_ui, &window);
         let imgui_draw_data = imgui_ui.render();
 
-        let mut render = renderer.begin_render();
+        let mut render_pass = renderer.begin_render_pass();
 
-        render.draw_geometry(&scene_renderer_geometry_ids[..]);
-        render.draw_ui(&imgui_draw_data);
+        render_pass.draw_geometry(&scene_renderer_geometry_ids[..]);
+        render_pass.draw_ui(&imgui_draw_data);
 
-        render.finish();
+        render_pass.finish();
     }
 
     for renderer_geometry_id in scene_renderer_geometry_ids {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,10 @@ use wgpu::winit;
 
 use hurban_selector::camera::{Camera, CameraOptions};
 use hurban_selector::geometry;
-use hurban_selector::imgui_renderer::ImguiRenderer;
 use hurban_selector::importer::Importer;
 use hurban_selector::input::InputManager;
+use hurban_selector::renderer::{Msaa, Renderer, RendererOptions, SceneRendererGeometry};
 use hurban_selector::ui;
-use hurban_selector::viewport_renderer::{
-    Msaa, RendererGeometry, ViewportRenderer, ViewportRendererOptions,
-};
-
-const SWAP_CHAIN_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
 
 fn main() {
     env_logger::init();
@@ -38,18 +33,6 @@ fn main() {
         .to_physical(window.get_hidpi_factor());
 
     let wgpu_instance = wgpu::Instance::new();
-    let surface = wgpu_instance.create_surface(&window);
-    let adapter = wgpu_instance.get_adapter(&wgpu::AdapterDescriptor {
-        power_preference: wgpu::PowerPreference::HighPerformance,
-    });
-
-    let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
-        extensions: wgpu::Extensions {
-            anisotropic_filtering: false,
-        },
-        limits: wgpu::Limits::default(),
-    });
-    let mut swap_chain = create_swap_chain(&device, &surface, window_size);
 
     let mut input_manager = InputManager::new();
     let mut camera = Camera::new(
@@ -70,18 +53,22 @@ fn main() {
             zfar: 1000.0,
         },
     );
-    let mut viewport_renderer = ViewportRenderer::new(
-        &mut device,
-        window_size,
+
+    let (mut imgui_context, mut imgui_winit_platform) = ui::init(&window);
+
+    let mut renderer = Renderer::new(
+        &wgpu_instance,
+        &window,
         &camera.projection_matrix(),
         &camera.view_matrix(),
-        ViewportRendererOptions {
-            // FIXME: Msaa X4 is the only value currently working on
-            // all devices we tried. We should query the device
-            // capabilities (but how?!) to select the proper MSAA
-            // value.
+        imgui_context.fonts(),
+        RendererOptions {
+            // FIXME: @Correctness Msaa X4 is the only value currently
+            // working on all devices we tried. Once device
+            // capabilities are queryable with wgpu `Limits`, we
+            // should have a chain of options the renderer tries
+            // before giving up.
             msaa: Msaa::X4,
-            output_format: SWAP_CHAIN_FORMAT,
         },
     );
 
@@ -99,21 +86,12 @@ fn main() {
 
     let mut scene_renderer_geometry_ids = Vec::with_capacity(scene_geometries.len());
     for geometry in &scene_geometries {
-        let renderer_geometry = RendererGeometry::from_geometry(geometry);
-        let renderer_geometry_id = viewport_renderer
-            .add_geometry(&device, &renderer_geometry)
+        let renderer_geometry = SceneRendererGeometry::from_geometry(geometry);
+        let renderer_geometry_id = renderer
+            .add_scene_geometry(&renderer_geometry)
             .expect("Failed to add geometry to renderer");
         scene_renderer_geometry_ids.push(renderer_geometry_id);
     }
-
-    let (mut imgui_context, mut winit_platform) = ui::init(&window);
-    let mut imgui_renderer = ImguiRenderer::new(
-        &mut imgui_context,
-        &mut device,
-        wgpu::TextureFormat::Bgra8Unorm,
-        None,
-    )
-    .expect("Failed to create imgui renderer");
 
     let time_start = Instant::now();
     let mut time = time_start;
@@ -168,22 +146,22 @@ fn main() {
 
         event_loop.poll_events(|event| {
             input_events.push(event.clone());
-            winit_platform.handle_event(imgui_context.io_mut(), &window, &event);
+            imgui_winit_platform.handle_event(imgui_context.io_mut(), &window, &event);
         });
 
         // Start UI and input manger frames
-        winit_platform
+        imgui_winit_platform
             .prepare_frame(imgui_context.io_mut(), &window)
             .expect("Failed to start imgui frame");
         let imgui_ui = imgui_context.frame();
-        let imgui_ui_io = imgui_ui.io();
+        let imgui_io = imgui_ui.io();
 
         input_manager.start_frame();
 
         // Imgui's IO is updated after current frame starts, else it'd contain
         // outdated values.
-        let ui_captured_keyboard = imgui_ui_io.want_capture_keyboard;
-        let ui_captured_mouse = imgui_ui_io.want_capture_mouse;
+        let ui_captured_keyboard = imgui_io.want_capture_keyboard;
+        let ui_captured_mouse = imgui_io.want_capture_mouse;
 
         for event in input_events {
             input_manager.process_event(event, ui_captured_keyboard, ui_captured_mouse);
@@ -218,9 +196,10 @@ fn main() {
                         Ok(models) => {
                             for model in models {
                                 let geometry = model.geometry;
-                                let renderer_geometry = RendererGeometry::from_geometry(&geometry);
-                                let renderer_geometry_id = viewport_renderer
-                                    .add_geometry(&device, &renderer_geometry)
+                                let renderer_geometry =
+                                    SceneRendererGeometry::from_geometry(&geometry);
+                                let renderer_geometry_id = renderer
+                                    .add_scene_geometry(&renderer_geometry)
                                     .expect("Failed to add geometry to renderer");
 
                                 scene_geometries.push(geometry);
@@ -253,20 +232,14 @@ fn main() {
                 physical_size.height,
             );
 
-            camera.set_screen_size([physical_size.width as f32, physical_size.height as f32]);
-
-            swap_chain = create_swap_chain(&device, &surface, physical_size);
-            viewport_renderer.set_screen_size(&mut device, physical_size);
+            camera.set_window_size(physical_size);
+            renderer.set_window_size(physical_size);
         }
 
         // Camera matrices have to be uploaded when either window
-        // resizes, or anything the camera moves. Seems easier to just
-        // upload them always.
-        viewport_renderer.set_camera_matrices(
-            &mut device,
-            &camera.projection_matrix(),
-            &camera.view_matrix(),
-        );
+        // resizes or the camera moves. We do it every frame for
+        // simplicity.
+        renderer.set_camera_matrices(&camera.projection_matrix(), &camera.view_matrix());
 
         #[cfg(debug_assertions)]
         ui::draw_fps_window(&imgui_ui);
@@ -283,15 +256,15 @@ fn main() {
                     // Clear existing scene first...
                     scene_geometries.clear();
                     for geometry in scene_renderer_geometry_ids.drain(..) {
-                        viewport_renderer.remove_geometry(geometry);
+                        renderer.remove_scene_geometry(geometry);
                     }
 
                     // ... and add everything we found to it
                     for model in models {
                         let geometry = model.geometry;
-                        let renderer_geometry = RendererGeometry::from_geometry(&geometry);
-                        let renderer_geometry_id = viewport_renderer
-                            .add_geometry(&device, &renderer_geometry)
+                        let renderer_geometry = SceneRendererGeometry::from_geometry(&geometry);
+                        let renderer_geometry_id = renderer
+                            .add_scene_geometry(&renderer_geometry)
                             .expect("Failed to add geometry to renderer");
 
                         scene_geometries.push(geometry);
@@ -308,44 +281,18 @@ fn main() {
             }
         }
 
-        winit_platform.prepare_render(&imgui_ui, &window);
+        imgui_winit_platform.prepare_render(&imgui_ui, &window);
         let imgui_draw_data = imgui_ui.render();
 
-        let frame = swap_chain.get_next_texture();
-        let mut encoder =
-            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
+        let mut render = renderer.begin_render();
 
-        viewport_renderer.draw_geometry(
-            &mut encoder,
-            &frame.view,
-            &scene_renderer_geometry_ids[..],
-        );
+        render.draw_geometry(&scene_renderer_geometry_ids[..]);
+        render.draw_ui(&imgui_draw_data);
 
-        imgui_renderer
-            .render(&mut device, &mut encoder, &frame.view, imgui_draw_data)
-            .expect("Should render an imgui frame");
-
-        device.get_queue().submit(&[encoder.finish()]);
+        render.finish();
     }
 
     for renderer_geometry_id in scene_renderer_geometry_ids {
-        viewport_renderer.remove_geometry(renderer_geometry_id);
+        renderer.remove_scene_geometry(renderer_geometry_id);
     }
-}
-
-fn create_swap_chain(
-    device: &wgpu::Device,
-    surface: &wgpu::Surface,
-    window_size: winit::dpi::PhysicalSize,
-) -> wgpu::SwapChain {
-    device.create_swap_chain(
-        &surface,
-        &wgpu::SwapChainDescriptor {
-            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
-            format: SWAP_CHAIN_FORMAT,
-            width: window_size.width.round() as u32,
-            height: window_size.height.round() as u32,
-            present_mode: wgpu::PresentMode::Vsync,
-        },
-    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ fn main() {
         render_pass.draw_geometry(&scene_renderer_geometry_ids[..]);
         render_pass.draw_ui(&imgui_draw_data);
 
-        render_pass.finish();
+        render_pass.submit();
     }
 
     for renderer_geometry_id in scene_renderer_geometry_ids {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
 
     let mut input_manager = InputManager::new();
     let mut camera = Camera::new(
-        [window_size.width as f32, window_size.height as f32],
+        window_size,
         5.0,
         45f32.to_radians(),
         60f32.to_radians(),

--- a/src/renderer/common.rs
+++ b/src/renderer/common.rs
@@ -1,0 +1,59 @@
+use std::convert::TryFrom;
+use std::mem;
+
+use crate::convert::cast_u32;
+
+#[macro_export]
+macro_rules! include_shader {
+    ($name:expr) => {{
+        include_bytes!(concat!(env!("OUT_DIR"), "/shaders/", $name))
+    }};
+}
+
+pub fn wgpu_size_of<T>() -> wgpu::BufferAddress {
+    let size = mem::size_of::<T>();
+    wgpu::BufferAddress::try_from(size)
+        .unwrap_or_else(|_| panic!("Size {} does not fit into wgpu BufferAddress", size))
+}
+
+pub fn upload_texture_rgba8_unorm(
+    device: &mut wgpu::Device,
+    texture: &wgpu::Texture,
+    width: u32,
+    height: u32,
+    data: &[u8],
+) {
+    let buffer = device
+        .create_buffer_mapped(data.len(), wgpu::BufferUsage::TRANSFER_SRC)
+        .fill_from_slice(data);
+
+    let byte_count = cast_u32(data.len());
+    let pixel_size = byte_count / width / height;
+
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
+    encoder.copy_buffer_to_texture(
+        wgpu::BufferCopyView {
+            buffer: &buffer,
+            offset: 0,
+            row_pitch: pixel_size * width,
+            image_height: height,
+        },
+        wgpu::TextureCopyView {
+            texture,
+            mip_level: 0,
+            array_layer: 0,
+            origin: wgpu::Origin3d {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+        },
+        wgpu::Extent3d {
+            width,
+            height,
+            depth: 1,
+        },
+    );
+
+    device.get_queue().submit(&[encoder.finish()]);
+}

--- a/src/renderer/imgui_renderer.rs
+++ b/src/renderer/imgui_renderer.rs
@@ -1,6 +1,5 @@
 use std::io;
 
-use bitflags::bitflags;
 use imgui;
 use imgui::internal::RawWrapper;
 
@@ -17,12 +16,6 @@ pub enum ImguiRendererError {
 pub struct ImguiRendererOptions {
     pub sample_count: u32,
     pub output_color_attachment_format: wgpu::TextureFormat,
-}
-
-bitflags! {
-    pub struct ImguiRendererClearFlags: u8 {
-        const COLOR = 0b_0000_0001;
-    }
 }
 
 pub struct ImguiRenderer {
@@ -262,7 +255,7 @@ impl ImguiRenderer {
 
     pub fn draw_ui(
         &self,
-        clear_flags: ImguiRendererClearFlags,
+        color_needs_clearing: bool,
         device: &mut wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         color_attachment: &wgpu::TextureView,
@@ -323,7 +316,7 @@ impl ImguiRenderer {
         // `idx_start..idx_end` and set those to the render pass, and
         // finally draw.
 
-        let color_load_op = if clear_flags.contains(ImguiRendererClearFlags::COLOR) {
+        let color_load_op = if color_needs_clearing {
             wgpu::LoadOp::Clear
         } else {
             wgpu::LoadOp::Load

--- a/src/renderer/imgui_renderer.rs
+++ b/src/renderer/imgui_renderer.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use bitflags::bitflags;
 use imgui;
 use imgui::internal::RawWrapper;
 
@@ -16,6 +17,12 @@ pub enum ImguiRendererError {
 pub struct ImguiRendererOptions {
     pub sample_count: u32,
     pub output_color_attachment_format: wgpu::TextureFormat,
+}
+
+bitflags! {
+    pub struct ImguiRendererClearFlags: u8 {
+        const COLOR = 0b_0000_0001;
+    }
 }
 
 pub struct ImguiRenderer {
@@ -255,7 +262,7 @@ impl ImguiRenderer {
 
     pub fn draw_ui(
         &self,
-        clear_color_requested: bool,
+        clear_flags: ImguiRendererClearFlags,
         device: &mut wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         color_attachment: &wgpu::TextureView,
@@ -316,7 +323,7 @@ impl ImguiRenderer {
         // `idx_start..idx_end` and set those to the render pass, and
         // finally draw.
 
-        let color_load_op = if clear_color_requested {
+        let color_load_op = if clear_flags.contains(ImguiRendererClearFlags::COLOR) {
             wgpu::LoadOp::Clear
         } else {
             wgpu::LoadOp::Load

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,0 +1,343 @@
+use nalgebra::base::Matrix4;
+use wgpu::winit;
+
+pub use self::scene_renderer::{SceneRendererGeometry, SceneRendererGeometryId};
+
+use self::imgui_renderer::{ImguiRenderer, ImguiRendererOptions};
+use self::scene_renderer::{SceneRenderer, SceneRendererAddGeometryError, SceneRendererOptions};
+
+#[macro_use]
+mod common;
+
+mod imgui_renderer;
+mod scene_renderer;
+
+const SWAP_CHAIN_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
+const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::D32Float;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RendererOptions {
+    pub msaa: Msaa,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Msaa {
+    Disabled,
+    X4,
+    X8,
+    X16,
+}
+
+impl Msaa {
+    pub fn enabled(self) -> bool {
+        match self {
+            Msaa::Disabled => false,
+            _ => true,
+        }
+    }
+
+    pub fn sample_count(self) -> u32 {
+        match self {
+            Msaa::Disabled => 1,
+            Msaa::X4 => 4,
+            Msaa::X8 => 8,
+            Msaa::X16 => 16,
+        }
+    }
+}
+
+pub struct Renderer {
+    device: wgpu::Device,
+    surface: wgpu::Surface,
+    swap_chain: wgpu::SwapChain,
+    msaa_texture_view: Option<wgpu::TextureView>,
+    depth_texture_view: wgpu::TextureView,
+    scene_renderer: SceneRenderer,
+    imgui_renderer: ImguiRenderer,
+    options: RendererOptions,
+}
+
+impl Renderer {
+    pub fn new(
+        instance: &wgpu::Instance,
+        window: &winit::Window,
+        projection_matrix: &Matrix4<f32>,
+        view_matrix: &Matrix4<f32>,
+        imgui_font_atlas: imgui::FontAtlasRefMut,
+        options: RendererOptions,
+    ) -> Self {
+        let surface = instance.create_surface(window);
+        let adapter = instance.get_adapter(&wgpu::AdapterDescriptor {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+        });
+        let mut device = adapter.request_device(&wgpu::DeviceDescriptor {
+            extensions: wgpu::Extensions {
+                anisotropic_filtering: false,
+            },
+            limits: wgpu::Limits::default(),
+        });
+
+        let window_size = window
+            .get_inner_size()
+            .expect("Failed to get window inner size")
+            .to_physical(window.get_hidpi_factor());
+        let (width, height) = (window_size.width as u32, window_size.height as u32);
+
+        let swap_chain = create_swap_chain(&device, &surface, width, height);
+        let msaa_texture = if options.msaa.enabled() {
+            Some(create_msaa_texture(
+                &device,
+                width,
+                height,
+                options.msaa.sample_count(),
+            ))
+        } else {
+            None
+        };
+        let depth_texture =
+            create_depth_texture(&device, width, height, options.msaa.sample_count());
+
+        let scene_renderer = SceneRenderer::new(
+            &mut device,
+            projection_matrix,
+            view_matrix,
+            SceneRendererOptions {
+                sample_count: options.msaa.sample_count(),
+                output_color_attachment_format: SWAP_CHAIN_FORMAT,
+                output_depth_attachment_format: DEPTH_FORMAT,
+            },
+        );
+
+        let imgui_renderer = ImguiRenderer::new(
+            imgui_font_atlas,
+            &mut device,
+            ImguiRendererOptions {
+                sample_count: options.msaa.sample_count(),
+                output_color_attachment_format: SWAP_CHAIN_FORMAT,
+            },
+        )
+        .expect("Failed to create imgui renderer");
+
+        Self {
+            device,
+            surface,
+            swap_chain,
+            msaa_texture_view: msaa_texture.map(|texture| texture.create_default_view()),
+            depth_texture_view: depth_texture.create_default_view(),
+            scene_renderer,
+            imgui_renderer,
+            options,
+        }
+    }
+
+    /// Update camera matrices (projection matrix and view matrix).
+    pub fn set_camera_matrices(
+        &mut self,
+        projection_matrix: &Matrix4<f32>,
+        view_matrix: &Matrix4<f32>,
+    ) {
+        self.scene_renderer
+            .set_camera_matrices(&mut self.device, projection_matrix, view_matrix);
+    }
+
+    /// Update window size. Recreate swap chain and all render target
+    /// textures.
+    pub fn set_window_size(&mut self, window_size: winit::dpi::PhysicalSize) {
+        let (width, height) = (
+            window_size.width.round() as u32,
+            window_size.height.round() as u32,
+        );
+
+        self.swap_chain = create_swap_chain(&self.device, &self.surface, width, height);
+
+        if self.options.msaa.enabled() {
+            let msaa_texture = create_msaa_texture(
+                &self.device,
+                width,
+                height,
+                self.options.msaa.sample_count(),
+            );
+
+            self.msaa_texture_view = Some(msaa_texture.create_default_view());
+        }
+
+        let depth_texture = create_depth_texture(
+            &self.device,
+            width,
+            height,
+            self.options.msaa.sample_count(),
+        );
+        self.depth_texture_view = depth_texture.create_default_view();
+    }
+
+    pub fn add_scene_geometry(
+        &mut self,
+        geometry: &SceneRendererGeometry,
+    ) -> Result<SceneRendererGeometryId, SceneRendererAddGeometryError> {
+        self.scene_renderer.add_geometry(&self.device, geometry)
+    }
+
+    pub fn remove_scene_geometry(&mut self, id: SceneRendererGeometryId) {
+        self.scene_renderer.remove_geometry(id);
+    }
+
+    pub fn add_ui_texture_rgba8_unorm(
+        &mut self,
+        width: u32,
+        height: u32,
+        data: &[u8],
+    ) -> imgui::TextureId {
+        self.imgui_renderer
+            .add_texture_rgba8_unorm(&mut self.device, width, height, data)
+    }
+
+    pub fn remove_ui_texture(&mut self, id: imgui::TextureId) {
+        self.imgui_renderer.remove_texture(id);
+    }
+
+    pub fn begin_render(&mut self) -> Render {
+        let frame = self.swap_chain.get_next_texture();
+        let encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
+
+        Render {
+            color_needs_clearing: true,
+            depth_needs_clearing: true,
+            device: &mut self.device,
+            frame,
+            encoder: Some(encoder),
+            msaa_attachment: self.msaa_texture_view.as_ref(),
+            depth_attachment: &self.depth_texture_view,
+            scene_renderer: &self.scene_renderer,
+            imgui_renderer: &self.imgui_renderer,
+        }
+    }
+}
+
+pub struct Render<'a> {
+    color_needs_clearing: bool,
+    depth_needs_clearing: bool,
+    device: &'a mut wgpu::Device,
+    frame: wgpu::SwapChainOutput<'a>,
+    encoder: Option<wgpu::CommandEncoder>,
+    msaa_attachment: Option<&'a wgpu::TextureView>,
+    depth_attachment: &'a wgpu::TextureView,
+    scene_renderer: &'a SceneRenderer,
+    imgui_renderer: &'a ImguiRenderer,
+}
+
+impl Render<'_> {
+    pub fn draw_geometry(&mut self, ids: &[SceneRendererGeometryId]) {
+        self.scene_renderer.draw_geometry(
+            self.color_needs_clearing,
+            self.depth_needs_clearing,
+            self.encoder
+                .as_mut()
+                .expect("Need encoder to record drawing"),
+            &self.frame.view,
+            self.msaa_attachment,
+            &self.depth_attachment,
+            ids,
+        );
+
+        self.color_needs_clearing = false;
+        self.depth_needs_clearing = false;
+    }
+
+    pub fn draw_ui(&mut self, draw_data: &imgui::DrawData) {
+        self.imgui_renderer
+            .draw_ui(
+                self.color_needs_clearing,
+                self.device,
+                self.encoder
+                    .as_mut()
+                    .expect("Need encoder to record drawing"),
+                &self.frame.view,
+                self.msaa_attachment,
+                draw_data,
+            )
+            .expect("Imgui drawing failed");
+
+        self.color_needs_clearing = false;
+    }
+
+    pub fn finish(mut self) {
+        let encoder = self.encoder.take().expect("Can't finish rendering twice");
+        self.device.get_queue().submit(&[encoder.finish()]);
+    }
+}
+
+impl Drop for Render<'_> {
+    fn drop(&mut self) {
+        assert!(
+            self.encoder.is_none(),
+            "Rendering must be finished by the time it goes out of scope"
+        );
+    }
+}
+
+fn create_swap_chain(
+    device: &wgpu::Device,
+    surface: &wgpu::Surface,
+    width: u32,
+    height: u32,
+) -> wgpu::SwapChain {
+    device.create_swap_chain(
+        &surface,
+        &wgpu::SwapChainDescriptor {
+            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+            format: SWAP_CHAIN_FORMAT,
+            width,
+            height,
+            present_mode: wgpu::PresentMode::Vsync,
+        },
+    )
+}
+
+fn create_msaa_texture(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+    sample_count: u32,
+) -> wgpu::Texture {
+    assert!(
+        sample_count > 1,
+        "Msaa texture shouldn't be created if not multisampling"
+    );
+
+    device.create_texture(&wgpu::TextureDescriptor {
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth: 1,
+        },
+        array_layer_count: 1,
+        mip_level_count: 1,
+        sample_count,
+        dimension: wgpu::TextureDimension::D2,
+        format: SWAP_CHAIN_FORMAT,
+        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+    })
+}
+
+fn create_depth_texture(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+    sample_count: u32,
+) -> wgpu::Texture {
+    device.create_texture(&wgpu::TextureDescriptor {
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth: 1,
+        },
+        array_layer_count: 1,
+        mip_level_count: 1,
+        sample_count,
+        dimension: wgpu::TextureDimension::D2,
+        format: DEPTH_FORMAT,
+        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+    })
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -3,8 +3,10 @@ use wgpu::winit;
 
 pub use self::scene_renderer::{SceneRendererGeometry, SceneRendererGeometryId};
 
-use self::imgui_renderer::{ImguiRenderer, ImguiRendererOptions};
-use self::scene_renderer::{SceneRenderer, SceneRendererAddGeometryError, SceneRendererOptions};
+use self::imgui_renderer::{ImguiRenderer, ImguiRendererClearFlags, ImguiRendererOptions};
+use self::scene_renderer::{
+    SceneRenderer, SceneRendererAddGeometryError, SceneRendererClearFlags, SceneRendererOptions,
+};
 
 #[macro_use]
 mod common;
@@ -229,9 +231,16 @@ pub struct Render<'a> {
 
 impl Render<'_> {
     pub fn draw_geometry(&mut self, ids: &[SceneRendererGeometryId]) {
+        let mut clear_flags = SceneRendererClearFlags::empty();
+        if self.color_needs_clearing {
+            clear_flags.insert(SceneRendererClearFlags::COLOR);
+        }
+        if self.depth_needs_clearing {
+            clear_flags.insert(SceneRendererClearFlags::DEPTH);
+        }
+
         self.scene_renderer.draw_geometry(
-            self.color_needs_clearing,
-            self.depth_needs_clearing,
+            clear_flags,
             self.encoder
                 .as_mut()
                 .expect("Need encoder to record drawing"),
@@ -246,9 +255,14 @@ impl Render<'_> {
     }
 
     pub fn draw_ui(&mut self, draw_data: &imgui::DrawData) {
+        let mut clear_flags = ImguiRendererClearFlags::empty();
+        if self.color_needs_clearing {
+            clear_flags.insert(ImguiRendererClearFlags::COLOR);
+        }
+
         self.imgui_renderer
             .draw_ui(
-                self.color_needs_clearing,
+                clear_flags,
                 self.device,
                 self.encoder
                     .as_mut()

--- a/src/renderer/scene_renderer.rs
+++ b/src/renderer/scene_renderer.rs
@@ -4,6 +4,7 @@ use std::error;
 use std::fmt;
 use std::io;
 
+use bitflags::bitflags;
 use nalgebra::base::{Matrix4, Vector3};
 use nalgebra::geometry::Point3;
 
@@ -222,6 +223,13 @@ pub struct SceneRendererOptions {
     pub sample_count: u32,
     pub output_color_attachment_format: wgpu::TextureFormat,
     pub output_depth_attachment_format: wgpu::TextureFormat,
+}
+
+bitflags! {
+    pub struct SceneRendererClearFlags: u8 {
+        const COLOR = 0b_0000_0001;
+        const DEPTH = 0b_0000_0010;
+    }
 }
 
 /// 3D renderer of the editor scene.
@@ -538,21 +546,20 @@ impl SceneRenderer {
     /// to the `color_attachment`.
     pub fn draw_geometry(
         &self,
-        clear_color_requested: bool,
-        clear_depth_requested: bool,
+        clear_flags: SceneRendererClearFlags,
         encoder: &mut wgpu::CommandEncoder,
         color_attachment: &wgpu::TextureView,
         msaa_attachment: Option<&wgpu::TextureView>,
         depth_attachment: &wgpu::TextureView,
         ids: &[SceneRendererGeometryId],
     ) {
-        let color_load_op = if clear_color_requested {
+        let color_load_op = if clear_flags.contains(SceneRendererClearFlags::COLOR) {
             wgpu::LoadOp::Clear
         } else {
             wgpu::LoadOp::Load
         };
 
-        let depth_load_op = if clear_depth_requested {
+        let depth_load_op = if clear_flags.contains(SceneRendererClearFlags::DEPTH) {
             wgpu::LoadOp::Clear
         } else {
             wgpu::LoadOp::Load

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -1,6 +1,0 @@
-#[macro_export]
-macro_rules! include_shader {
-    ($name:expr) => {{
-        include_bytes!(concat!(env!("OUT_DIR"), "/shaders/", $name))
-    }};
-}


### PR DESCRIPTION
This commit presents 2 major changes:

1) Viewport (now renamed to Scene) and Imgui renderers are no longer
visible. They are instead hidden in the renderer module, which only
exports a single `Renderer` facade.

2) Drawing is done via the `Renderer.begin_render()` method and the
`Render` struct, which delegate work to Viewport/Scene and Imgui
renderers.

Feature-wise, the refactor allows us to have MSAA for imgui. Also, the
renderers can now more easily share resources internally where
applicable:

- The renderer facade now manages the swapchain, the depth texture,
the MSAA buffer, etc.

- Command encoders are still re-used across both renderers, having in
a single submission for the entire gui and scene, but now the usage
code doesn't need to know anything about it.

- Although I originally wanted to factor out GPU resource management
from the subrenderers to the renderer facade, due to a limitation in
`imgui::TextureId` (there is no way not to use it when writing a
renderer for imgui-rs), the texture resource management needs to be
internal to `ImguiRenderer` and cannot be extracted out. For symmetry
reasons, I left geometry management internal to `SceneRenderer`.

- I also created a swamp file for common renderer functionality:
`rendrer/common.rs` (commoners!)