### PR TITLE
Importer worker thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "d3d12"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +455,7 @@ name = "hurban_selector"
 version = "0.1.0"
 dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "imgui 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "imgui-winit-support 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1514,6 +1532,8 @@ dependencies = [
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+"checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum d3d12 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4fda5547c55c93b070d59108464bbfd7d9da9563b2ce78fceefc6430e972a420"
 "checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ log = "0.4.7"
 nalgebra = "0.18.0"
 env_logger = "0.6.2"
 png = "0.15.0"
+crossbeam-channel = "0.3.9"
 
 [build-dependencies]
 shaderc = "0.6.0"

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -3,6 +3,8 @@ use std::f32;
 
 use nalgebra::{Matrix4, Point3, Rotation3, Vector3};
 
+use crate::math::clamp;
+
 const TWO_PI: f32 = f32::consts::PI * 2.0;
 const ZOOM_SPEED_BASE: f32 = 0.95;
 
@@ -172,10 +174,4 @@ impl Camera {
 
         self.origin + Vector3::new(x, y, z)
     }
-}
-
-fn clamp(x: f32, min: f32, max: f32) -> f32 {
-    // FIXME: clamp may eventually be stabilized in std
-    // https://github.com/rust-lang/rust/issues/44095
-    f32::max(min, f32::min(max, x))
 }

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -4,8 +4,11 @@ use std::error;
 use std::fmt;
 use std::fs;
 use std::io::{self, Read};
+use std::thread;
 
 use crc32fast;
+use crossbeam_channel::unbounded;
+use log;
 use nalgebra::base::Vector3;
 use nalgebra::geometry::Point3;
 use tobj;
@@ -61,6 +64,8 @@ pub struct FileMetadata {
     last_modified: std::time::SystemTime,
 }
 
+type ImporterResult = Result<Vec<Model>, ImporterError>;
+
 /// `Importer` takes care of importing of obj files and caching of their
 /// internal representations. It holds paths to files, their metadata
 /// (checksums, timestamps) and models of parsed obj files.
@@ -80,7 +85,7 @@ impl Importer {
     /// Otherwise, file is read, checksum calculated and cache is checked whether
     /// given file contents were already saved. If not, obj file is parsed and
     /// cached.
-    pub fn import_obj(&mut self, path: &str) -> Result<Vec<Model>, ImporterError> {
+    pub fn import_obj(&mut self, path: &str) -> ImporterResult {
         let mut file = fs::File::open(path)?;
         let file_modified = file.metadata().and_then(|metadata| metadata.modified())?;
 
@@ -142,6 +147,101 @@ impl Importer {
         }
 
         false
+    }
+}
+
+enum ImporterWorkerMessage {
+    NewImport(String),
+    Terminate,
+}
+
+/// Single threaded worker encapsulating obj importer.
+///
+/// Only one message (import or termination request) is processed at a time, so
+/// if there's a long running import, this thread can still block termination
+/// of the application.
+pub struct ImporterWorker {
+    thread: Option<thread::JoinHandle<()>>,
+    response_rx: crossbeam_channel::Receiver<ImporterResult>,
+    request_tx: crossbeam_channel::Sender<ImporterWorkerMessage>,
+}
+
+impl ImporterWorker {
+    /// Prepares communication channels and spawns a thread listening for
+    /// `ImporterWorkerMessage`.
+    pub fn new() -> Self {
+        let (request_tx, request_rx) = unbounded();
+        let (response_tx, response_rx) = unbounded();
+
+        let thread = thread::spawn(move || {
+            log::info!("Spawned importer worker.");
+
+            let mut importer = Importer::new();
+
+            while let ImporterWorkerMessage::NewImport(path) = request_rx
+                .recv()
+                .expect("Failed to receive message in importer worker")
+            {
+                log::info!("Received obj to parse: {}", &path);
+
+                let imported_file = importer.import_obj(&path);
+
+                log::info!("Successfully parsed obj: {}", &path);
+
+                response_tx
+                    .send(imported_file)
+                    .expect("Failed to send importer result message to main thread");
+            }
+        });
+
+        ImporterWorker {
+            thread: Some(thread),
+            request_tx,
+            response_rx,
+        }
+    }
+
+    /// Requests import of object with given `filename`. This request is put to
+    /// a queue.
+    pub fn import_obj(&self, filename: &str) {
+        self.request_tx
+            .send(ImporterWorkerMessage::NewImport(filename.to_string()))
+            .expect("Failed to send new import message to improter worker");
+    }
+
+    /// Reads response queue and returns last parsed obj in case there's any.
+    pub fn parsed_obj(&self) -> Option<ImporterResult> {
+        if self.response_rx.is_empty() {
+            None
+        } else {
+            let obj_importer_result = self
+                .response_rx
+                .recv()
+                .expect("Failed to receive message from importer worker");
+
+            Some(obj_importer_result)
+        }
+    }
+}
+
+impl Default for ImporterWorker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for ImporterWorker {
+    fn drop(&mut self) {
+        self.request_tx
+            .send(ImporterWorkerMessage::Terminate)
+            .expect("Failed to send terminate message to importer worker");
+
+        if let Some(thread) = self.thread.take() {
+            log::info!("Shutting down the importer worker.");
+            thread
+                .join()
+                .expect("Should have joined importer worker thread");
+        }
     }
 }
 

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -64,7 +64,7 @@ pub struct FileMetadata {
     last_modified: std::time::SystemTime,
 }
 
-type ImporterResult = Result<Vec<Model>, ImporterError>;
+pub type ImporterResult = Result<Vec<Model>, ImporterError>;
 
 /// `Importer` takes care of importing of obj files and caching of their
 /// internal representations. It holds paths to files, their metadata

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod geometry;
 pub mod imgui_renderer;
 pub mod importer;
 pub mod input;
+pub mod math;
 pub mod shader;
 pub mod ui;
 pub mod viewport_renderer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,11 +161,11 @@ fn main() {
 
         imgui_context.io_mut().delta_time = duration_last_frame_s;
 
-        if !is_importing {
-            import_progress = 1.0;
+        import_progress = if !is_importing {
+            1.0
         } else {
-            import_progress = decay(import_progress, 1.0, 0.5, duration_last_frame_s);
-        }
+            decay(import_progress, 1.0, 0.5, duration_last_frame_s)
+        };
 
         // Since input manager needs to process events separately after imgui
         // handles them, this buffer with copies of events is needed.

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,8 +1,3 @@
-/// Linear interpolation between values `a` and `b` for parameter `f`.
-fn lerp(a: f32, b: f32, f: f32) -> f32 {
-    a + f * (b - a)
-}
-
 pub fn clamp(x: f32, min: f32, max: f32) -> f32 {
     // FIXME: clamp may eventually be stabilized in std
     // https://github.com/rust-lang/rust/issues/44095
@@ -25,4 +20,9 @@ pub fn decay(source: f32, target: f32, smoothness: f32, delta: f32) -> f32 {
         target,
         1.0 - clamp(smoothness, 0.0, 1.0).powf(delta),
     )
+}
+
+/// Linear interpolation between values `a` and `b` for parameter `f`.
+fn lerp(a: f32, b: f32, f: f32) -> f32 {
+    a + f * (b - a)
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,28 @@
+/// Linear interpolation between values `a` and `b` for parameter `f`.
+fn lerp(a: f32, b: f32, f: f32) -> f32 {
+    a + f * (b - a)
+}
+
+pub fn clamp(x: f32, min: f32, max: f32) -> f32 {
+    // FIXME: clamp may eventually be stabilized in std
+    // https://github.com/rust-lang/rust/issues/44095
+    f32::max(min, f32::min(max, x))
+}
+
+/// Exponentially decay `source` to `target` over time. Framerate aware.
+///
+/// `smoothness` is a floating point number clamped between 0 amd 1.
+/// It determines, what fraction of `source` still hasn't decayed towards
+/// `target` after 1 second. `smoothness` equal to 0 essentially means
+/// `source = target` while 1 means `source = source`
+///
+/// `delta` is previous frame's processing time in seconds.
+///
+/// http://www.rorydriscoll.com/2016/03/07/frame-rate-independent-damping-using-lerp/
+pub fn decay(source: f32, target: f32, smoothness: f32, delta: f32) -> f32 {
+    lerp(
+        source,
+        target,
+        1.0 - clamp(smoothness, 0.0, 1.0).powf(delta),
+    )
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -37,21 +37,27 @@ pub fn draw_fps_window(ui: &imgui::Ui) {
 
 /// Draws window with list of model filenames. If any of them is clicked, the
 /// filename is returned for further processing.
-pub fn draw_model_window(ui: &imgui::Ui, filenames: &[String]) -> Option<String> {
+pub fn draw_model_window(
+    ui: &imgui::Ui,
+    filenames: &[String],
+    loading_progress: f32,
+) -> Option<String> {
     let _button_style = ui.push_style_var(imgui::StyleVar::ButtonTextAlign([-1.0, 0.0]));
     let mut clicked_button = None;
 
-    for filename in filenames {
-        ui.window(imgui::im_str!("Models"))
-            .position([50.0, 200.0], imgui::Condition::Always)
-            .movable(false)
-            .resizable(false)
-            .build(|| {
+    ui.window(imgui::im_str!("Models"))
+        .position([50.0, 200.0], imgui::Condition::Always)
+        .movable(false)
+        .resizable(false)
+        .build(|| {
+            ui.progress_bar(loading_progress).build();
+
+            for filename in filenames {
                 if ui.button(&imgui::im_str!("{}", filename), [180.0, 20.0]) {
                     clicked_button = Some(filename.clone());
                 }
-            });
-    }
+            }
+        });
 
     clicked_button
 }


### PR DESCRIPTION
This patch extracts `Importer` into a separate thread, so it doesn't block main thread while importing. The only downside is that it processes just one message at a time, so if there's a long running import, a terminate message still wait for it before it cleans up the thread. As discussed IRL, we'll keep it as is for now since all imports are very fast in release binary. This will be fixed later.