### PR TITLE
Add UV Sphere geometry primitive and ability to compute normals

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -2,7 +2,13 @@ use nalgebra as na;
 use nalgebra::base::Vector3;
 use nalgebra::geometry::Point3;
 
-use crate::convert::cast_u32;
+use crate::convert::{cast_u32, cast_usize};
+
+#[derive(Debug, Clone, Copy)]
+pub enum NormalStrategy {
+    Sharp,
+    // FIXME: add `Smooth`
+}
 
 /// Geometric data containing multiple possibly _variable-length_
 /// lists of geometric data, such as vertices and normals, and faces -
@@ -20,41 +26,67 @@ use crate::convert::cast_u32;
 pub struct Geometry {
     faces: Vec<Face>,
     vertices: Vec<Point3<f32>>,
-    normals: Option<Vec<Vector3<f32>>>,
+    normals: Vec<Vector3<f32>>,
 }
 
 impl Geometry {
-    /// Create new triangle face geometry from provided faces and vertices.
+    /// Create new triangle face geometry from provided faces and
+    /// vertices, and compute normals based on `normal_strategy`.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices.
-    pub fn from_triangle_faces_with_vertices(
-        faces: Vec<TriangleFace>,
+    pub fn from_triangle_faces_with_vertices_and_computed_normals(
+        faces: Vec<(u32, u32, u32)>,
         vertices: Vec<Point3<f32>>,
+        normal_strategy: NormalStrategy,
     ) -> Self {
         // FIXME: orphan removal
 
+        let mut normals = Vec::with_capacity(faces.len());
         let vertices_range = 0..cast_u32(vertices.len());
-        for face in &faces {
-            let v = face.vertices;
+        for &(v1, v2, v3) in &faces {
             assert!(
-                vertices_range.contains(&v.0),
-                "Faces reference out of bounds data"
+                vertices_range.contains(&v1),
+                "Faces reference out of bounds position data"
             );
             assert!(
-                vertices_range.contains(&v.1),
-                "Faces reference out of bounds data"
+                vertices_range.contains(&v2),
+                "Faces reference out of bounds position data"
             );
             assert!(
-                vertices_range.contains(&v.2),
-                "Faces reference out of bounds data"
+                vertices_range.contains(&v3),
+                "Faces reference out of bounds position data"
             );
+
+            // FIXME: computing smooth normals in the future won't be
+            // so simple as just computing a normal per face, we will
+            // need to analyze larger parts of the geometry
+            let face_normal = match normal_strategy {
+                NormalStrategy::Sharp => compute_triangle_normal(
+                    &vertices[cast_usize(v1)],
+                    &vertices[cast_usize(v2)],
+                    &vertices[cast_usize(v3)],
+                ),
+            };
+
+            normals.push(face_normal);
         }
 
+        assert_eq!(normals.len(), faces.len());
+        assert_eq!(normals.capacity(), faces.len());
+
         Self {
-            faces: faces.into_iter().map(Face::Triangle).collect(),
+            faces: faces
+                .into_iter()
+                .enumerate()
+                .map(|(i, (i1, i2, i3))| {
+                    let normal_index = cast_u32(i);
+                    TriangleFace::new_separate(i1, i2, i3, normal_index, normal_index, normal_index)
+                })
+                .map(Face::from)
+                .collect(),
             vertices,
-            normals: None,
+            normals,
         }
     }
 
@@ -74,37 +106,37 @@ impl Geometry {
         let normals_range = 0..cast_u32(normals.len());
         for face in &faces {
             let v = face.vertices;
-            let n = face.normals.expect("Normals must be present in faces");
+            let n = face.normals;
             assert!(
                 vertices_range.contains(&v.0),
-                "Faces reference out of bounds data"
+                "Faces reference out of bounds position data"
             );
             assert!(
                 vertices_range.contains(&v.1),
-                "Faces reference out of bounds data"
+                "Faces reference out of bounds position data"
             );
             assert!(
                 vertices_range.contains(&v.2),
-                "Faces reference out of bounds data"
+                "Faces reference out of bounds position data"
             );
             assert!(
                 normals_range.contains(&n.0),
-                "Faces reference out of bounds data"
+                "Faces reference out of bounds normal data"
             );
             assert!(
                 normals_range.contains(&n.1),
-                "Faces reference out of bounds data"
+                "Faces reference out of bounds normal data"
             );
             assert!(
                 normals_range.contains(&n.2),
-                "Faces reference out of bounds data"
+                "Faces reference out of bounds normal data"
             );
         }
 
         Self {
             faces: faces.into_iter().map(Face::Triangle).collect(),
             vertices,
-            normals: Some(normals),
+            normals,
         }
     }
 
@@ -131,8 +163,8 @@ impl Geometry {
         &self.vertices
     }
 
-    pub fn normals(&self) -> Option<&[Vector3<f32>]> {
-        self.normals.as_ref().map(Vec::as_slice)
+    pub fn normals(&self) -> &[Vector3<f32>] {
+        &self.normals
     }
 }
 
@@ -142,13 +174,47 @@ pub enum Face {
     Triangle(TriangleFace),
 }
 
+impl From<TriangleFace> for Face {
+    fn from(triangle_face: TriangleFace) -> Face {
+        Face::Triangle(triangle_face)
+    }
+}
+
 /// A triangular face. Contains indices to other geometry data, such
 /// as vertices and normals.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TriangleFace {
     pub vertices: (u32, u32, u32),
-    pub normals: Option<(u32, u32, u32)>,
-    // tex_coords
+    pub normals: (u32, u32, u32),
+}
+
+impl TriangleFace {
+    pub fn new(i1: u32, i2: u32, i3: u32) -> TriangleFace {
+        TriangleFace {
+            vertices: (i1, i2, i3),
+            normals: (i1, i2, i3),
+        }
+    }
+
+    pub fn new_separate(
+        vi1: u32,
+        vi2: u32,
+        vi3: u32,
+        ni1: u32,
+        ni2: u32,
+        ni3: u32,
+    ) -> TriangleFace {
+        TriangleFace {
+            vertices: (vi1, vi2, vi3),
+            normals: (ni1, ni2, ni3),
+        }
+    }
+}
+
+impl From<(u32, u32, u32)> for TriangleFace {
+    fn from((i1, i2, i3): (u32, u32, u32)) -> TriangleFace {
+        TriangleFace::new(i1, i2, i3)
+    }
 }
 
 pub fn plane_same_len(position: [f32; 3], scale: f32) -> Geometry {
@@ -174,8 +240,8 @@ pub fn plane_same_len(position: [f32; 3], scale: f32) -> Geometry {
 
     #[rustfmt::skip]
     let faces = vec![
-        tf_vn(0, 1, 2),
-        tf_vn(3, 4, 5),
+        TriangleFace::new(0, 1, 2),
+        TriangleFace::new(3, 4, 5),
     ];
 
     Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
@@ -199,14 +265,14 @@ pub fn plane_var_len(position: [f32; 3], scale: f32) -> Geometry {
 
     #[rustfmt::skip]
     let faces = vec![
-        tf_vn_separate(0, 1, 2, 0, 0, 0),
-        tf_vn_separate(3, 4, 5, 0, 0, 0),
+        TriangleFace::new_separate(0, 1, 2, 0, 0, 0),
+        TriangleFace::new_separate(3, 4, 5, 0, 0, 0),
     ];
 
     Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
 }
 
-pub fn cube_same_len(position: [f32; 3], scale: f32) -> Geometry {
+pub fn cube_smooth_same_len(position: [f32; 3], scale: f32) -> Geometry {
     #[rustfmt::skip]
     let vertex_positions = vec![
         // back
@@ -242,29 +308,29 @@ pub fn cube_same_len(position: [f32; 3], scale: f32) -> Geometry {
     #[rustfmt::skip]
     let faces = vec![
         // back
-        tf_vn(0, 1, 2),
-        tf_vn(2, 3, 0),
+        TriangleFace::new(0, 1, 2),
+        TriangleFace::new(2, 3, 0),
         // front
-        tf_vn(4, 5, 6),
-        tf_vn(6, 7, 4),
+        TriangleFace::new(4, 5, 6),
+        TriangleFace::new(6, 7, 4),
         // top
-        tf_vn(7, 6, 2),
-        tf_vn(2, 1, 7),
+        TriangleFace::new(7, 6, 2),
+        TriangleFace::new(2, 1, 7),
         // bottom
-        tf_vn(4, 0, 3),
-        tf_vn(3, 5, 4),
+        TriangleFace::new(4, 0, 3),
+        TriangleFace::new(3, 5, 4),
         // right
-        tf_vn(5, 3, 2),
-        tf_vn(2, 6, 5),
+        TriangleFace::new(5, 3, 2),
+        TriangleFace::new(2, 6, 5),
         // left
-        tf_vn(4, 7, 1),
-        tf_vn(1, 0, 4),
+        TriangleFace::new(4, 7, 1),
+        TriangleFace::new(1, 0, 4),
     ];
 
     Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
 }
 
-pub fn uv_cube_same_len(position: [f32; 3], scale: f32) -> Geometry {
+pub fn cube_sharp_same_len(position: [f32; 3], scale: f32) -> Geometry {
     #[rustfmt::skip]
     let vertex_positions = vec![
         // back
@@ -336,29 +402,29 @@ pub fn uv_cube_same_len(position: [f32; 3], scale: f32) -> Geometry {
     #[rustfmt::skip]
     let faces = vec![
         // back
-        tf_vn(0, 1, 2),
-        tf_vn(2, 3, 0),
+        TriangleFace::new(0, 1, 2),
+        TriangleFace::new(2, 3, 0),
         // front
-        tf_vn(4, 5, 6),
-        tf_vn(6, 7, 4),
+        TriangleFace::new(4, 5, 6),
+        TriangleFace::new(6, 7, 4),
         // top
-        tf_vn(8, 9, 10),
-        tf_vn(10, 11, 8),
+        TriangleFace::new(8, 9, 10),
+        TriangleFace::new(10, 11, 8),
         // bottom
-        tf_vn(12, 13, 14),
-        tf_vn(14, 15, 12),
+        TriangleFace::new(12, 13, 14),
+        TriangleFace::new(14, 15, 12),
         // right
-        tf_vn(16, 17, 18),
-        tf_vn(18, 19, 16),
+        TriangleFace::new(16, 17, 18),
+        TriangleFace::new(18, 19, 16),
         // left
-        tf_vn(20, 21, 22),
-        tf_vn(22, 23, 20),
+        TriangleFace::new(20, 21, 22),
+        TriangleFace::new(22, 23, 20),
     ];
 
     Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
 }
 
-pub fn uv_cube_var_len(position: [f32; 3], scale: f32) -> Geometry {
+pub fn cube_sharp_var_len(position: [f32; 3], scale: f32) -> Geometry {
     #[rustfmt::skip]
     let vertex_positions = vec![
         // back
@@ -392,26 +458,115 @@ pub fn uv_cube_var_len(position: [f32; 3], scale: f32) -> Geometry {
     #[rustfmt::skip]
     let faces = vec![
         // back
-        tf_vn_separate(0, 1, 2, 0, 0, 0),
-        tf_vn_separate(2, 3, 0, 0, 0, 0),
+        TriangleFace::new_separate(0, 1, 2, 0, 0, 0),
+        TriangleFace::new_separate(2, 3, 0, 0, 0, 0),
         // front
-        tf_vn_separate(4, 5, 6, 1, 1, 1),
-        tf_vn_separate(6, 7, 4, 1, 1, 1),
+        TriangleFace::new_separate(4, 5, 6, 1, 1, 1),
+        TriangleFace::new_separate(6, 7, 4, 1, 1, 1),
         // top
-        tf_vn_separate(7, 6, 2, 2, 2, 2),
-        tf_vn_separate(2, 1, 7, 2, 2, 2),
+        TriangleFace::new_separate(7, 6, 2, 2, 2, 2),
+        TriangleFace::new_separate(2, 1, 7, 2, 2, 2),
         // bottom
-        tf_vn_separate(4, 0, 3, 3, 3, 3),
-        tf_vn_separate(3, 5, 4, 3, 3, 3),
+        TriangleFace::new_separate(4, 0, 3, 3, 3, 3),
+        TriangleFace::new_separate(3, 5, 4, 3, 3, 3),
         // right
-        tf_vn_separate(5, 3, 2, 4, 4, 4),
-        tf_vn_separate(2, 6, 5, 4, 4, 4),
+        TriangleFace::new_separate(5, 3, 2, 4, 4, 4),
+        TriangleFace::new_separate(2, 6, 5, 4, 4, 4),
         // left
-        tf_vn_separate(4, 7, 1, 5, 5, 5),
-        tf_vn_separate(1, 0, 4, 5, 5, 5),
+        TriangleFace::new_separate(4, 7, 1, 5, 5, 5),
+        TriangleFace::new_separate(1, 0, 4, 5, 5, 5),
     ];
 
     Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
+}
+
+/// Create UV Sphere primitive at `position` with `scale`,
+/// `n_parallels` and `n_meridians`.
+///
+/// # Panics
+/// Panics if number of parallels is less than 2 or number of
+/// meridians is less than 3.
+pub fn uv_sphere(position: [f32; 3], scale: f32, n_parallels: u32, n_meridians: u32) -> Geometry {
+    assert!(n_parallels >= 2, "Need at least 2 paralells");
+    assert!(n_meridians >= 3, "Need at least 3 meridians");
+
+    // Add the poles
+    let lat_line_max = n_parallels + 2;
+    // Add the last, wrapping meridian
+    let lng_line_max = n_meridians + 1;
+
+    use std::f32::consts::PI;
+    const TWO_PI: f32 = 2.0 * PI;
+
+    // 1 North pole + 1 South pole + `n_parallels` * `n_meridians`
+    let vertex_data_count = cast_usize(2 + n_parallels * n_meridians);
+    let mut vertex_positions = Vec::with_capacity(vertex_data_count);
+
+    // Produce vertex data for bands in between parallels
+
+    for lat_line in 0..n_parallels {
+        for lng_line in 0..n_meridians {
+            let polar_t = (lat_line + 1) as f32 / (lat_line_max - 1) as f32;
+            let azimuthal_t = lng_line as f32 / (lng_line_max - 1) as f32;
+
+            let x = (PI * polar_t).sin() * (TWO_PI * azimuthal_t).cos();
+            let y = (PI * polar_t).sin() * (TWO_PI * azimuthal_t).sin();
+            let z = (PI * polar_t).cos();
+
+            vertex_positions.push(v(x, y, z, position, scale));
+        }
+    }
+
+    // Triangles from North and South poles to the nearest band + 2 * quads in bands
+    let faces_count = cast_usize(2 * n_meridians + 2 * n_meridians * (n_parallels - 1));
+    let mut faces = Vec::with_capacity(faces_count);
+
+    // Produce faces for bands in-between parallels
+
+    for i in 1..n_parallels {
+        for j in 0..n_meridians {
+            // Produces 2 CCW wound triangles: (p1, p2, p3) and (p3, p4, p1)
+
+            let p1 = i * n_meridians + j;
+            let p2 = i * n_meridians + ((j + 1) % n_meridians);
+
+            let p4 = (i - 1) * n_meridians + j;
+            let p3 = (i - 1) * n_meridians + ((j + 1) % n_meridians);
+
+            faces.push((p1, p2, p3));
+            faces.push((p3, p4, p1));
+        }
+    }
+
+    // Add vertex data and band-connecting faces for North and South poles
+
+    let north_pole = cast_u32(vertex_positions.len());
+    vertex_positions.push(v(0.0, 0.0, 1.0, position, scale));
+
+    let south_pole = cast_u32(vertex_positions.len());
+    vertex_positions.push(v(0.0, 0.0, -1.0, position, scale));
+
+    for i in 0..n_meridians {
+        let north_p1 = i;
+        let north_p2 = (i + 1) % n_meridians;
+
+        let south_p1 = (n_parallels - 1) * n_meridians + i;
+        let south_p2 = (n_parallels - 1) * n_meridians + ((i + 1) % n_meridians);
+
+        faces.push((north_p1, north_p2, north_pole));
+        faces.push((south_p2, south_p1, south_pole));
+    }
+
+    assert_eq!(vertex_positions.len(), vertex_data_count);
+    assert_eq!(vertex_positions.capacity(), vertex_data_count);
+    assert_eq!(faces.len(), faces_count);
+    assert_eq!(faces.capacity(), faces_count);
+
+    Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+        faces,
+        vertex_positions,
+        NormalStrategy::Sharp,
+    )
 }
 
 pub fn compute_bounding_sphere(geometries: &[Geometry]) -> (Point3<f32>, f32) {
@@ -460,25 +615,18 @@ fn n(x: f32, y: f32, z: f32) -> Vector3<f32> {
     Vector3::new(x, y, z)
 }
 
-fn tf_vn(i1: u32, i2: u32, i3: u32) -> TriangleFace {
-    TriangleFace {
-        vertices: (i1, i2, i3),
-        normals: Some((i1, i2, i3)),
-    }
-}
+fn compute_triangle_normal(p1: &Point3<f32>, p2: &Point3<f32>, p3: &Point3<f32>) -> Vector3<f32> {
+    let u = p2 - p1;
+    let v = p3 - p1;
 
-fn tf_vn_separate(v1: u32, v2: u32, v3: u32, n1: u32, n2: u32, n3: u32) -> TriangleFace {
-    TriangleFace {
-        vertices: (v1, v2, v3),
-        normals: Some((n1, n2, n3)),
-    }
+    Vector3::cross(&u, &v)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn quad() -> (Vec<TriangleFace>, Vec<Point3<f32>>) {
+    fn quad() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
         #[rustfmt::skip]
         let vertices = vec![
             v(-1.0, -1.0,  0.0, [0.0, 0.0, 0.0], 1.0),
@@ -489,8 +637,8 @@ mod tests {
 
         #[rustfmt::skip]
         let faces = vec![
-            tf_v(0, 1, 2),
-            tf_v(2, 3, 0),
+            (0, 1, 2),
+            (2, 3, 0),
         ];
 
         (faces, vertices)
@@ -515,41 +663,48 @@ mod tests {
 
         #[rustfmt::skip]
         let faces = vec![
-            tf_vn(0, 1, 2),
-            tf_vn(2, 3, 0),
+            TriangleFace::new(0, 1, 2),
+            TriangleFace::new(2, 3, 0),
         ];
 
         (faces, vertices, normals)
     }
 
-    fn tf_v(a: u32, b: u32, c: u32) -> TriangleFace {
-        TriangleFace {
-            vertices: (a, b, c),
-            normals: None,
-        }
-    }
-
     #[test]
-    fn test_geometry_from_triangle_faces_with_vertices() {
+    fn test_geometry_from_triangle_faces_with_vertices_and_computed_normals() {
         let (faces, vertices) = quad();
-        let geometry = Geometry::from_triangle_faces_with_vertices(faces.clone(), vertices.clone());
+        let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+            faces.clone(),
+            vertices.clone(),
+            NormalStrategy::Sharp,
+        );
         let geometry_faces: Vec<_> = geometry.triangle_faces_iter().collect();
 
         assert_eq!(vertices.as_slice(), geometry.vertices());
-        assert_eq!(faces.as_slice(), geometry_faces.as_slice());
+        assert_eq!(
+            faces,
+            geometry_faces
+                .into_iter()
+                .map(|triangle_face| triangle_face.vertices)
+                .collect::<Vec<_>>(),
+        );
     }
 
     #[test]
-    #[should_panic(expected = "Faces reference out of bounds data")]
-    fn test_geometry_from_triangle_faces_with_vertices_bounds_check() {
+    #[should_panic(expected = "Faces reference out of bounds position data")]
+    fn test_geometry_from_triangle_faces_with_vertices_and_computed_normals_bounds_check() {
         let (_, vertices) = quad();
         #[rustfmt::skip]
         let faces = vec![
-            tf_v(0, 1, 2),
-            tf_v(2, 3, 4),
+            (0, 1, 2),
+            (2, 3, 4),
         ];
 
-        let _geometry = Geometry::from_triangle_faces_with_vertices(faces, vertices);
+        let _geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+            faces,
+            vertices,
+            NormalStrategy::Sharp,
+        );
     }
 
     #[test]
@@ -563,18 +718,18 @@ mod tests {
         let geometry_faces: Vec<_> = geometry.triangle_faces_iter().collect();
 
         assert_eq!(vertices.as_slice(), geometry.vertices());
-        assert_eq!(normals.as_slice(), geometry.normals().unwrap());
+        assert_eq!(normals.as_slice(), geometry.normals());
         assert_eq!(faces.as_slice(), geometry_faces.as_slice());
     }
 
     #[test]
-    #[should_panic(expected = "Faces reference out of bounds data")]
+    #[should_panic(expected = "Faces reference out of bounds position data")]
     fn test_geometry_from_triangle_faces_with_vertices_and_normals_bounds_check() {
         let (_, vertices, normals) = quad_with_normals();
         #[rustfmt::skip]
         let faces = vec![
-            tf_vn(0, 1, 2),
-            tf_vn(2, 3, 4),
+            TriangleFace::new(0, 1, 2),
+            TriangleFace::new(2, 3, 4),
         ];
 
         let _geometry = Geometry::from_triangle_faces_with_vertices_and_normals(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,13 +90,20 @@ pub fn init_and_run(options: Options) -> ! {
     let mut scene_geometries = vec![
         // FIXME: This is just temporary code so that we can see
         // something in the scene and know the renderer works.
-        geometry::uv_cube_var_len([0.0, 0.0, 0.0], 0.5),
-        geometry::uv_cube_same_len([0.0, 50.0, 0.0], 5.0),
-        geometry::uv_cube_same_len([50.0, 0.0, 0.0], 5.0),
-        geometry::cube_same_len([0.0, 5.0, 0.0], 0.9),
-        geometry::cube_same_len([0.0, 0.0, 5.0], 1.5),
-        geometry::plane_same_len([0.0, 0.0, 20.0], 10.0),
-        geometry::plane_var_len([0.0, 0.0, -20.0], 10.0),
+        geometry::uv_sphere([0.0, 0.0, 0.0], 5.0, 2, 3),
+        geometry::uv_sphere([20.0, 0.0, 0.0], 5.0, 3, 3),
+        geometry::uv_sphere([40.0, 0.0, 0.0], 5.0, 4, 4),
+        geometry::uv_sphere([60.0, 0.0, 0.0], 5.0, 5, 5),
+        geometry::uv_sphere([80.0, 0.0, 0.0], 5.0, 6, 6),
+        geometry::uv_sphere([100.0, 0.0, 0.0], 5.0, 7, 7),
+        geometry::uv_sphere([120.0, 0.0, 0.0], 5.0, 8, 8),
+        geometry::uv_sphere([170.0, 0.0, 0.0], 20.0, 20, 20),
+        geometry::cube_sharp_var_len([220.0, 0.0, 0.0], 5.0),
+        geometry::cube_sharp_same_len([240.0, 0.0, 0.0], 5.0),
+        geometry::cube_smooth_same_len([260.0, 0.0, 0.0], 5.0),
+        geometry::cube_smooth_same_len([280.0, 0.0, 0.0], 5.0),
+        geometry::plane_same_len([300.0, 0.0, 0.0], 5.0),
+        geometry::plane_var_len([320.0, 0.0, 0.0], 5.0),
     ];
 
     let mut scene_renderer_geometry_ids = Vec::with_capacity(scene_geometries.len());


### PR DESCRIPTION
This PR adds the UV Sphere geometry primitive and makes normals mandatory in geometry. The UV Sphere will be required later, most notably for the "covering sphere" operation I am implementing, but we might also use it in the renderer to produce skydomes/skyspheres.

Making normals mandatory gets rid of a few corner-cases we had to otherwise assert here and there.

If no normals are not present in the source data, there is `Geometry::from_triangle_faces_with_vertices_and_computed_normals` which can compute them.