### PR TITLE
Remove orphan vertices and normals

### DIFF
--- a/src/edge_analysis.rs
+++ b/src/edge_analysis.rs
@@ -48,7 +48,7 @@ pub fn edge_valencies<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
 mod tests {
     use nalgebra::Point3;
 
-    use crate::geometry::{Geometry, NormalStrategy};
+    use crate::geometry::{Geometry, NormalStrategy, Vertices};
 
     use super::*;
 
@@ -60,7 +60,7 @@ mod tests {
         )
     }
 
-    fn quad() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+    fn quad() -> (Vec<(u32, u32, u32)>, Vertices) {
         #[rustfmt::skip]
         let vertices = vec![
             v(-1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -364,11 +364,11 @@ fn remove_orphan_vertices(
     faces: Vec<(u32, u32, u32)>,
     vertices: Vertices,
 ) -> (Vec<(u32, u32, u32)>, Vertices) {
-    let mut vertices_reduced: Vertices = Vec::new();
+    let mut vertices_reduced: Vertices = Vec::with_capacity(vertices.len());
     let original_vertex_len = vertices.len();
     let unused_vertex_marker = vertices.len();
     let mut old_new_vertex_map: Vec<usize> = vec![unused_vertex_marker; original_vertex_len];
-    let mut faces_renumbered: Vec<(u32, u32, u32)> = Vec::new();
+    let mut faces_renumbered: Vec<(u32, u32, u32)> = Vec::with_capacity(faces.len());
 
     for face in faces {
         let old_vertex_index_0 = cast_usize(face.0);
@@ -408,6 +408,9 @@ fn remove_orphan_vertices(
         ));
     }
 
+    faces_renumbered.shrink_to_fit();
+    vertices_reduced.shrink_to_fit();
+
     (faces_renumbered, vertices_reduced)
 }
 
@@ -416,11 +419,11 @@ fn remove_orphan_normals(
     faces: Vec<TriangleFace>,
     normals: Normals,
 ) -> (Vec<TriangleFace>, Normals) {
-    let mut normals_reduced: Normals = Vec::new();
+    let mut normals_reduced: Normals = Vec::with_capacity(normals.len());
     let original_normal_len = normals.len();
     let unused_normal_marker = normals.len();
     let mut old_new_normal_map: Vec<usize> = vec![unused_normal_marker; original_normal_len];
-    let mut faces_renumbered: Vec<TriangleFace> = Vec::new();
+    let mut faces_renumbered: Vec<TriangleFace> = Vec::with_capacity(faces.len());
 
     for face in faces {
         let old_normal_index_0 = cast_usize(face.normals.0);
@@ -463,6 +466,9 @@ fn remove_orphan_normals(
         ));
     }
 
+    faces_renumbered.shrink_to_fit();
+    normals_reduced.shrink_to_fit();
+
     (faces_renumbered, normals_reduced)
 }
 
@@ -471,16 +477,17 @@ fn remove_orphan_vertices_and_normals(
     vertices: Vertices,
     normals: Normals,
 ) -> (Vec<TriangleFace>, Vertices, Normals) {
-    let mut vertices_reduced: Vertices = Vec::new();
+    let mut vertices_reduced: Vertices = Vec::with_capacity(vertices.len());
     let original_vertex_len = vertices.len();
     let unused_vertex_marker = vertices.len();
     let mut old_new_vertex_map: Vec<usize> = vec![unused_vertex_marker; original_vertex_len];
 
-    let mut normals_reduced: Normals = Vec::new();
+    let mut normals_reduced: Normals = Vec::with_capacity(normals.len());
     let original_normal_len = normals.len();
     let unused_normal_marker = normals.len();
     let mut old_new_normal_map: Vec<usize> = vec![unused_normal_marker; original_normal_len];
-    let mut faces_renumbered: Vec<TriangleFace> = Vec::new();
+
+    let mut faces_renumbered: Vec<TriangleFace> = Vec::with_capacity(faces.len());
 
     for face in faces {
         let old_vertex_index_0 = cast_usize(face.vertices.0);
@@ -552,6 +559,10 @@ fn remove_orphan_vertices_and_normals(
             cast_u32(new_normal_index_2),
         ));
     }
+
+    faces_renumbered.shrink_to_fit();
+    vertices_reduced.shrink_to_fit();
+    normals_reduced.shrink_to_fit();
 
     (faces_renumbered, vertices_reduced, normals_reduced)
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -16,7 +16,6 @@ pub enum NormalStrategy {
     // FIXME: add `Smooth`
 }
 
-pub type FaceVertexTuples = Vec<(u32, u32, u32)>;
 pub type Vertices = Vec<Point3<f32>>;
 pub type Normals = Vec<Vector3<f32>>;
 
@@ -46,7 +45,7 @@ impl Geometry {
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices.
     pub fn from_triangle_faces_with_vertices_and_computed_normals(
-        faces: FaceVertexTuples,
+        faces: Vec<(u32, u32, u32)>,
         vertices: Vertices,
         normal_strategy: NormalStrategy,
     ) -> Self {
@@ -105,7 +104,7 @@ impl Geometry {
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices.
     pub fn from_triangle_faces_with_vertices_and_computed_normals_remove_orphans(
-        faces: FaceVertexTuples,
+        faces: Vec<(u32, u32, u32)>,
         vertices: Vertices,
         normal_strategy: NormalStrategy,
     ) -> Self {
@@ -362,48 +361,53 @@ impl Hash for UnorientedEdge {
 }
 
 fn remove_orphan_vertices(
-    faces: FaceVertexTuples,
+    faces: Vec<(u32, u32, u32)>,
     vertices: Vertices,
-) -> (FaceVertexTuples, Vertices) {
+) -> (Vec<(u32, u32, u32)>, Vertices) {
     let mut vertices_reduced: Vertices = Vec::new();
     let original_vertex_len = vertices.len();
     let unused_vertex_marker = vertices.len();
     let mut old_new_vertex_map: Vec<usize> = vec![unused_vertex_marker; original_vertex_len];
-    let mut faces_renumbered: FaceVertexTuples = Vec::new();
+    let mut faces_renumbered: Vec<(u32, u32, u32)> = Vec::new();
+
     for face in faces {
         let old_vertex_index_0 = cast_usize(face.0);
         let new_vertex_index_0 = if old_new_vertex_map[old_vertex_index_0] == unused_vertex_marker {
+            let new_index = vertices_reduced.len();
             vertices_reduced.push(vertices[old_vertex_index_0]);
-            let new_index = vertices_reduced.len() - 1;
             old_new_vertex_map[old_vertex_index_0] = new_index;
             new_index
         } else {
             old_new_vertex_map[old_vertex_index_0]
         };
+
         let old_vertex_index_1 = cast_usize(face.1);
         let new_vertex_index_1 = if old_new_vertex_map[old_vertex_index_1] == unused_vertex_marker {
+            let new_index = vertices_reduced.len();
             vertices_reduced.push(vertices[old_vertex_index_1]);
-            let new_index = vertices_reduced.len() - 1;
             old_new_vertex_map[old_vertex_index_1] = new_index;
             new_index
         } else {
             old_new_vertex_map[old_vertex_index_1]
         };
+
         let old_vertex_index_2 = cast_usize(face.2);
         let new_vertex_index_2 = if old_new_vertex_map[old_vertex_index_2] == unused_vertex_marker {
+            let new_index = vertices_reduced.len();
             vertices_reduced.push(vertices[old_vertex_index_2]);
-            let new_index = vertices_reduced.len() - 1;
             old_new_vertex_map[old_vertex_index_2] = new_index;
             new_index
         } else {
             old_new_vertex_map[old_vertex_index_2]
         };
+
         faces_renumbered.push((
             cast_u32(new_vertex_index_0),
             cast_u32(new_vertex_index_1),
             cast_u32(new_vertex_index_2),
         ));
     }
+
     (faces_renumbered, vertices_reduced)
 }
 
@@ -417,34 +421,38 @@ fn remove_orphan_normals(
     let unused_normal_marker = normals.len();
     let mut old_new_normal_map: Vec<usize> = vec![unused_normal_marker; original_normal_len];
     let mut faces_renumbered: Vec<TriangleFace> = Vec::new();
+
     for face in faces {
         let old_normal_index_0 = cast_usize(face.normals.0);
         let new_normal_index_0 = if old_new_normal_map[old_normal_index_0] == unused_normal_marker {
+            let new_index = normals_reduced.len();
             normals_reduced.push(normals[old_normal_index_0]);
-            let new_index = normals_reduced.len() - 1;
             old_new_normal_map[old_normal_index_0] = new_index;
             new_index
         } else {
             old_new_normal_map[old_normal_index_0]
         };
+
         let old_normal_index_1 = cast_usize(face.normals.1);
         let new_normal_index_1 = if old_new_normal_map[old_normal_index_1] == unused_normal_marker {
+            let new_index = normals_reduced.len();
             normals_reduced.push(normals[old_normal_index_1]);
-            let new_index = normals_reduced.len() - 1;
             old_new_normal_map[old_normal_index_1] = new_index;
             new_index
         } else {
             old_new_normal_map[old_normal_index_1]
         };
+
         let old_normal_index_2 = cast_usize(face.normals.2);
         let new_normal_index_2 = if old_new_normal_map[old_normal_index_2] == unused_normal_marker {
+            let new_index = normals_reduced.len();
             normals_reduced.push(normals[old_normal_index_2]);
-            let new_index = normals_reduced.len() - 1;
             old_new_normal_map[old_normal_index_2] = new_index;
             new_index
         } else {
             old_new_normal_map[old_normal_index_2]
         };
+
         faces_renumbered.push(TriangleFace::new_separate(
             face.vertices.0,
             face.vertices.1,
@@ -454,6 +462,7 @@ fn remove_orphan_normals(
             cast_u32(new_normal_index_2),
         ));
     }
+
     (faces_renumbered, normals_reduced)
 }
 
@@ -476,26 +485,28 @@ fn remove_orphan_vertices_and_normals(
     for face in faces {
         let old_vertex_index_0 = cast_usize(face.vertices.0);
         let new_vertex_index_0 = if old_new_vertex_map[old_vertex_index_0] == unused_vertex_marker {
+            let new_index = vertices_reduced.len();
             vertices_reduced.push(vertices[old_vertex_index_0]);
-            let new_index = vertices_reduced.len() - 1;
             old_new_vertex_map[old_vertex_index_0] = new_index;
             new_index
         } else {
             old_new_vertex_map[old_vertex_index_0]
         };
+
         let old_vertex_index_1 = cast_usize(face.vertices.1);
         let new_vertex_index_1 = if old_new_vertex_map[old_vertex_index_1] == unused_vertex_marker {
+            let new_index = vertices_reduced.len();
             vertices_reduced.push(vertices[old_vertex_index_1]);
-            let new_index = vertices_reduced.len() - 1;
             old_new_vertex_map[old_vertex_index_1] = new_index;
             new_index
         } else {
             old_new_vertex_map[old_vertex_index_1]
         };
+
         let old_vertex_index_2 = cast_usize(face.vertices.2);
         let new_vertex_index_2 = if old_new_vertex_map[old_vertex_index_2] == unused_vertex_marker {
+            let new_index = vertices_reduced.len();
             vertices_reduced.push(vertices[old_vertex_index_2]);
-            let new_index = vertices_reduced.len() - 1;
             old_new_vertex_map[old_vertex_index_2] = new_index;
             new_index
         } else {
@@ -504,26 +515,28 @@ fn remove_orphan_vertices_and_normals(
 
         let old_normal_index_0 = cast_usize(face.normals.0);
         let new_normal_index_0 = if old_new_normal_map[old_normal_index_0] == unused_normal_marker {
+            let new_index = normals_reduced.len();
             normals_reduced.push(normals[old_normal_index_0]);
-            let new_index = normals_reduced.len() - 1;
             old_new_normal_map[old_normal_index_0] = new_index;
             new_index
         } else {
             old_new_normal_map[old_normal_index_0]
         };
+
         let old_normal_index_1 = cast_usize(face.normals.1);
         let new_normal_index_1 = if old_new_normal_map[old_normal_index_1] == unused_normal_marker {
+            let new_index = normals_reduced.len();
             normals_reduced.push(normals[old_normal_index_1]);
-            let new_index = normals_reduced.len() - 1;
             old_new_normal_map[old_normal_index_1] = new_index;
             new_index
         } else {
             old_new_normal_map[old_normal_index_1]
         };
+
         let old_normal_index_2 = cast_usize(face.normals.2);
         let new_normal_index_2 = if old_new_normal_map[old_normal_index_2] == unused_normal_marker {
+            let new_index = normals_reduced.len();
             normals_reduced.push(normals[old_normal_index_2]);
-            let new_index = normals_reduced.len() - 1;
             old_new_normal_map[old_normal_index_2] = new_index;
             new_index
         } else {
@@ -971,7 +984,7 @@ mod tests {
 
     use super::*;
 
-    fn quad() -> (FaceVertexTuples, Vertices) {
+    fn quad() -> (Vec<(u32, u32, u32)>, Vertices) {
         #[rustfmt::skip]
         let vertices = vec![
             v(-1.0, -1.0,  0.0, [0.0, 0.0, 0.0], 1.0),

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -16,6 +16,10 @@ pub enum NormalStrategy {
     // FIXME: add `Smooth`
 }
 
+pub type FaceVertexTuples = Vec<(u32, u32, u32)>;
+pub type Vertices = Vec<Point3<f32>>;
+pub type Normals = Vec<Vector3<f32>>;
+
 /// Geometric data containing multiple possibly _variable-length_
 /// lists of geometric data, such as vertices and normals, and faces -
 /// a single list containing the index topology that describes the
@@ -31,8 +35,8 @@ pub enum NormalStrategy {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Geometry {
     faces: Vec<Face>,
-    vertices: Vec<Point3<f32>>,
-    normals: Vec<Vector3<f32>>,
+    vertices: Vertices,
+    normals: Normals,
 }
 
 impl Geometry {
@@ -42,8 +46,8 @@ impl Geometry {
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices.
     pub fn from_triangle_faces_with_vertices_and_computed_normals(
-        faces: Vec<(u32, u32, u32)>,
-        vertices: Vec<Point3<f32>>,
+        faces: FaceVertexTuples,
+        vertices: Vertices,
         normal_strategy: NormalStrategy,
     ) -> Self {
         // FIXME: orphan removal
@@ -103,58 +107,16 @@ impl Geometry {
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices.
     pub fn from_triangle_faces_with_vertices_and_computed_normals_remove_orphans(
-        faces: Vec<(u32, u32, u32)>,
-        vertices: Vec<Point3<f32>>,
+        faces: FaceVertexTuples,
+        vertices: Vertices,
         normal_strategy: NormalStrategy,
     ) -> Self {
         let (faces_purged, vertices_purged) = remove_orphan_vertices(faces, vertices);
-
-        let mut normals = Vec::with_capacity(faces_purged.len());
-        let vertices_range = 0..cast_u32(vertices_purged.len());
-        for &(v1, v2, v3) in &faces_purged {
-            assert!(
-                vertices_range.contains(&v1),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                vertices_range.contains(&v2),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                vertices_range.contains(&v3),
-                "Faces reference out of bounds position data"
-            );
-
-            // FIXME: computing smooth normals in the future won't be
-            // so simple as just computing a normal per face, we will
-            // need to analyze larger parts of the geometry
-            let face_normal = match normal_strategy {
-                NormalStrategy::Sharp => compute_triangle_normal(
-                    &vertices_purged[cast_usize(v1)],
-                    &vertices_purged[cast_usize(v2)],
-                    &vertices_purged[cast_usize(v3)],
-                ),
-            };
-
-            normals.push(face_normal);
-        }
-
-        assert_eq!(normals.len(), faces_purged.len());
-        assert_eq!(normals.capacity(), faces_purged.len());
-
-        Self {
-            faces: faces_purged
-                .into_iter()
-                .enumerate()
-                .map(|(i, (i1, i2, i3))| {
-                    let normal_index = cast_u32(i);
-                    TriangleFace::new_separate(i1, i2, i3, normal_index, normal_index, normal_index)
-                })
-                .map(Face::from)
-                .collect(),
-            vertices: vertices_purged,
-            normals,
-        }
+        Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+            faces_purged,
+            vertices_purged,
+            normal_strategy,
+        )
     }
 
     /// Create new triangle face geometry from provided faces,
@@ -164,8 +126,8 @@ impl Geometry {
     /// Panics if faces refer to out-of-bounds vertices or normals.
     pub fn from_triangle_faces_with_vertices_and_normals(
         faces: Vec<TriangleFace>,
-        vertices: Vec<Point3<f32>>,
-        normals: Vec<Vector3<f32>>,
+        vertices: Vertices,
+        normals: Normals,
     ) -> Self {
         // FIXME: orphan removal
 
@@ -214,8 +176,8 @@ impl Geometry {
     /// Panics if faces refer to out-of-bounds vertices or normals.
     pub fn from_triangle_faces_with_vertices_and_normals_remove_orphans(
         faces: Vec<TriangleFace>,
-        vertices: Vec<Point3<f32>>,
-        normals: Vec<Vector3<f32>>,
+        vertices: Vertices,
+        normals: Normals,
     ) -> Self {
         let (faces_prepurged, vertices_purged) = remove_orphan_vertices(
             faces
@@ -232,43 +194,11 @@ impl Geometry {
                 .collect(),
             normals,
         );
-
-        let vertices_range = 0..cast_u32(vertices_purged.len());
-        let normals_range = 0..cast_u32(normals_purged.len());
-        for face in &faces_purged {
-            let v = face.vertices;
-            let n = face.normals;
-            assert!(
-                vertices_range.contains(&v.0),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                vertices_range.contains(&v.1),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                vertices_range.contains(&v.2),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                normals_range.contains(&n.0),
-                "Faces reference out of bounds normal data"
-            );
-            assert!(
-                normals_range.contains(&n.1),
-                "Faces reference out of bounds normal data"
-            );
-            assert!(
-                normals_range.contains(&n.2),
-                "Faces reference out of bounds normal data"
-            );
-        }
-
-        Self {
-            faces: faces_purged.into_iter().map(Face::Triangle).collect(),
-            vertices: vertices_purged,
-            normals: normals_purged,
-        }
+        Geometry::from_triangle_faces_with_vertices_and_normals(
+            faces_purged,
+            vertices_purged,
+            normals_purged,
+        )
     }
 
     /// Return a view of all triangle faces in this geometry. Skip all
@@ -447,20 +377,18 @@ impl Hash for UnorientedEdge {
     }
 }
 
-#[allow(dead_code, clippy::type_complexity)]
 fn remove_orphan_vertices(
-    faces: Vec<(u32, u32, u32)>,
-    vertices: Vec<Point3<f32>>,
-) -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+    faces: FaceVertexTuples,
+    vertices: Vertices,
+) -> (FaceVertexTuples, Vertices) {
     let mut old_to_new_vertex_index: HashMap<u32, u32> = HashMap::new();
-    let mut reduced_vertices: Vec<Point3<f32>> = Vec::new();
+    let mut reduced_vertices: Vertices = Vec::new();
     let mut new_index = 0;
-    #[allow(clippy::needless_range_loop)]
-    for original_index in 0..vertices.len() {
+    for (original_index, vertex) in vertices.iter().enumerate() {
         let o_i = cast_u32(original_index);
         if faces.iter().any(|f| f.0 == o_i || f.1 == o_i || f.2 == o_i) {
             old_to_new_vertex_index.insert(o_i, new_index);
-            reduced_vertices.push(vertices[original_index]);
+            reduced_vertices.push(*vertex);
             new_index += 1;
         }
     }
@@ -485,23 +413,21 @@ fn remove_orphan_vertices(
     (recomputed_faces, reduced_vertices)
 }
 
-#[allow(dead_code)]
 fn remove_orphan_normals(
     faces: Vec<TriangleFace>,
-    normals: Vec<Vector3<f32>>,
-) -> (Vec<TriangleFace>, Vec<Vector3<f32>>) {
+    normals: Normals,
+) -> (Vec<TriangleFace>, Normals) {
     let mut old_to_new_normal_index: HashMap<u32, u32> = HashMap::new();
-    let mut reduced_normals: Vec<Vector3<f32>> = Vec::new();
+    let mut reduced_normals: Normals = Vec::new();
     let mut new_index = 0;
-    #[allow(clippy::needless_range_loop)]
-    for original_index in 0..normals.len() {
+    for (original_index, normal) in normals.iter().enumerate() {
         let o_i = cast_u32(original_index);
         if faces
             .iter()
             .any(|f| f.normals.0 == o_i || f.normals.1 == o_i || f.normals.2 == o_i)
         {
             old_to_new_normal_index.insert(o_i, new_index);
-            reduced_normals.push(normals[original_index]);
+            reduced_normals.push(*normal);
             new_index += 1;
         }
     }
@@ -957,7 +883,7 @@ mod tests {
 
     use super::*;
 
-    fn quad() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+    fn quad() -> (FaceVertexTuples, Vertices) {
         #[rustfmt::skip]
         let vertices = vec![
             v(-1.0, -1.0,  0.0, [0.0, 0.0, 0.0], 1.0),
@@ -975,7 +901,7 @@ mod tests {
         (faces, vertices)
     }
 
-    fn quad_with_normals() -> (Vec<TriangleFace>, Vec<Point3<f32>>, Vec<Vector3<f32>>) {
+    fn quad_with_normals() -> (Vec<TriangleFace>, Vertices, Normals) {
         #[rustfmt::skip]
         let vertices = vec![
             v(-1.0, -1.0,  0.0, [0.0, 0.0, 0.0], 1.0),
@@ -1350,13 +1276,11 @@ mod tests {
     }
     #[test]
     fn test_remove_orphan_vertices() {
-        let (faces, vertices, _normals) = quad_with_normals();
+        let (faces, vertices) = quad();
         let extra_vertex = vec![v(0.0, 0.0, 0.0, [0.0, 0.0, 0.0], 1.0)];
         let vertices_extended = [&extra_vertex[..], &vertices[..]].concat();
-        let faces_renumbered_to_match_extend_vertices: Vec<_> = faces
-            .iter()
-            .map(|f| (f.vertices.0 + 1, f.vertices.1 + 1, f.vertices.2 + 1))
-            .collect();
+        let faces_renumbered_to_match_extend_vertices: Vec<_> =
+            faces.iter().map(|f| (f.0 + 1, f.1 + 1, f.2 + 1)).collect();
 
         let faces_length = &faces.len();
 
@@ -1402,18 +1326,16 @@ mod tests {
 
     #[test]
     fn test_geometry_from_triangle_faces_with_vertices_and_computed_normals_remove_orphans() {
-        let (faces, vertices, _normals) = quad_with_normals();
+        let (faces, vertices) = quad();
         let extra_vertex = vec![v(0.0, 0.0, 0.0, [0.0, 0.0, 0.0], 1.0)];
         let vertices_extended = [&extra_vertex[..], &vertices[..]].concat();
-        let faces_renumbered_to_match_extend_vertices: Vec<_> = faces
-            .iter()
-            .map(|f| (f.vertices.0 + 1, f.vertices.1 + 1, f.vertices.2 + 1))
-            .collect();
+        let faces_renumbered_to_match_extend_vertices: Vec<_> =
+            faces.iter().map(|f| (f.0 + 1, f.1 + 1, f.2 + 1)).collect();
 
         let geometry =
             Geometry::from_triangle_faces_with_vertices_and_computed_normals_remove_orphans(
-                faces_renumbered_to_match_extend_vertices.clone(),
-                vertices_extended.clone(),
+                faces_renumbered_to_match_extend_vertices,
+                vertices_extended,
                 NormalStrategy::Sharp,
             );
 
@@ -1443,9 +1365,9 @@ mod tests {
             .collect();
 
         let geometry = Geometry::from_triangle_faces_with_vertices_and_normals_remove_orphans(
-            faces_renumbered_to_match_extend_vertices_and_normals.clone(),
-            vertices_extended.clone(),
-            normals_extended.clone(),
+            faces_renumbered_to_match_extend_vertices_and_normals,
+            vertices_extended,
+            normals_extended,
         );
 
         assert!(geometry.has_no_orphan_vertices());

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -175,21 +175,9 @@ impl Geometry {
         vertices: Vertices,
         normals: Normals,
     ) -> Self {
-        let (faces_prepurged, vertices_purged) = remove_orphan_vertices(
-            faces
-                .iter()
-                .map(|f| (f.vertices.0, f.vertices.1, f.vertices.2))
-                .collect(),
-            vertices,
-        );
+        let (faces_purged, vertices_purged, normals_purged) =
+            remove_orphan_vertices_and_normals(faces, vertices, normals);
 
-        let (faces_purged, normals_purged) = remove_orphan_normals(
-            faces_prepurged
-                .iter()
-                .map(|f| TriangleFace::new(f.0, f.1, f.2))
-                .collect(),
-            normals,
-        );
         Geometry::from_triangle_faces_with_vertices_and_normals(
             faces_purged,
             vertices_purged,
@@ -378,37 +366,37 @@ fn remove_orphan_vertices(
     vertices: Vertices,
 ) -> (FaceVertexTuples, Vertices) {
     let mut vertices_reduced: Vertices = Vec::new();
-    let original_item_len = vertices.len();
-    let unused_item_marker = vertices.len();
-    let mut old_new_item_map: Vec<usize> = vec![unused_item_marker; original_item_len];
+    let original_vertex_len = vertices.len();
+    let unused_vertex_marker = vertices.len();
+    let mut old_new_vertex_map: Vec<usize> = vec![unused_vertex_marker; original_vertex_len];
     let mut faces_renumbered: FaceVertexTuples = Vec::new();
     for face in faces {
         let old_vertex_index_0 = cast_usize(face.0);
-        let new_vertex_index_0 = if old_new_item_map[old_vertex_index_0] == unused_item_marker {
+        let new_vertex_index_0 = if old_new_vertex_map[old_vertex_index_0] == unused_vertex_marker {
             vertices_reduced.push(vertices[old_vertex_index_0]);
             let new_index = vertices_reduced.len() - 1;
-            old_new_item_map[old_vertex_index_0] = new_index;
+            old_new_vertex_map[old_vertex_index_0] = new_index;
             new_index
         } else {
-            old_new_item_map[old_vertex_index_0]
+            old_new_vertex_map[old_vertex_index_0]
         };
         let old_vertex_index_1 = cast_usize(face.1);
-        let new_vertex_index_1 = if old_new_item_map[old_vertex_index_1] == unused_item_marker {
+        let new_vertex_index_1 = if old_new_vertex_map[old_vertex_index_1] == unused_vertex_marker {
             vertices_reduced.push(vertices[old_vertex_index_1]);
             let new_index = vertices_reduced.len() - 1;
-            old_new_item_map[old_vertex_index_1] = new_index;
+            old_new_vertex_map[old_vertex_index_1] = new_index;
             new_index
         } else {
-            old_new_item_map[old_vertex_index_1]
+            old_new_vertex_map[old_vertex_index_1]
         };
         let old_vertex_index_2 = cast_usize(face.2);
-        let new_vertex_index_2 = if old_new_item_map[old_vertex_index_2] == unused_item_marker {
+        let new_vertex_index_2 = if old_new_vertex_map[old_vertex_index_2] == unused_vertex_marker {
             vertices_reduced.push(vertices[old_vertex_index_2]);
             let new_index = vertices_reduced.len() - 1;
-            old_new_item_map[old_vertex_index_2] = new_index;
+            old_new_vertex_map[old_vertex_index_2] = new_index;
             new_index
         } else {
-            old_new_item_map[old_vertex_index_2]
+            old_new_vertex_map[old_vertex_index_2]
         };
         faces_renumbered.push((
             cast_u32(new_vertex_index_0),
@@ -419,50 +407,140 @@ fn remove_orphan_vertices(
     (faces_renumbered, vertices_reduced)
 }
 
+#[allow(dead_code)]
 fn remove_orphan_normals(
     faces: Vec<TriangleFace>,
     normals: Normals,
 ) -> (Vec<TriangleFace>, Normals) {
     let mut normals_reduced: Normals = Vec::new();
-    let original_item_len = normals.len();
-    let unused_item_marker = normals.len();
-    let mut old_new_item_map: Vec<usize> = vec![unused_item_marker; original_item_len];
+    let original_normal_len = normals.len();
+    let unused_normal_marker = normals.len();
+    let mut old_new_normal_map: Vec<usize> = vec![unused_normal_marker; original_normal_len];
     let mut faces_renumbered: Vec<TriangleFace> = Vec::new();
     for face in faces {
         let old_normal_index_0 = cast_usize(face.normals.0);
-        let new_normal_index_0 = if old_new_item_map[old_normal_index_0] == unused_item_marker {
+        let new_normal_index_0 = if old_new_normal_map[old_normal_index_0] == unused_normal_marker {
             normals_reduced.push(normals[old_normal_index_0]);
             let new_index = normals_reduced.len() - 1;
-            old_new_item_map[old_normal_index_0] = new_index;
+            old_new_normal_map[old_normal_index_0] = new_index;
             new_index
         } else {
-            old_new_item_map[old_normal_index_0]
+            old_new_normal_map[old_normal_index_0]
         };
         let old_normal_index_1 = cast_usize(face.normals.1);
-        let new_normal_index_1 = if old_new_item_map[old_normal_index_1] == unused_item_marker {
+        let new_normal_index_1 = if old_new_normal_map[old_normal_index_1] == unused_normal_marker {
             normals_reduced.push(normals[old_normal_index_1]);
             let new_index = normals_reduced.len() - 1;
-            old_new_item_map[old_normal_index_1] = new_index;
+            old_new_normal_map[old_normal_index_1] = new_index;
             new_index
         } else {
-            old_new_item_map[old_normal_index_1]
+            old_new_normal_map[old_normal_index_1]
         };
         let old_normal_index_2 = cast_usize(face.normals.2);
-        let new_normal_index_2 = if old_new_item_map[old_normal_index_2] == unused_item_marker {
+        let new_normal_index_2 = if old_new_normal_map[old_normal_index_2] == unused_normal_marker {
             normals_reduced.push(normals[old_normal_index_2]);
             let new_index = normals_reduced.len() - 1;
-            old_new_item_map[old_normal_index_2] = new_index;
+            old_new_normal_map[old_normal_index_2] = new_index;
             new_index
         } else {
-            old_new_item_map[old_normal_index_2]
+            old_new_normal_map[old_normal_index_2]
         };
-        faces_renumbered.push(TriangleFace::from((
+        faces_renumbered.push(TriangleFace::new_separate(
+            face.vertices.0,
+            face.vertices.1,
+            face.vertices.2,
             cast_u32(new_normal_index_0),
             cast_u32(new_normal_index_1),
             cast_u32(new_normal_index_2),
-        )));
+        ));
     }
     (faces_renumbered, normals_reduced)
+}
+
+fn remove_orphan_vertices_and_normals(
+    faces: Vec<TriangleFace>,
+    vertices: Vertices,
+    normals: Normals,
+) -> (Vec<TriangleFace>, Vertices, Normals) {
+    let mut vertices_reduced: Vertices = Vec::new();
+    let original_vertex_len = vertices.len();
+    let unused_vertex_marker = vertices.len();
+    let mut old_new_vertex_map: Vec<usize> = vec![unused_vertex_marker; original_vertex_len];
+
+    let mut normals_reduced: Normals = Vec::new();
+    let original_normal_len = normals.len();
+    let unused_normal_marker = normals.len();
+    let mut old_new_normal_map: Vec<usize> = vec![unused_normal_marker; original_normal_len];
+    let mut faces_renumbered: Vec<TriangleFace> = Vec::new();
+
+    for face in faces {
+        let old_vertex_index_0 = cast_usize(face.vertices.0);
+        let new_vertex_index_0 = if old_new_vertex_map[old_vertex_index_0] == unused_vertex_marker {
+            vertices_reduced.push(vertices[old_vertex_index_0]);
+            let new_index = vertices_reduced.len() - 1;
+            old_new_vertex_map[old_vertex_index_0] = new_index;
+            new_index
+        } else {
+            old_new_vertex_map[old_vertex_index_0]
+        };
+        let old_vertex_index_1 = cast_usize(face.vertices.1);
+        let new_vertex_index_1 = if old_new_vertex_map[old_vertex_index_1] == unused_vertex_marker {
+            vertices_reduced.push(vertices[old_vertex_index_1]);
+            let new_index = vertices_reduced.len() - 1;
+            old_new_vertex_map[old_vertex_index_1] = new_index;
+            new_index
+        } else {
+            old_new_vertex_map[old_vertex_index_1]
+        };
+        let old_vertex_index_2 = cast_usize(face.vertices.2);
+        let new_vertex_index_2 = if old_new_vertex_map[old_vertex_index_2] == unused_vertex_marker {
+            vertices_reduced.push(vertices[old_vertex_index_2]);
+            let new_index = vertices_reduced.len() - 1;
+            old_new_vertex_map[old_vertex_index_2] = new_index;
+            new_index
+        } else {
+            old_new_vertex_map[old_vertex_index_2]
+        };
+
+        let old_normal_index_0 = cast_usize(face.normals.0);
+        let new_normal_index_0 = if old_new_normal_map[old_normal_index_0] == unused_normal_marker {
+            normals_reduced.push(normals[old_normal_index_0]);
+            let new_index = normals_reduced.len() - 1;
+            old_new_normal_map[old_normal_index_0] = new_index;
+            new_index
+        } else {
+            old_new_normal_map[old_normal_index_0]
+        };
+        let old_normal_index_1 = cast_usize(face.normals.1);
+        let new_normal_index_1 = if old_new_normal_map[old_normal_index_1] == unused_normal_marker {
+            normals_reduced.push(normals[old_normal_index_1]);
+            let new_index = normals_reduced.len() - 1;
+            old_new_normal_map[old_normal_index_1] = new_index;
+            new_index
+        } else {
+            old_new_normal_map[old_normal_index_1]
+        };
+        let old_normal_index_2 = cast_usize(face.normals.2);
+        let new_normal_index_2 = if old_new_normal_map[old_normal_index_2] == unused_normal_marker {
+            normals_reduced.push(normals[old_normal_index_2]);
+            let new_index = normals_reduced.len() - 1;
+            old_new_normal_map[old_normal_index_2] = new_index;
+            new_index
+        } else {
+            old_new_normal_map[old_normal_index_2]
+        };
+
+        faces_renumbered.push(TriangleFace::new_separate(
+            cast_u32(new_vertex_index_0),
+            cast_u32(new_vertex_index_1),
+            cast_u32(new_vertex_index_2),
+            cast_u32(new_normal_index_0),
+            cast_u32(new_normal_index_1),
+            cast_u32(new_normal_index_2),
+        ));
+    }
+
+    (faces_renumbered, vertices_reduced, normals_reduced)
 }
 
 pub fn plane_same_len(position: [f32; 3], scale: f32) -> Geometry {
@@ -1331,6 +1409,45 @@ mod tests {
         let faces_purged_length = &faces_purged.len();
 
         assert_eq!(faces_length, faces_purged_length);
+        assert_eq!(normals_purged, normals);
+    }
+
+    #[test]
+    fn test_remove_orphan_vertices_and_normals() {
+        let (faces, vertices, normals) = quad_with_normals();
+
+        let extra_vertex = vec![v(0.0, 0.0, 0.0, [0.0, 0.0, 0.0], 1.0)];
+        let vertices_extended = [&extra_vertex[..], &vertices[..]].concat();
+
+        let extra_normal = vec![n(0.0, 0.0, 0.0)];
+        let normals_extended = [&extra_normal[..], &normals[..]].concat();
+
+        let faces_renumbered_to_match_extend_data: Vec<_> = faces
+            .iter()
+            .map(|f| {
+                TriangleFace::new_separate(
+                    f.vertices.0 + 1,
+                    f.vertices.1 + 1,
+                    f.vertices.2 + 1,
+                    f.normals.0 + 1,
+                    f.normals.1 + 1,
+                    f.normals.2 + 1,
+                )
+            })
+            .collect();
+
+        let faces_length = &faces.len();
+
+        let (faces_purged, vertices_purged, normals_purged) = remove_orphan_vertices_and_normals(
+            faces_renumbered_to_match_extend_data,
+            vertices_extended,
+            normals_extended,
+        );
+
+        let faces_purged_length = &faces_purged.len();
+
+        assert_eq!(faces_length, faces_purged_length);
+        assert_eq!(vertices_purged, vertices);
         assert_eq!(normals_purged, normals);
     }
 

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -116,7 +116,7 @@ mod tests {
 
     use crate::edge_analysis::edge_valencies;
     use crate::geometry::{
-        self, cube_sharp_var_len, Geometry, NormalStrategy, TriangleFace, UnorientedEdge,
+        self, cube_sharp_var_len, Geometry, NormalStrategy, TriangleFace, UnorientedEdge, Vertices,
     };
     use crate::test_geometry_fixtures::{double_torus, torus, triple_torus};
 
@@ -134,7 +134,7 @@ mod tests {
         Vector3::new(x, y, z)
     }
 
-    pub fn quad() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+    pub fn quad() -> (Vec<(u32, u32, u32)>, Vertices) {
         let vertices = vec![
             v(-1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
             v(1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
@@ -147,7 +147,7 @@ mod tests {
         (faces, vertices)
     }
 
-    pub fn non_manifold_shape() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+    pub fn non_manifold_shape() -> (Vec<(u32, u32, u32)>, Vertices) {
         let vertices = vec![
             v(-1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
             v(1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),

--- a/src/test_geometry_fixtures.rs
+++ b/src/test_geometry_fixtures.rs
@@ -3,8 +3,10 @@
 
 use nalgebra::Point3;
 
+use crate::geometry::Vertices;
+
 #[allow(dead_code, clippy::unreadable_literal, clippy::approx_constant)]
-pub fn torus() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+pub fn torus() -> (Vec<(u32, u32, u32)>, Vertices) {
     #[rustfmt::skip]
         let vertices = vec![
         Point3::new(1.0, 0.0, 0.25),
@@ -233,7 +235,7 @@ pub fn torus() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
 }
 
 #[allow(dead_code, clippy::unreadable_literal, clippy::approx_constant)]
-pub fn double_torus() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+pub fn double_torus() -> (Vec<(u32, u32, u32)>, Vertices) {
     #[rustfmt::skip]
         let vertices = vec![
         Point3::new(-1.375, 0.0, 0.0),
@@ -910,7 +912,7 @@ pub fn double_torus() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
 }
 
 #[allow(dead_code, clippy::unreadable_literal, clippy::approx_constant)]
-pub fn triple_torus() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+pub fn triple_torus() -> (Vec<(u32, u32, u32)>, Vertices) {
     #[rustfmt::skip]
         let vertices = vec![
         Point3::new(-3.5, 0.0, 0.0),


### PR DESCRIPTION
The pull request deals with orphan vertices and normals - data not referenced in any indexing structure (in our case a face) and thus not used by our software (yet and probably never). 

Two new functions are introduced:

- `remove_orphan_vertices(faces: Vec<(u32, u32, u32)>, vertices: Vec<Point3<f32>>) -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>)`
- `remove_orphan_normals(faces: Vec<TriangleFace>, normals: Vec<Vector3<f32>>) -> (Vec<TriangleFace>, Vec<Vector3<f32>>)`

The functions are intended to be used when the mesh geometry is being created, therefore the input and the output is not the geometry itself but rather its source data. The two functions are independent and can be used separately. For sake of performance, there could be a compound function removing both types of orphans at once.

The main struggle is the renumbering of the data indices (in our case `TriangleFace`s) to match the reduced set of vertices or normals respectively. The functions first create maps of old index -> new index, a list of reduced data (vertices or normals), then renumber the face data and return both, the reduced dataset (vertices or normals) and renumbered faces. 

 The orphan removal is optional (because we don't know why do they exist in the first place; they may have been created intentionally), therefore there are two new geometry constructors: `from_triangle_faces_with_vertices_and_computed_normals_remove_orphans`, which removes orphan vertices and `from_triangle_faces_with_vertices_and_normals_remove_orphans`, which removes both types or orphans, the vertices and the normals.