### PR TITLE
Remove installation of clippy and rustfmt from CI

### DIFF
--- a/ci/install-rust.yml
+++ b/ci/install-rust.yml
@@ -18,10 +18,6 @@ steps:
       rustup update $TOOLCHAIN
       rustup default $TOOLCHAIN
     displayName: Install rust
-  - bash: rustup component add clippy || echo "clippy not available"
-    displayName: "Install clippy"
-  - bash: rustup component add rustfmt
-    displayName: "Install rustfmt"
   - bash: |
       set -ex
       rustup -V


### PR DESCRIPTION
Since Rustup 1.20 introduced concept of profiles, manual installation of clippy and rustfmt isn't needed anymore. They are already present in default profile.