### PR TITLE
Remove triangle_faces_iter and triangle_faces_count from Geometry

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -39,8 +39,9 @@ pub struct Geometry {
 }
 
 impl Geometry {
-    /// Creates new triangular geometry from provided triangle faces
-    /// and vertices, and computes normals based on `normal_strategy`.
+    /// Creates new triangulated mesh geometry from provided triangle
+    /// faces and vertices, and computes normals based on
+    /// `normal_strategy`.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices.
@@ -124,9 +125,9 @@ impl Geometry {
         }
     }
 
-    /// Creates new triangular geometry from provided triangle faces
-    /// and vertices, removes orphan vertices and computes normals
-    /// based on `normal_strategy`.
+    /// Creates new triangulated mesh geometry from provided triangle
+    /// faces and vertices, removes orphan vertices, and computes
+    /// normals based on `normal_strategy`.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices.
@@ -148,8 +149,8 @@ impl Geometry {
         )
     }
 
-    /// Creates new triangular geometry from provided triangle faces,
-    /// vertices, and normals.
+    /// Creates new triangulated mesh geometry from provided triangle
+    /// faces, vertices and normals.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices or normals.
@@ -170,8 +171,9 @@ impl Geometry {
         )
     }
 
-    /// Creates new triangular geometry from provided triangle faces,
-    /// vertices, and normals and removes orphan vertices and normals.
+    /// Creates new triangulated mesh geometry from provided triangle
+    /// faces, vertices and normals, and removes orphan vertices and
+    /// normals.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices or normals.
@@ -252,8 +254,9 @@ impl Geometry {
         }
     }
 
-    /// Creates new triangular geometry from provided triangle faces,
-    /// vertices, and normals and removes orphan vertices and normals.
+    /// Creates new triangulated geometry from provided triangle
+    /// faces, vertices, and normals and removes orphan vertices and
+    /// normals.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices or normals.
@@ -310,8 +313,9 @@ impl Geometry {
         })
     }
 
-    /// Returns whether the geometry contains exclusively triangular faces.
-    pub fn is_triangular(&self) -> bool {
+    /// Returns whether the geometry contains exclusively triangle
+    /// faces - is triangulated.
+    pub fn is_triangulated(&self) -> bool {
         self.faces().iter().all(|face| match face {
             Face::Triangle(_) => true,
         })
@@ -1180,7 +1184,7 @@ mod tests {
             vertices.clone(),
             NormalStrategy::Sharp,
         );
-        assert!(geometry.is_triangular());
+        assert!(geometry.is_triangulated());
 
         let geometry_faces: Vec<_> = geometry
             .faces()
@@ -1225,7 +1229,7 @@ mod tests {
             vertices.clone(),
             normals.clone(),
         );
-        assert!(geometry.is_triangular());
+        assert!(geometry.is_triangulated());
 
         let geometry_faces: Vec<_> = geometry
             .faces()

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,9 +1,9 @@
 use std::cmp;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
+use std::iter::IntoIterator;
 
 use arrayvec::ArrayVec;
-
 use nalgebra as na;
 use nalgebra::base::Vector3;
 use nalgebra::geometry::Point3;
@@ -39,149 +39,235 @@ pub struct Geometry {
 }
 
 impl Geometry {
-    /// Create new triangle face geometry from provided faces and
-    /// vertices, and compute normals based on `normal_strategy`.
+    /// Creates new triangular geometry from provided triangle faces
+    /// and vertices, and computes normals based on `normal_strategy`.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices.
-    pub fn from_triangle_faces_with_vertices_and_computed_normals(
-        faces: Vec<(u32, u32, u32)>,
-        vertices: Vertices,
+    pub fn from_triangle_faces_with_vertices_and_computed_normals<F, V>(
+        faces: F,
+        vertices: V,
         normal_strategy: NormalStrategy,
-    ) -> Self {
-        let mut normals = Vec::with_capacity(faces.len());
-        let vertices_range = 0..cast_u32(vertices.len());
-        for &(v1, v2, v3) in &faces {
-            assert!(
-                vertices_range.contains(&v1),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                vertices_range.contains(&v2),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                vertices_range.contains(&v3),
-                "Faces reference out of bounds position data"
-            );
+    ) -> Self
+    where
+        F: IntoIterator<Item = (u32, u32, u32)>,
+        V: IntoIterator<Item = Point3<f32>>,
+    {
+        // To avoid one additional cloning of this collection, we
+        // first materialize it into its final structure (Vec<Face>),
+        // and later assert the only kind of faces there are
+        // triangles.
+        let faces_collection: Vec<_> = faces
+            .into_iter()
+            .enumerate()
+            .map(|(i, (i1, i2, i3))| {
+                let normal_index = cast_u32(i);
+                TriangleFace::new_separate(i1, i2, i3, normal_index, normal_index, normal_index)
+            })
+            .map(Face::from)
+            .collect();
 
-            // FIXME: computing smooth normals in the future won't be
-            // so simple as just computing a normal per face, we will
-            // need to analyze larger parts of the geometry
-            let face_normal = match normal_strategy {
-                NormalStrategy::Sharp => compute_triangle_normal(
-                    &vertices[cast_usize(v1)],
-                    &vertices[cast_usize(v2)],
-                    &vertices[cast_usize(v3)],
-                ),
-            };
+        let vertices_collection: Vec<_> = vertices.into_iter().collect();
+        let mut normals_collection = Vec::with_capacity(faces_collection.len());
 
-            normals.push(face_normal);
+        let vertices_range = 0..cast_u32(vertices_collection.len());
+        for face in &faces_collection {
+            match face {
+                Face::Triangle(triangle_face) => {
+                    let (v1, v2, v3) = triangle_face.vertices;
+
+                    assert!(
+                        vertices_range.contains(&v1),
+                        "Faces reference out of bounds position data"
+                    );
+                    assert!(
+                        vertices_range.contains(&v2),
+                        "Faces reference out of bounds position data"
+                    );
+                    assert!(
+                        vertices_range.contains(&v3),
+                        "Faces reference out of bounds position data"
+                    );
+
+                    // FIXME: computing smooth normals in the future won't be
+                    // so simple as just computing a normal per face, we will
+                    // need to analyze larger parts of the geometry
+                    let face_normal = match normal_strategy {
+                        NormalStrategy::Sharp => compute_triangle_normal(
+                            &vertices_collection[cast_usize(v1)],
+                            &vertices_collection[cast_usize(v2)],
+                            &vertices_collection[cast_usize(v3)],
+                        ),
+                    };
+
+                    normals_collection.push(face_normal);
+
+                }
+                // FIXME: once we add other kinds of faces, they must panic here
+                // _ => panic!("Face must be triangular, we just created it"),
+            }
         }
 
-        assert_eq!(normals.len(), faces.len());
-        assert_eq!(normals.capacity(), faces.len());
+        assert_eq!(normals_collection.len(), faces_collection.len());
+        assert_eq!(normals_collection.capacity(), faces_collection.len());
 
         Self {
-            faces: faces
-                .into_iter()
-                .enumerate()
-                .map(|(i, (i1, i2, i3))| {
-                    let normal_index = cast_u32(i);
-                    TriangleFace::new_separate(i1, i2, i3, normal_index, normal_index, normal_index)
-                })
-                .map(Face::from)
-                .collect(),
-            vertices,
-            normals,
+            faces: faces_collection,
+            vertices: vertices_collection,
+            normals: normals_collection,
         }
     }
 
-    /// Create new triangle face geometry from provided faces and
-    /// vertices, remove orphan vertices and
-    /// compute normals based on `normal_strategy`.
+    /// Creates new triangular geometry from provided triangle faces
+    /// and vertices, removes orphan vertices and computes normals
+    /// based on `normal_strategy`.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices.
-    pub fn from_triangle_faces_with_vertices_and_computed_normals_remove_orphans(
-        faces: Vec<(u32, u32, u32)>,
-        vertices: Vertices,
+    pub fn from_triangle_faces_with_vertices_and_computed_normals_remove_orphans<F, V>(
+        faces: F,
+        vertices: V,
         normal_strategy: NormalStrategy,
-    ) -> Self {
-        let (faces_purged, vertices_purged) = remove_orphan_vertices(faces, vertices);
-        Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+    ) -> Self
+    where
+        F: IntoIterator<Item = (u32, u32, u32)>,
+        V: IntoIterator<Item = Point3<f32>>,
+    {
+        let (faces_purged, vertices_purged) =
+            remove_orphan_vertices(faces.into_iter().collect(), vertices.into_iter().collect());
+        Self::from_triangle_faces_with_vertices_and_computed_normals(
             faces_purged,
             vertices_purged,
             normal_strategy,
         )
     }
 
-    /// Create new triangle face geometry from provided faces,
+    /// Creates new triangular geometry from provided triangle faces,
     /// vertices, and normals.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices or normals.
-    pub fn from_triangle_faces_with_vertices_and_normals(
-        faces: Vec<TriangleFace>,
-        vertices: Vertices,
-        normals: Normals,
-    ) -> Self {
-        let vertices_range = 0..cast_u32(vertices.len());
-        let normals_range = 0..cast_u32(normals.len());
-        for face in &faces {
-            let v = face.vertices;
-            let n = face.normals;
-            assert!(
-                vertices_range.contains(&v.0),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                vertices_range.contains(&v.1),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                vertices_range.contains(&v.2),
-                "Faces reference out of bounds position data"
-            );
-            assert!(
-                normals_range.contains(&n.0),
-                "Faces reference out of bounds normal data"
-            );
-            assert!(
-                normals_range.contains(&n.1),
-                "Faces reference out of bounds normal data"
-            );
-            assert!(
-                normals_range.contains(&n.2),
-                "Faces reference out of bounds normal data"
-            );
-        }
-
-        Self {
-            faces: faces.into_iter().map(Face::Triangle).collect(),
+    pub fn from_triangle_faces_with_vertices_and_normals<F, V, N>(
+        faces: F,
+        vertices: V,
+        normals: N,
+    ) -> Self
+    where
+        F: IntoIterator<Item = TriangleFace>,
+        V: IntoIterator<Item = Point3<f32>>,
+        N: IntoIterator<Item = Vector3<f32>>,
+    {
+        Self::from_faces_with_vertices_and_normals(
+            faces.into_iter().map(Face::Triangle),
             vertices,
             normals,
-        }
+        )
     }
 
-    /// Create new triangle face geometry from provided faces,
-    /// vertices, and normals and remove orphan vertices and normals.
+    /// Creates new triangular geometry from provided triangle faces,
+    /// vertices, and normals and removes orphan vertices and normals.
     ///
     /// # Panics
     /// Panics if faces refer to out-of-bounds vertices or normals.
-    pub fn from_triangle_faces_with_vertices_and_normals_remove_orphans(
-        faces: Vec<TriangleFace>,
-        vertices: Vertices,
-        normals: Normals,
-    ) -> Self {
-        let (faces_purged, vertices_purged, normals_purged) =
-            remove_orphan_vertices_and_normals(faces, vertices, normals);
+    pub fn from_triangle_faces_with_vertices_and_normals_remove_orphans<F, V, N>(
+        faces: F,
+        vertices: V,
+        normals: N,
+    ) -> Self
+    where
+        F: IntoIterator<Item = TriangleFace>,
+        V: IntoIterator<Item = Point3<f32>>,
+        N: IntoIterator<Item = Vector3<f32>>,
+    {
+        let (faces_purged, vertices_purged, normals_purged) = remove_orphan_vertices_and_normals(
+            faces.into_iter().map(Face::Triangle).collect(),
+            vertices.into_iter().collect(),
+            normals.into_iter().collect(),
+        );
 
-        Geometry::from_triangle_faces_with_vertices_and_normals(
-            faces_purged,
-            vertices_purged,
-            normals_purged,
-        )
+        Self::from_faces_with_vertices_and_normals(faces_purged, vertices_purged, normals_purged)
+    }
+
+    /// Creates new geometry of any face kind from provided faces,
+    /// vertices and normals.
+    ///
+    /// # Panics
+    /// Panics if faces refer to out-of-bounds vertices or normals.
+    pub fn from_faces_with_vertices_and_normals<F, V, N>(faces: F, vertices: V, normals: N) -> Self
+    where
+        F: IntoIterator<Item = Face>,
+        V: IntoIterator<Item = Point3<f32>>,
+        N: IntoIterator<Item = Vector3<f32>>,
+    {
+        let faces_collection: Vec<_> = faces.into_iter().collect();
+        let vertices_collection: Vec<_> = vertices.into_iter().collect();
+        let normals_collection: Vec<_> = normals.into_iter().collect();
+
+        let vertices_range = 0..cast_u32(vertices_collection.len());
+        let normals_range = 0..cast_u32(normals_collection.len());
+
+        for face in &faces_collection {
+            match face {
+                Face::Triangle(triangle_face) => {
+                    let v = triangle_face.vertices;
+                    let n = triangle_face.normals;
+                    assert!(
+                        vertices_range.contains(&v.0),
+                        "Faces reference out of bounds position data"
+                    );
+                    assert!(
+                        vertices_range.contains(&v.1),
+                        "Faces reference out of bounds position data"
+                    );
+                    assert!(
+                        vertices_range.contains(&v.2),
+                        "Faces reference out of bounds position data"
+                    );
+                    assert!(
+                        normals_range.contains(&n.0),
+                        "Faces reference out of bounds normal data"
+                    );
+                    assert!(
+                        normals_range.contains(&n.1),
+                        "Faces reference out of bounds normal data"
+                    );
+                    assert!(
+                        normals_range.contains(&n.2),
+                        "Faces reference out of bounds normal data"
+                    );
+                }
+            }
+        }
+
+        Self {
+            faces: faces_collection,
+            vertices: vertices_collection,
+            normals: normals_collection,
+        }
+    }
+
+    /// Creates new triangular geometry from provided triangle faces,
+    /// vertices, and normals and removes orphan vertices and normals.
+    ///
+    /// # Panics
+    /// Panics if faces refer to out-of-bounds vertices or normals.
+    pub fn from_faces_with_vertices_and_normals_remove_orphans<F, V, N>(
+        faces: F,
+        vertices: V,
+        normals: N,
+    ) -> Self
+    where
+        F: IntoIterator<Item = Face>,
+        V: IntoIterator<Item = Point3<f32>>,
+        N: IntoIterator<Item = Vector3<f32>>,
+    {
+        let (faces_purged, vertices_purged, normals_purged) = remove_orphan_vertices_and_normals(
+            faces.into_iter().collect(),
+            vertices.into_iter().collect(),
+            normals.into_iter().collect(),
+        );
+
+        Self::from_faces_with_vertices_and_normals(faces_purged, vertices_purged, normals_purged)
     }
 
     pub fn faces(&self) -> &[Face] {
@@ -504,10 +590,10 @@ fn remove_orphan_normals(
 }
 
 fn remove_orphan_vertices_and_normals(
-    faces: Vec<TriangleFace>,
+    faces: Vec<Face>,
     vertices: Vertices,
     normals: Normals,
-) -> (Vec<TriangleFace>, Vertices, Normals) {
+) -> (Vec<Face>, Vertices, Normals) {
     let mut vertices_reduced: Vertices = Vec::with_capacity(vertices.len());
     let original_vertex_len = vertices.len();
     let unused_vertex_marker = vertices.len();
@@ -518,77 +604,87 @@ fn remove_orphan_vertices_and_normals(
     let unused_normal_marker = normals.len();
     let mut old_new_normal_map: Vec<usize> = vec![unused_normal_marker; original_normal_len];
 
-    let mut faces_renumbered: Vec<TriangleFace> = Vec::with_capacity(faces.len());
+    let mut faces_renumbered: Vec<Face> = Vec::with_capacity(faces.len());
 
     for face in faces {
-        let old_vertex_index_0 = cast_usize(face.vertices.0);
-        let new_vertex_index_0 = if old_new_vertex_map[old_vertex_index_0] == unused_vertex_marker {
-            let new_index = vertices_reduced.len();
-            vertices_reduced.push(vertices[old_vertex_index_0]);
-            old_new_vertex_map[old_vertex_index_0] = new_index;
-            new_index
-        } else {
-            old_new_vertex_map[old_vertex_index_0]
-        };
+        match face {
+            Face::Triangle(triangle_face) => {
+                let old_vertex_index_0 = cast_usize(triangle_face.vertices.0);
+                let new_vertex_index_0 =
+                    if old_new_vertex_map[old_vertex_index_0] == unused_vertex_marker {
+                        let new_index = vertices_reduced.len();
+                        vertices_reduced.push(vertices[old_vertex_index_0]);
+                        old_new_vertex_map[old_vertex_index_0] = new_index;
+                        new_index
+                    } else {
+                        old_new_vertex_map[old_vertex_index_0]
+                    };
 
-        let old_vertex_index_1 = cast_usize(face.vertices.1);
-        let new_vertex_index_1 = if old_new_vertex_map[old_vertex_index_1] == unused_vertex_marker {
-            let new_index = vertices_reduced.len();
-            vertices_reduced.push(vertices[old_vertex_index_1]);
-            old_new_vertex_map[old_vertex_index_1] = new_index;
-            new_index
-        } else {
-            old_new_vertex_map[old_vertex_index_1]
-        };
+                let old_vertex_index_1 = cast_usize(triangle_face.vertices.1);
+                let new_vertex_index_1 =
+                    if old_new_vertex_map[old_vertex_index_1] == unused_vertex_marker {
+                        let new_index = vertices_reduced.len();
+                        vertices_reduced.push(vertices[old_vertex_index_1]);
+                        old_new_vertex_map[old_vertex_index_1] = new_index;
+                        new_index
+                    } else {
+                        old_new_vertex_map[old_vertex_index_1]
+                    };
 
-        let old_vertex_index_2 = cast_usize(face.vertices.2);
-        let new_vertex_index_2 = if old_new_vertex_map[old_vertex_index_2] == unused_vertex_marker {
-            let new_index = vertices_reduced.len();
-            vertices_reduced.push(vertices[old_vertex_index_2]);
-            old_new_vertex_map[old_vertex_index_2] = new_index;
-            new_index
-        } else {
-            old_new_vertex_map[old_vertex_index_2]
-        };
+                let old_vertex_index_2 = cast_usize(triangle_face.vertices.2);
+                let new_vertex_index_2 =
+                    if old_new_vertex_map[old_vertex_index_2] == unused_vertex_marker {
+                        let new_index = vertices_reduced.len();
+                        vertices_reduced.push(vertices[old_vertex_index_2]);
+                        old_new_vertex_map[old_vertex_index_2] = new_index;
+                        new_index
+                    } else {
+                        old_new_vertex_map[old_vertex_index_2]
+                    };
 
-        let old_normal_index_0 = cast_usize(face.normals.0);
-        let new_normal_index_0 = if old_new_normal_map[old_normal_index_0] == unused_normal_marker {
-            let new_index = normals_reduced.len();
-            normals_reduced.push(normals[old_normal_index_0]);
-            old_new_normal_map[old_normal_index_0] = new_index;
-            new_index
-        } else {
-            old_new_normal_map[old_normal_index_0]
-        };
+                let old_normal_index_0 = cast_usize(triangle_face.normals.0);
+                let new_normal_index_0 =
+                    if old_new_normal_map[old_normal_index_0] == unused_normal_marker {
+                        let new_index = normals_reduced.len();
+                        normals_reduced.push(normals[old_normal_index_0]);
+                        old_new_normal_map[old_normal_index_0] = new_index;
+                        new_index
+                    } else {
+                        old_new_normal_map[old_normal_index_0]
+                    };
 
-        let old_normal_index_1 = cast_usize(face.normals.1);
-        let new_normal_index_1 = if old_new_normal_map[old_normal_index_1] == unused_normal_marker {
-            let new_index = normals_reduced.len();
-            normals_reduced.push(normals[old_normal_index_1]);
-            old_new_normal_map[old_normal_index_1] = new_index;
-            new_index
-        } else {
-            old_new_normal_map[old_normal_index_1]
-        };
+                let old_normal_index_1 = cast_usize(triangle_face.normals.1);
+                let new_normal_index_1 =
+                    if old_new_normal_map[old_normal_index_1] == unused_normal_marker {
+                        let new_index = normals_reduced.len();
+                        normals_reduced.push(normals[old_normal_index_1]);
+                        old_new_normal_map[old_normal_index_1] = new_index;
+                        new_index
+                    } else {
+                        old_new_normal_map[old_normal_index_1]
+                    };
 
-        let old_normal_index_2 = cast_usize(face.normals.2);
-        let new_normal_index_2 = if old_new_normal_map[old_normal_index_2] == unused_normal_marker {
-            let new_index = normals_reduced.len();
-            normals_reduced.push(normals[old_normal_index_2]);
-            old_new_normal_map[old_normal_index_2] = new_index;
-            new_index
-        } else {
-            old_new_normal_map[old_normal_index_2]
-        };
+                let old_normal_index_2 = cast_usize(triangle_face.normals.2);
+                let new_normal_index_2 =
+                    if old_new_normal_map[old_normal_index_2] == unused_normal_marker {
+                        let new_index = normals_reduced.len();
+                        normals_reduced.push(normals[old_normal_index_2]);
+                        old_new_normal_map[old_normal_index_2] = new_index;
+                        new_index
+                    } else {
+                        old_new_normal_map[old_normal_index_2]
+                    };
 
-        faces_renumbered.push(TriangleFace::new_separate(
-            cast_u32(new_vertex_index_0),
-            cast_u32(new_vertex_index_1),
-            cast_u32(new_vertex_index_2),
-            cast_u32(new_normal_index_0),
-            cast_u32(new_normal_index_1),
-            cast_u32(new_normal_index_2),
-        ));
+                faces_renumbered.push(Face::Triangle(TriangleFace::new_separate(
+                    cast_u32(new_vertex_index_0),
+                    cast_u32(new_vertex_index_1),
+                    cast_u32(new_vertex_index_2),
+                    cast_u32(new_normal_index_0),
+                    cast_u32(new_normal_index_1),
+                    cast_u32(new_normal_index_2),
+                )));
+            }
+        }
     }
 
     faces_renumbered.shrink_to_fit();
@@ -1507,9 +1603,10 @@ mod tests {
                     f.normals.2 + 1,
                 )
             })
+            .map(Face::Triangle)
             .collect();
 
-        let faces_length = &faces.len();
+        let faces_length = faces.len();
 
         let (faces_purged, vertices_purged, normals_purged) = remove_orphan_vertices_and_normals(
             faces_renumbered_to_match_extend_data,
@@ -1517,7 +1614,7 @@ mod tests {
             normals_extended,
         );
 
-        let faces_purged_length = &faces_purged.len();
+        let faces_purged_length = faces_purged.len();
 
         assert_eq!(faces_length, faces_purged_length);
         assert_eq!(vertices_purged, vertices);

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -218,6 +218,13 @@ impl Geometry {
         })
     }
 
+    /// Returns whether the geometry contains exclusively triangular faces.
+    pub fn is_triangular(&self) -> bool {
+        self.faces().iter().all(|face| match face {
+            Face::Triangle(_) => true,
+        })
+    }
+
     /// Does the mesh contain unused (not referenced in faces) vertices
     pub fn has_no_orphan_vertices(&self) -> bool {
         let mut used_vertices = HashSet::new();
@@ -1071,6 +1078,7 @@ mod tests {
             vertices.clone(),
             NormalStrategy::Sharp,
         );
+        assert!(geometry.is_triangular());
 
         let geometry_faces: Vec<_> = geometry
             .faces()
@@ -1079,11 +1087,6 @@ mod tests {
                 Face::Triangle(triangle_face) => Some(triangle_face),
             })
             .collect();
-        assert_eq!(
-            geometry.faces().len(),
-            geometry_faces.len(),
-            "All faces must be triangular",
-        );
 
         assert_eq!(vertices.as_slice(), geometry.vertices());
         assert_eq!(
@@ -1120,6 +1123,7 @@ mod tests {
             vertices.clone(),
             normals.clone(),
         );
+        assert!(geometry.is_triangular());
 
         let geometry_faces: Vec<_> = geometry
             .faces()
@@ -1129,11 +1133,6 @@ mod tests {
             })
             .copied()
             .collect();
-        assert_eq!(
-            geometry.faces().len(),
-            geometry_faces.len(),
-            "All faces must be triangular",
-        );
 
         assert_eq!(vertices.as_slice(), geometry.vertices());
         assert_eq!(normals.as_slice(), geometry.normals());

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -301,7 +301,7 @@ pub fn tobj_to_internal(tobj_models: Vec<tobj::Model>) -> Vec<Model> {
             .map(|chunk| Point3::new(chunk[0], chunk[1], chunk[2]))
             .collect();
 
-        let vertex_normals = if model.mesh.normals.is_empty() {
+        let vertex_normals: Option<Vec<_>> = if model.mesh.normals.is_empty() {
             None
         } else {
             let normals = model
@@ -323,7 +323,7 @@ pub fn tobj_to_internal(tobj_models: Vec<tobj::Model>) -> Vec<Model> {
 
         let geometry = if let Some(vertex_normals) = vertex_normals {
             Geometry::from_triangle_faces_with_vertices_and_normals(
-                faces_raw.into_iter().map(TriangleFace::from).collect(),
+                faces_raw.into_iter().map(TriangleFace::from),
                 vertex_positions,
                 vertex_normals,
             )

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -119,9 +119,7 @@ mod tests {
     use nalgebra::geometry::Point3;
 
     use crate::edge_analysis::edge_valencies;
-    use crate::geometry::{
-        self, Face, Geometry, NormalStrategy, TriangleFace, UnorientedEdge, Vertices,
-    };
+    use crate::geometry::{self, Geometry, NormalStrategy, TriangleFace, UnorientedEdge, Vertices};
 
     use super::*;
 

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -101,15 +101,15 @@ pub fn is_mesh_watertight(edge_valencies: &EdgeCountMap) -> bool {
     })
 }
 
-/// Computes the mesh genus.
+/// Computes the mesh genus of a triangulated mesh.
 ///
 /// Genus of a mesh is the number of holes in topology / connectivity.
-/// The mesh **must** be triangular and watertight for this to produce
+/// The mesh **must** be triangulated and watertight for this to produce
 /// usable results.
 ///
 /// The genus (G) is computed as: `V - E + F = 2*(1 - G)`.
 #[allow(dead_code)]
-pub fn mesh_genus(vertex_count: usize, edge_count: usize, face_count: usize) -> i32 {
+pub fn triangulated_mesh_genus(vertex_count: usize, edge_count: usize, face_count: usize) -> i32 {
     1 - (cast_i32(vertex_count) - cast_i32(edge_count) + cast_i32(face_count)) / 2
 }
 
@@ -590,13 +590,13 @@ mod tests {
     }
 
     #[test]
-    fn test_geometry_mesh_genus_box_should_be_0() {
+    fn test_geometry_triangulated_mesh_genus_box_should_be_0() {
         let geometry = geometry::cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
-        assert!(geometry.is_triangular());
+        assert!(geometry.is_triangulated());
 
         let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
 
-        let genus = mesh_genus(
+        let genus = triangulated_mesh_genus(
             geometry.vertices().len(),
             edges.len(),
             geometry.faces().len(),
@@ -605,18 +605,18 @@ mod tests {
     }
 
     #[test]
-    fn test_geometry_mesh_genus_torus_should_be_1() {
+    fn test_geometry_triangulated_mesh_genus_torus_should_be_1() {
         let (faces, vertices) = torus();
         let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
             faces.clone(),
             vertices.clone(),
             NormalStrategy::Sharp,
         );
-        assert!(geometry.is_triangular());
+        assert!(geometry.is_triangulated());
 
         let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
 
-        let genus = mesh_genus(
+        let genus = triangulated_mesh_genus(
             geometry.vertices().len(),
             edges.len(),
             geometry.faces().len(),
@@ -625,18 +625,18 @@ mod tests {
     }
 
     #[test]
-    fn test_geometry_mesh_genus_double_torus_should_be_2() {
+    fn test_geometry_triangulated_mesh_genus_double_torus_should_be_2() {
         let (faces, vertices) = double_torus();
         let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
             faces.clone(),
             vertices.clone(),
             NormalStrategy::Sharp,
         );
-        assert!(geometry.is_triangular());
+        assert!(geometry.is_triangulated());
 
         let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
 
-        let genus = mesh_genus(
+        let genus = triangulated_mesh_genus(
             geometry.vertices().len(),
             edges.len(),
             geometry.faces().len(),
@@ -645,18 +645,18 @@ mod tests {
     }
 
     #[test]
-    fn test_geometry_mesh_genus_triple_torus_should_be_3() {
+    fn test_geometry_triangulated_mesh_genus_triple_torus_should_be_3() {
         let (faces, vertices) = triple_torus();
         let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
             faces.clone(),
             vertices.clone(),
             NormalStrategy::Sharp,
         );
-        assert!(geometry.is_triangular());
+        assert!(geometry.is_triangulated());
 
         let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
 
-        let genus = mesh_genus(
+        let genus = triangulated_mesh_genus(
             geometry.vertices().len(),
             edges.len(),
             geometry.faces().len(),

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -101,9 +101,13 @@ pub fn is_mesh_watertight(edge_valencies: &EdgeCountMap) -> bool {
     })
 }
 
-/// Genus of a mesh is the number of holes in topology / connectivity
-/// The mesh must be triangular and watertight
-/// V - E + F = 2 (1 - G)
+/// Computes the mesh genus.
+///
+/// Genus of a mesh is the number of holes in topology / connectivity.
+/// The mesh **must** be triangular and watertight for this to produce
+/// usable results.
+///
+/// The genus (G) is computed as: `V - E + F = 2*(1 - G)`.
 #[allow(dead_code)]
 pub fn mesh_genus(vertex_count: usize, edge_count: usize, face_count: usize) -> i32 {
     1 - (cast_i32(vertex_count) - cast_i32(edge_count) + cast_i32(face_count)) / 2
@@ -116,7 +120,7 @@ mod tests {
 
     use crate::edge_analysis::edge_valencies;
     use crate::geometry::{
-        self, cube_sharp_var_len, Geometry, NormalStrategy, TriangleFace, UnorientedEdge, Vertices,
+        self, Face, Geometry, NormalStrategy, TriangleFace, UnorientedEdge, Vertices,
     };
 
     use super::*;
@@ -589,13 +593,26 @@ mod tests {
 
     #[test]
     fn test_geometry_mesh_genus_box_should_be_0() {
-        let geometry = cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
+        let geometry = geometry::cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
         let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
+        let triangle_faces_count = geometry
+            .faces()
+            .iter()
+            .filter(|face| match face {
+                Face::Triangle(_) => true,
+            })
+            .count();
+
+        assert_eq!(
+            triangle_faces_count,
+            geometry.faces().len(),
+            "All geometry faces must be triangular for the mesh genus",
+        );
 
         let genus = mesh_genus(
             geometry.vertices().len(),
             edges.len(),
-            geometry.triangle_faces_iter().count(),
+            geometry.faces().len(),
         );
         assert_eq!(genus, 0);
     }
@@ -609,11 +626,24 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
+        let triangle_faces_count = geometry
+            .faces()
+            .iter()
+            .filter(|face| match face {
+                Face::Triangle(_) => true,
+            })
+            .count();
+
+        assert_eq!(
+            triangle_faces_count,
+            geometry.faces().len(),
+            "All geometry faces must be triangular for the mesh genus",
+        );
 
         let genus = mesh_genus(
             geometry.vertices().len(),
             edges.len(),
-            geometry.triangle_faces_iter().count(),
+            geometry.faces().len(),
         );
         assert_eq!(genus, 1);
     }
@@ -627,11 +657,24 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
+        let triangle_faces_count = geometry
+            .faces()
+            .iter()
+            .filter(|face| match face {
+                Face::Triangle(_) => true,
+            })
+            .count();
+
+        assert_eq!(
+            triangle_faces_count,
+            geometry.faces().len(),
+            "All geometry faces must be triangular for the mesh genus",
+        );
 
         let genus = mesh_genus(
             geometry.vertices().len(),
             edges.len(),
-            geometry.triangle_faces_iter().count(),
+            geometry.faces().len(),
         );
         assert_eq!(genus, 2);
     }
@@ -645,11 +688,24 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
+        let triangle_faces_count = geometry
+            .faces()
+            .iter()
+            .filter(|face| match face {
+                Face::Triangle(_) => true,
+            })
+            .count();
+
+        assert_eq!(
+            triangle_faces_count,
+            geometry.faces().len(),
+            "All geometry faces must be triangular for the mesh genus",
+        );
 
         let genus = mesh_genus(
             geometry.vertices().len(),
             edges.len(),
-            geometry.triangle_faces_iter().count(),
+            geometry.faces().len(),
         );
         assert_eq!(genus, 3);
     }

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -594,20 +594,9 @@ mod tests {
     #[test]
     fn test_geometry_mesh_genus_box_should_be_0() {
         let geometry = geometry::cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
-        let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
-        let triangle_faces_count = geometry
-            .faces()
-            .iter()
-            .filter(|face| match face {
-                Face::Triangle(_) => true,
-            })
-            .count();
+        assert!(geometry.is_triangular());
 
-        assert_eq!(
-            triangle_faces_count,
-            geometry.faces().len(),
-            "All geometry faces must be triangular for the mesh genus",
-        );
+        let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
 
         let genus = mesh_genus(
             geometry.vertices().len(),
@@ -625,20 +614,9 @@ mod tests {
             vertices.clone(),
             NormalStrategy::Sharp,
         );
-        let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
-        let triangle_faces_count = geometry
-            .faces()
-            .iter()
-            .filter(|face| match face {
-                Face::Triangle(_) => true,
-            })
-            .count();
+        assert!(geometry.is_triangular());
 
-        assert_eq!(
-            triangle_faces_count,
-            geometry.faces().len(),
-            "All geometry faces must be triangular for the mesh genus",
-        );
+        let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
 
         let genus = mesh_genus(
             geometry.vertices().len(),
@@ -656,20 +634,9 @@ mod tests {
             vertices.clone(),
             NormalStrategy::Sharp,
         );
-        let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
-        let triangle_faces_count = geometry
-            .faces()
-            .iter()
-            .filter(|face| match face {
-                Face::Triangle(_) => true,
-            })
-            .count();
+        assert!(geometry.is_triangular());
 
-        assert_eq!(
-            triangle_faces_count,
-            geometry.faces().len(),
-            "All geometry faces must be triangular for the mesh genus",
-        );
+        let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
 
         let genus = mesh_genus(
             geometry.vertices().len(),
@@ -687,20 +654,9 @@ mod tests {
             vertices.clone(),
             NormalStrategy::Sharp,
         );
-        let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
-        let triangle_faces_count = geometry
-            .faces()
-            .iter()
-            .filter(|face| match face {
-                Face::Triangle(_) => true,
-            })
-            .count();
+        assert!(geometry.is_triangular());
 
-        assert_eq!(
-            triangle_faces_count,
-            geometry.faces().len(),
-            "All geometry faces must be triangular for the mesh genus",
-        );
+        let edges: HashSet<UnorientedEdge> = geometry.unoriented_edges_iter().collect();
 
         let genus = mesh_genus(
             geometry.vertices().len(),


### PR DESCRIPTION
It seems this filtering view is virtually never what we want to do,
when we ever have nontriangular faces. It was allowing us to not care
about other kind of faces, potentially leading to incorrect behaviour
in the future.