### PR TITLE
Find mesh border edge loops

### DIFF
--- a/src/edge_analysis.rs
+++ b/src/edge_analysis.rs
@@ -88,7 +88,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
         let unoriented_edges_one_way_correct = vec![
             UnorientedEdge(OrientedEdge::new(0, 1)),
             UnorientedEdge(OrientedEdge::new(1, 2)),
@@ -101,27 +101,27 @@ mod tests {
         ];
 
         for u_e in unoriented_edges_one_way_correct {
-            assert!(edge_valency_map.contains_key(&u_e));
+            assert!(edge_sharing_map.contains_key(&u_e));
             if u_e.0.vertices.0 < u_e.0.vertices.1 {
-                assert_eq!(edge_valency_map.get(&u_e).unwrap().ascending_edges.len(), 1);
+                assert_eq!(edge_sharing_map.get(&u_e).unwrap().ascending_edges.len(), 1);
                 assert_eq!(
-                    edge_valency_map.get(&u_e).unwrap().descending_edges.len(),
+                    edge_sharing_map.get(&u_e).unwrap().descending_edges.len(),
                     0
                 );
             } else {
-                assert_eq!(edge_valency_map.get(&u_e).unwrap().ascending_edges.len(), 0);
+                assert_eq!(edge_sharing_map.get(&u_e).unwrap().ascending_edges.len(), 0);
                 assert_eq!(
-                    edge_valency_map.get(&u_e).unwrap().descending_edges.len(),
+                    edge_sharing_map.get(&u_e).unwrap().descending_edges.len(),
                     1
                 );
             }
         }
 
         for u_e in unoriented_edges_two_ways_correct {
-            assert!(edge_valency_map.contains_key(&u_e));
-            assert_eq!(edge_valency_map.get(&u_e).unwrap().ascending_edges.len(), 1);
+            assert!(edge_sharing_map.contains_key(&u_e));
+            assert_eq!(edge_sharing_map.get(&u_e).unwrap().ascending_edges.len(), 1);
             assert_eq!(
-                edge_valency_map.get(&u_e).unwrap().descending_edges.len(),
+                edge_sharing_map.get(&u_e).unwrap().descending_edges.len(),
                 1
             );
         }

--- a/src/edge_analysis.rs
+++ b/src/edge_analysis.rs
@@ -2,46 +2,47 @@ use std::collections::HashMap;
 
 use crate::geometry::{OrientedEdge, UnorientedEdge};
 
-/// Used in EdgeCountMap
+/// Used in EdgeSharingMap
 /// ascending_edges contains edges oriented from lower index to higher
 /// descending_edges contains edges oriented from higher index to lower
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SimilarEdges {
+pub struct SharedEdges {
     pub ascending_edges: Vec<OrientedEdge>,
     pub descending_edges: Vec<OrientedEdge>,
 }
 
-pub type EdgeCountMap = HashMap<UnorientedEdge, SimilarEdges>;
+pub type EdgeSharingMap = HashMap<UnorientedEdge, SharedEdges>;
 
-/// Calculate edge valencies = number of faces sharing an edge
+/// Calculate edge sharing and pack shared edges into SharedEdges
+/// Edge valency = number of faces sharing an edge
 /// 1 -> border edge = acceptable but mesh is not watertight
 /// 2 -> manifold edge = correct
 /// 3 or more -> non-manifold edge = corrupted mesh
 #[allow(dead_code)]
-pub fn edge_valencies<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
+pub fn edge_sharing<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
     oriented_edges: I,
-) -> EdgeCountMap {
-    let mut edge_valency_map: EdgeCountMap = HashMap::new();
+) -> EdgeSharingMap {
+    let mut edge_sharing_map: EdgeSharingMap = HashMap::new();
     for edge in oriented_edges {
         let unoriented_edge = UnorientedEdge(*edge);
         let ascending_edges: Vec<OrientedEdge> = Vec::new();
         let descending_edges: Vec<OrientedEdge> = Vec::new();
 
-        let edge_count = edge_valency_map
+        let shared_edges = edge_sharing_map
             .entry(unoriented_edge)
-            .or_insert(SimilarEdges {
+            .or_insert(SharedEdges {
                 ascending_edges,
                 descending_edges,
             });
 
         if edge.vertices.0 < edge.vertices.1 {
-            edge_count.ascending_edges.push(*edge);
+            shared_edges.ascending_edges.push(*edge);
         } else {
-            edge_count.descending_edges.push(*edge);
+            shared_edges.descending_edges.push(*edge);
         }
     }
 
-    edge_valency_map
+    edge_sharing_map
 }
 
 #[cfg(test)]
@@ -87,7 +88,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
         let unoriented_edges_one_way_correct = vec![
             UnorientedEdge(OrientedEdge::new(0, 1)),
             UnorientedEdge(OrientedEdge::new(1, 2)),
@@ -100,27 +101,27 @@ mod tests {
         ];
 
         for u_e in unoriented_edges_one_way_correct {
-            assert!(edge_valency_map.contains_key(&u_e));
+            assert!(edge_sharing_map.contains_key(&u_e));
             if u_e.0.vertices.0 < u_e.0.vertices.1 {
-                assert_eq!(edge_valency_map.get(&u_e).unwrap().ascending_edges.len(), 1);
+                assert_eq!(edge_sharing_map.get(&u_e).unwrap().ascending_edges.len(), 1);
                 assert_eq!(
-                    edge_valency_map.get(&u_e).unwrap().descending_edges.len(),
+                    edge_sharing_map.get(&u_e).unwrap().descending_edges.len(),
                     0
                 );
             } else {
-                assert_eq!(edge_valency_map.get(&u_e).unwrap().ascending_edges.len(), 0);
+                assert_eq!(edge_sharing_map.get(&u_e).unwrap().ascending_edges.len(), 0);
                 assert_eq!(
-                    edge_valency_map.get(&u_e).unwrap().descending_edges.len(),
+                    edge_sharing_map.get(&u_e).unwrap().descending_edges.len(),
                     1
                 );
             }
         }
 
         for u_e in unoriented_edges_two_ways_correct {
-            assert!(edge_valency_map.contains_key(&u_e));
-            assert_eq!(edge_valency_map.get(&u_e).unwrap().ascending_edges.len(), 1);
+            assert!(edge_sharing_map.contains_key(&u_e));
+            assert_eq!(edge_sharing_map.get(&u_e).unwrap().ascending_edges.len(), 1);
             assert_eq!(
-                edge_valency_map.get(&u_e).unwrap().descending_edges.len(),
+                edge_sharing_map.get(&u_e).unwrap().descending_edges.len(),
                 1
             );
         }

--- a/src/edge_analysis.rs
+++ b/src/edge_analysis.rs
@@ -18,6 +18,7 @@ pub type EdgeSharingMap = HashMap<UnorientedEdge, SharedEdges>;
 /// 1 -> border edge = acceptable but mesh is not watertight
 /// 2 -> manifold edge = correct
 /// 3 or more -> non-manifold edge = corrupted mesh
+// FIXME: Implement also for UnorientedEdges
 #[allow(dead_code)]
 pub fn edge_sharing<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
     oriented_edges: I,

--- a/src/edge_analysis.rs
+++ b/src/edge_analysis.rs
@@ -13,21 +13,22 @@ pub struct SharedEdges {
 
 pub type EdgeSharingMap = HashMap<UnorientedEdge, SharedEdges>;
 
-/// Calculate edge valencies = number of faces sharing an edge
+/// Calculate edge sharing and pack shared edges into SharedEdges
+/// Edge valency = number of faces sharing an edge
 /// 1 -> border edge = acceptable but mesh is not watertight
 /// 2 -> manifold edge = correct
 /// 3 or more -> non-manifold edge = corrupted mesh
 #[allow(dead_code)]
-pub fn edge_valencies<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
+pub fn edge_sharing<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
     oriented_edges: I,
 ) -> EdgeSharingMap {
-    let mut edge_valency_map: EdgeSharingMap = HashMap::new();
+    let mut edge_sharing_map: EdgeSharingMap = HashMap::new();
     for edge in oriented_edges {
         let unoriented_edge = UnorientedEdge(*edge);
         let ascending_edges: Vec<OrientedEdge> = Vec::new();
         let descending_edges: Vec<OrientedEdge> = Vec::new();
 
-        let edge_count = edge_valency_map
+        let shared_edges = edge_sharing_map
             .entry(unoriented_edge)
             .or_insert(SharedEdges {
                 ascending_edges,
@@ -35,13 +36,13 @@ pub fn edge_valencies<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
             });
 
         if edge.vertices.0 < edge.vertices.1 {
-            edge_count.ascending_edges.push(*edge);
+            shared_edges.ascending_edges.push(*edge);
         } else {
-            edge_count.descending_edges.push(*edge);
+            shared_edges.descending_edges.push(*edge);
         }
     }
 
-    edge_valency_map
+    edge_sharing_map
 }
 
 #[cfg(test)]
@@ -87,7 +88,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_valency_map = edge_sharing(&oriented_edges);
         let unoriented_edges_one_way_correct = vec![
             UnorientedEdge(OrientedEdge::new(0, 1)),
             UnorientedEdge(OrientedEdge::new(1, 2)),

--- a/src/edge_analysis.rs
+++ b/src/edge_analysis.rs
@@ -2,16 +2,16 @@ use std::collections::HashMap;
 
 use crate::geometry::{OrientedEdge, UnorientedEdge};
 
-/// Used in EdgeCountMap
+/// Used in EdgeSharingMap
 /// ascending_edges contains edges oriented from lower index to higher
 /// descending_edges contains edges oriented from higher index to lower
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SimilarEdges {
+pub struct SharedEdges {
     pub ascending_edges: Vec<OrientedEdge>,
     pub descending_edges: Vec<OrientedEdge>,
 }
 
-pub type EdgeCountMap = HashMap<UnorientedEdge, SimilarEdges>;
+pub type EdgeSharingMap = HashMap<UnorientedEdge, SharedEdges>;
 
 /// Calculate edge valencies = number of faces sharing an edge
 /// 1 -> border edge = acceptable but mesh is not watertight
@@ -20,8 +20,8 @@ pub type EdgeCountMap = HashMap<UnorientedEdge, SimilarEdges>;
 #[allow(dead_code)]
 pub fn edge_valencies<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
     oriented_edges: I,
-) -> EdgeCountMap {
-    let mut edge_valency_map: EdgeCountMap = HashMap::new();
+) -> EdgeSharingMap {
+    let mut edge_valency_map: EdgeSharingMap = HashMap::new();
     for edge in oriented_edges {
         let unoriented_edge = UnorientedEdge(*edge);
         let ascending_edges: Vec<OrientedEdge> = Vec::new();
@@ -29,7 +29,7 @@ pub fn edge_valencies<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
 
         let edge_count = edge_valency_map
             .entry(unoriented_edge)
-            .or_insert(SimilarEdges {
+            .or_insert(SharedEdges {
                 ascending_edges,
                 descending_edges,
             });

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -385,6 +385,12 @@ impl Hash for UnorientedEdge {
     }
 }
 
+impl UnorientedEdge {
+    pub fn share_vertex(self, other: UnorientedEdge) -> bool {
+        self.0.contains_vertex(other.0.vertices.0) || self.0.contains_vertex(other.0.vertices.1)
+    }
+}
+
 fn remove_orphan_vertices(
     faces: Vec<(u32, u32, u32)>,
     vertices: Vertices,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -385,6 +385,12 @@ impl Hash for UnorientedEdge {
     }
 }
 
+impl UnorientedEdge {
+    pub fn shares_vertex(self, other: UnorientedEdge) -> bool {
+        other.0.contains_vertex(self.0.vertices.0) || other.0.contains_vertex(self.0.vertices.1)
+    }
+}
+
 fn remove_orphan_vertices(
     faces: Vec<(u32, u32, u32)>,
     vertices: Vertices,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -370,6 +370,12 @@ impl OrientedEdge {
 #[derive(Debug, Clone, Copy, Eq)]
 pub struct UnorientedEdge(pub OrientedEdge);
 
+impl UnorientedEdge {
+    pub fn shares_vertex(self, other: UnorientedEdge) -> bool {
+        other.0.contains_vertex(self.0.vertices.0) || other.0.contains_vertex(self.0.vertices.1)
+    }
+}
+
 impl PartialEq for UnorientedEdge {
     fn eq(&self, other: &Self) -> bool {
         (self.0.vertices.0 == other.0.vertices.0 && self.0.vertices.1 == other.0.vertices.1)
@@ -382,12 +388,6 @@ impl Hash for UnorientedEdge {
     fn hash<H: Hasher>(&self, state: &mut H) {
         cmp::min(self.0.vertices.0, self.0.vertices.1).hash(state);
         cmp::max(self.0.vertices.0, self.0.vertices.1).hash(state);
-    }
-}
-
-impl UnorientedEdge {
-    pub fn shares_vertex(self, other: UnorientedEdge) -> bool {
-        other.0.contains_vertex(self.0.vertices.0) || other.0.contains_vertex(self.0.vertices.1)
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -385,12 +385,6 @@ impl Hash for UnorientedEdge {
     }
 }
 
-impl UnorientedEdge {
-    pub fn share_vertex(self, other: UnorientedEdge) -> bool {
-        self.0.contains_vertex(other.0.vertices.0) || self.0.contains_vertex(other.0.vertices.1)
-    }
-}
-
 fn remove_orphan_vertices(
     faces: Vec<(u32, u32, u32)>,
     vertices: Vertices,

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -61,8 +61,8 @@ pub fn non_manifold_edges<'a>(
         })
 }
 
-/// Finds border vertex indices in a mesh edge collection
-/// A vertex is border when its edge's valency is 1
+///Finds border vertex indices in a mesh edge collection.
+///A vertex is border when its edge's valency is 1
 #[allow(dead_code)]
 pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
     let mut border_vertices = HashSet::new();
@@ -74,35 +74,32 @@ pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
     border_vertices
 }
 
-/// Finds continuous loops of border edges,
-/// starting from a random edge.
-/// The mesh may contain holes or islands,
-/// therefore it may have an unknown number of edge loops.
-/// If two edge loops meet at a single vertex, the result
-/// may be unpredictable and erratic.
+/// Finds continuous loops of border edges, starting from a random edge.
+///
+/// The mesh may contain holes or islands, therefore it may have an
+/// unknown number of edge loops. If two edge loops meet at a single vertex,
+/// the result may be unpredictable and erratic.
 #[allow(dead_code)]
 pub fn border_edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<UnorientedEdge>> {
     let mut border_edges: Vec<_> = border_edges(edge_sharing).map(UnorientedEdge).collect();
 
     let mut edge_loops: Vec<Vec<UnorientedEdge>> = Vec::new();
 
-    while !border_edges.is_empty() {
-        if let Some(edge) = border_edges.pop() {
-            let mut current_loop: Vec<UnorientedEdge> = vec![edge];
+    while let Some(edge) = border_edges.pop() {
+        let mut current_loop: Vec<UnorientedEdge> = vec![edge];
 
-            while current_loop.len() < 3
-                || !current_loop[current_loop.len() - 1].shares_vertex(current_loop[0])
-            {
-                for (i, other_edge) in border_edges.iter().enumerate() {
-                    if current_loop[current_loop.len() - 1].shares_vertex(*other_edge) {
-                        current_loop.push(border_edges.remove(i));
-                        break;
-                    }
+        while current_loop.len() < 3
+            || !current_loop[current_loop.len() - 1].shares_vertex(current_loop[0])
+        {
+            for (i, other_edge) in border_edges.iter().enumerate() {
+                if current_loop[current_loop.len() - 1].shares_vertex(*other_edge) {
+                    current_loop.push(border_edges.remove(i));
+                    break;
                 }
             }
-
-            edge_loops.push(current_loop);
         }
+
+        edge_loops.push(current_loop);
     }
 
     edge_loops
@@ -148,7 +145,7 @@ mod tests {
     use nalgebra::base::Vector3;
     use nalgebra::geometry::Point3;
 
-    use crate::edge_analysis::edge_sharing;
+    use crate::edge_analysis;
     use crate::geometry::{
         self, cube_sharp_var_len, Geometry, NormalStrategy, TriangleFace, UnorientedEdge, Vertices,
     };
@@ -479,7 +476,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         let oriented_edges_with_valency_1_correct = vec![
             OrientedEdge::new(0, 1),
@@ -516,7 +513,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         let oriented_edges_border_correct = vec![
             OrientedEdge::new(0, 1),
@@ -541,7 +538,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         let oriented_edges_manifold_correct =
             vec![OrientedEdge::new(2, 0), OrientedEdge::new(0, 2)];
@@ -562,7 +559,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         let oriented_edges_non_manifold_correct =
             vec![OrientedEdge::new(2, 0), OrientedEdge::new(0, 2)];
@@ -586,7 +583,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         let border_vertex_indices_correct = vec![0, 1, 2, 3];
 
@@ -601,7 +598,7 @@ mod tests {
     fn test_mesh_analysis_is_mesh_orientable_returns_true_watertight_mesh() {
         let geometry = geometry::cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         assert!(is_mesh_orientable(&edge_sharing_map));
     }
@@ -615,7 +612,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         assert!(is_mesh_orientable(&edge_sharing_map));
     }
@@ -625,7 +622,7 @@ mod tests {
         let geometry = cube_sharp_mismatching_winding([0.0, 0.0, 0.0], 1.0);
 
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         assert!(!is_mesh_orientable(&edge_sharing_map));
     }
@@ -634,7 +631,7 @@ mod tests {
     fn test_mesh_analysis_is_mesh_watertight_returns_true_for_watertight_mesh() {
         let geometry = geometry::cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         assert!(is_mesh_watertight(&edge_sharing_map));
     }
@@ -649,7 +646,7 @@ mod tests {
         );
 
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         assert!(!is_mesh_watertight(&edge_sharing_map));
     }
@@ -722,7 +719,7 @@ mod tests {
     }
 
     #[test]
-    fn test_border_edge_loops_should_be_one() {
+    fn test_border_edge_loops_returns_one_for_tessellated_triangle() {
         let (faces, vertices) = tessellated_triangle();
         let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
             faces.clone(),
@@ -731,7 +728,7 @@ mod tests {
         );
 
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         let correct_loop: Vec<UnorientedEdge> = vec![
             UnorientedEdge(OrientedEdge::new(0, 1)),
@@ -745,17 +742,18 @@ mod tests {
         let calculated_loops = border_edge_loops(&edge_sharing_map);
 
         assert_eq!(calculated_loops.len(), 1);
+        assert_eq!(calculated_loops[0].len(), correct_loop.len());
         for edge in correct_loop {
             assert!(calculated_loops[0].iter().any(|e| *e == edge));
         }
     }
 
     #[test]
-    fn test_border_edge_loops_should_be_none() {
+    fn test_border_edge_loops_returns_one_for_cube() {
         let geometry = cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
 
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
         let calculated_loops = border_edge_loops(&edge_sharing_map);
 
@@ -763,7 +761,7 @@ mod tests {
     }
 
     #[test]
-    fn test_border_edge_loops_should_be_two() {
+    fn test_border_edge_loops_returns_two_for_tessellated_triangle_with_island() {
         let (faces, vertices) = tessellated_triangle_with_island();
         let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
             faces.clone(),
@@ -772,27 +770,46 @@ mod tests {
         );
 
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_sharing_map = edge_sharing(&oriented_edges);
+        let edge_sharing_map = edge_analysis::edge_sharing(&oriented_edges);
 
-        let correct_loop: Vec<UnorientedEdge> = vec![
-            UnorientedEdge(OrientedEdge::new(0, 1)),
-            UnorientedEdge(OrientedEdge::new(1, 2)),
-            UnorientedEdge(OrientedEdge::new(2, 4)),
-            UnorientedEdge(OrientedEdge::new(4, 5)),
-            UnorientedEdge(OrientedEdge::new(5, 3)),
-            UnorientedEdge(OrientedEdge::new(3, 0)),
-            UnorientedEdge(OrientedEdge::new(6, 7)),
-            UnorientedEdge(OrientedEdge::new(7, 8)),
-            UnorientedEdge(OrientedEdge::new(8, 6)),
+        let correct_loops: Vec<Vec<UnorientedEdge>> = vec![
+            vec![
+                UnorientedEdge(OrientedEdge::new(0, 1)),
+                UnorientedEdge(OrientedEdge::new(1, 2)),
+                UnorientedEdge(OrientedEdge::new(2, 4)),
+                UnorientedEdge(OrientedEdge::new(4, 5)),
+                UnorientedEdge(OrientedEdge::new(5, 3)),
+                UnorientedEdge(OrientedEdge::new(3, 0)),
+            ],
+            vec![
+                UnorientedEdge(OrientedEdge::new(6, 7)),
+                UnorientedEdge(OrientedEdge::new(7, 8)),
+                UnorientedEdge(OrientedEdge::new(8, 6)),
+            ],
         ];
 
         let calculated_loops = border_edge_loops(&edge_sharing_map);
 
         assert_eq!(calculated_loops.len(), 2);
-        for edge in correct_loop {
-            assert!(calculated_loops
-                .iter()
-                .any(|e_l| e_l.iter().any(|e| *e == edge)));
+        assert!(
+            calculated_loops[0].len() == correct_loops[0].len()
+                || calculated_loops[0].len() == correct_loops[1].len()
+        );
+
+        if calculated_loops[0].len() == correct_loops[0].len() {
+            assert_eq!(calculated_loops[1].len(), correct_loops[1].len());
+            for (i, correct_loop) in correct_loops.iter().enumerate() {
+                for edge in correct_loop {
+                    assert!(calculated_loops[i].iter().any(|e| e == edge));
+                }
+            }
+        } else {
+            assert_eq!(calculated_loops[1].len(), correct_loops[0].len());
+            for (i, correct_loop) in correct_loops.iter().enumerate() {
+                for edge in correct_loop {
+                    assert!(calculated_loops[(i + 1) % 2].iter().any(|e| e == edge));
+                }
+            }
         }
     }
 }

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -76,7 +76,29 @@ pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
 
 #[allow(dead_code)]
 pub fn edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<UnorientedEdge>> {
-    let border_edges = border_edges(edge_sharing)
+    let mut border_edges: Vec<_> = border_edges(edge_sharing)
+        .map(|e| UnorientedEdge(e))
+        .collect();
+    let mut edge_loops: Vec<Vec<UnorientedEdge>> = Vec::new();
+
+    while !border_edges.is_empty() {
+        if let Some(edge) = border_edges.pop() {
+            let mut current_loop: Vec<UnorientedEdge> = vec![edge];
+
+            while current_loop.len() < 3
+                || !current_loop[current_loop.len() - 1].shares_vertex(current_loop[0])
+            {
+                for (i, other_edge) in border_edges.iter().enumerate() {
+                    if current_loop[current_loop.len() - 1].shares_vertex(*other_edge) {
+                        current_loop.push(border_edges.remove(i));
+                        break;
+                    }
+                }
+            }
+            edge_loops.push(current_loop);
+        }
+    }
+    edge_loops
 }
 
 /// Check if all the face normals point the same way.

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -81,7 +81,7 @@ pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
 /// If two edge loops meet at a single vertex, the result
 /// may be unpredictable and erratic.
 #[allow(dead_code)]
-pub fn edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<UnorientedEdge>> {
+pub fn border_edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<UnorientedEdge>> {
     let mut border_edges: Vec<_> = border_edges(edge_sharing)
         .map(|e| UnorientedEdge(e))
         .collect();
@@ -706,7 +706,7 @@ mod tests {
     }
 
     #[test]
-    fn test_edge_loops() {
+    fn test_border_edge_loops() {
         let (faces, vertices) = tessellated_triangle();
         let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
             faces.clone(),
@@ -726,7 +726,7 @@ mod tests {
             UnorientedEdge(OrientedEdge::new(3, 0)),
         ];
 
-        let calculated_loops = edge_loops(&edge_sharing_map);
+        let calculated_loops = border_edge_loops(&edge_sharing_map);
 
         assert_eq!(calculated_loops.len(), 1);
         for edge in correct_loop {

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
 
 use crate::convert::cast_i32;
-use crate::edge_analysis::EdgeCountMap;
+use crate::edge_analysis::EdgeSharingMap;
 use crate::geometry::OrientedEdge;
 
 /// Finds edges with a certain valency in a mesh edge collection
 /// Valency indicates how many faces share the edge
 fn find_edges_with_valency<'a>(
-    edge_valencies: &'a EdgeCountMap,
+    edge_valencies: &'a EdgeSharingMap,
     valency: usize,
 ) -> impl Iterator<Item = OrientedEdge> + 'a {
     edge_valencies
@@ -28,7 +28,7 @@ fn find_edges_with_valency<'a>(
 /// An edge is border when its valency is 1
 #[allow(dead_code)]
 pub fn border_edges<'a>(
-    edge_valencies: &'a EdgeCountMap,
+    edge_valencies: &'a EdgeSharingMap,
 ) -> impl Iterator<Item = OrientedEdge> + 'a {
     find_edges_with_valency(edge_valencies, 1)
 }
@@ -37,7 +37,7 @@ pub fn border_edges<'a>(
 /// An edge is manifold when its valency is 2
 #[allow(dead_code)]
 pub fn manifold_edges<'a>(
-    edge_valencies: &'a EdgeCountMap,
+    edge_valencies: &'a EdgeSharingMap,
 ) -> impl Iterator<Item = OrientedEdge> + 'a {
     find_edges_with_valency(edge_valencies, 2)
 }
@@ -45,7 +45,7 @@ pub fn manifold_edges<'a>(
 /// Finds non-manifold (errorneous) edges in a mesh edge collection
 #[allow(dead_code)]
 pub fn non_manifold_edges<'a>(
-    edge_valencies: &'a EdgeCountMap,
+    edge_valencies: &'a EdgeSharingMap,
 ) -> impl Iterator<Item = OrientedEdge> + 'a {
     edge_valencies
         .iter()
@@ -64,7 +64,7 @@ pub fn non_manifold_edges<'a>(
 /// Finds border vertex indices in a mesh edge collection
 /// A vertex is border when its edge's valency is 1
 #[allow(dead_code)]
-pub fn border_vertex_indices(edge_valencies: &EdgeCountMap) -> HashSet<u32> {
+pub fn border_vertex_indices(edge_valencies: &EdgeSharingMap) -> HashSet<u32> {
     let mut border_vertices = HashSet::new();
 
     border_edges(edge_valencies).for_each(|edge| {
@@ -81,7 +81,7 @@ pub fn border_vertex_indices(edge_valencies: &EdgeCountMap) -> HashSet<u32> {
 /// in a single reverted oriented edge and
 /// the border edges don't have any counterpart.
 #[allow(dead_code)]
-pub fn is_mesh_orientable(edge_valencies: &EdgeCountMap) -> bool {
+pub fn is_mesh_orientable(edge_valencies: &EdgeSharingMap) -> bool {
     edge_valencies.iter().all(|(_, edge_count)| {
         // Ascending_count and descending_count can never be both 0
         // at the same time because there is never a case that the
@@ -95,7 +95,7 @@ pub fn is_mesh_orientable(edge_valencies: &EdgeCountMap) -> bool {
 /// The mesh is watertight if there is no border or non-manifold edge,
 /// in other words, all edge valencies are 2
 #[allow(dead_code)]
-pub fn is_mesh_watertight(edge_valencies: &EdgeCountMap) -> bool {
+pub fn is_mesh_watertight(edge_valencies: &EdgeSharingMap) -> bool {
     edge_valencies.iter().all(|(_, edge_count)| {
         edge_count.ascending_edges.len() == 1 && edge_count.descending_edges.len() == 1
     })

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -61,8 +61,8 @@ pub fn non_manifold_edges<'a>(
         })
 }
 
-///Finds border vertex indices in a mesh edge collection.
-///A vertex is border when its edge's valency is 1
+/// Finds border vertex indices in a mesh edge collection.
+/// A vertex is border when its edge's valency is 1
 #[allow(dead_code)]
 pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
     let mut border_vertices = HashSet::new();

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -1,16 +1,16 @@
 use std::collections::HashSet;
 
 use crate::convert::cast_i32;
-use crate::edge_analysis::EdgeCountMap;
-use crate::geometry::OrientedEdge;
+use crate::edge_analysis::EdgeSharingMap;
+use crate::geometry::{OrientedEdge, UnorientedEdge};
 
 /// Finds edges with a certain valency in a mesh edge collection
 /// Valency indicates how many faces share the edge
 fn find_edges_with_valency<'a>(
-    edge_valencies: &'a EdgeCountMap,
+    edge_sharing: &'a EdgeSharingMap,
     valency: usize,
 ) -> impl Iterator<Item = OrientedEdge> + 'a {
-    edge_valencies
+    edge_sharing
         .iter()
         .filter(move |(_, similar_edges)| {
             similar_edges.ascending_edges.len() + similar_edges.descending_edges.len() == valency
@@ -28,26 +28,26 @@ fn find_edges_with_valency<'a>(
 /// An edge is border when its valency is 1
 #[allow(dead_code)]
 pub fn border_edges<'a>(
-    edge_valencies: &'a EdgeCountMap,
+    edge_sharing: &'a EdgeSharingMap,
 ) -> impl Iterator<Item = OrientedEdge> + 'a {
-    find_edges_with_valency(edge_valencies, 1)
+    find_edges_with_valency(edge_sharing, 1)
 }
 
 /// Finds manifold (inner) edges in a mesh edge collection
 /// An edge is manifold when its valency is 2
 #[allow(dead_code)]
 pub fn manifold_edges<'a>(
-    edge_valencies: &'a EdgeCountMap,
+    edge_sharing: &'a EdgeSharingMap,
 ) -> impl Iterator<Item = OrientedEdge> + 'a {
-    find_edges_with_valency(edge_valencies, 2)
+    find_edges_with_valency(edge_sharing, 2)
 }
 
 /// Finds non-manifold (errorneous) edges in a mesh edge collection
 #[allow(dead_code)]
 pub fn non_manifold_edges<'a>(
-    edge_valencies: &'a EdgeCountMap,
+    edge_sharing: &'a EdgeSharingMap,
 ) -> impl Iterator<Item = OrientedEdge> + 'a {
-    edge_valencies
+    edge_sharing
         .iter()
         .filter(|(_, edge_count)| {
             edge_count.ascending_edges.len() + edge_count.descending_edges.len() > 2
@@ -64,14 +64,50 @@ pub fn non_manifold_edges<'a>(
 /// Finds border vertex indices in a mesh edge collection
 /// A vertex is border when its edge's valency is 1
 #[allow(dead_code)]
-pub fn border_vertex_indices(edge_valencies: &EdgeCountMap) -> HashSet<u32> {
+pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
     let mut border_vertices = HashSet::new();
 
-    border_edges(edge_valencies).for_each(|edge| {
+    border_edges(edge_sharing).for_each(|edge| {
         border_vertices.insert(edge.vertices.0);
         border_vertices.insert(edge.vertices.1);
     });
     border_vertices
+}
+
+/// Finds continuous loops of border edges,
+/// starting from a random edge.
+/// The mesh may contain holes or islands,
+/// therefore it may have an unknown number of edge loops.
+/// If two edge loops meet at a single vertex, the result
+/// may be unpredictable and erratic.
+#[allow(dead_code)]
+pub fn border_edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<UnorientedEdge>> {
+    let mut border_edges: Vec<_> = border_edges(edge_sharing)
+        .map(|e| UnorientedEdge(e))
+        .collect();
+
+    let mut edge_loops: Vec<Vec<UnorientedEdge>> = Vec::new();
+
+    while !border_edges.is_empty() {
+        if let Some(edge) = border_edges.pop() {
+            let mut current_loop: Vec<UnorientedEdge> = vec![edge];
+
+            while current_loop.len() < 3
+                || !current_loop[current_loop.len() - 1].shares_vertex(current_loop[0])
+            {
+                for (i, other_edge) in border_edges.iter().enumerate() {
+                    if current_loop[current_loop.len() - 1].shares_vertex(*other_edge) {
+                        current_loop.push(border_edges.remove(i));
+                        break;
+                    }
+                }
+            }
+
+            edge_loops.push(current_loop);
+        }
+    }
+
+    edge_loops
 }
 
 /// Check if all the face normals point the same way.
@@ -81,8 +117,8 @@ pub fn border_vertex_indices(edge_valencies: &EdgeCountMap) -> HashSet<u32> {
 /// in a single reverted oriented edge and
 /// the border edges don't have any counterpart.
 #[allow(dead_code)]
-pub fn is_mesh_orientable(edge_valencies: &EdgeCountMap) -> bool {
-    edge_valencies.iter().all(|(_, edge_count)| {
+pub fn is_mesh_orientable(edge_sharing: &EdgeSharingMap) -> bool {
+    edge_sharing.iter().all(|(_, edge_count)| {
         // Ascending_count and descending_count can never be both 0
         // at the same time because there is never a case that the
         // edge doesn't exist in any direction.
@@ -95,8 +131,8 @@ pub fn is_mesh_orientable(edge_valencies: &EdgeCountMap) -> bool {
 /// The mesh is watertight if there is no border or non-manifold edge,
 /// in other words, all edge valencies are 2
 #[allow(dead_code)]
-pub fn is_mesh_watertight(edge_valencies: &EdgeCountMap) -> bool {
-    edge_valencies.iter().all(|(_, edge_count)| {
+pub fn is_mesh_watertight(edge_sharing: &EdgeSharingMap) -> bool {
+    edge_sharing.iter().all(|(_, edge_count)| {
         edge_count.ascending_edges.len() == 1 && edge_count.descending_edges.len() == 1
     })
 }
@@ -114,7 +150,7 @@ mod tests {
     use nalgebra::base::Vector3;
     use nalgebra::geometry::Point3;
 
-    use crate::edge_analysis::edge_valencies;
+    use crate::edge_analysis::edge_sharing;
     use crate::geometry::{
         self, cube_sharp_var_len, Geometry, NormalStrategy, TriangleFace, UnorientedEdge, Vertices,
     };
@@ -403,6 +439,21 @@ mod tests {
         )
     }
 
+    fn tessellated_triangle() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+        let vertices = vec![
+            Point3::new(-2.0, -2.0, 0.0),
+            Point3::new(0.0, -2.0, 0.0),
+            Point3::new(2.0, -2.0, 0.0),
+            Point3::new(-1.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 2.0, 0.0),
+        ];
+
+        let faces = vec![(0, 3, 1), (1, 3, 4), (1, 4, 2), (3, 5, 4)];
+
+        (faces, vertices)
+    }
+
     #[test]
     fn test_mesh_analysis_find_edge_with_valency() {
         let (faces, vertices) = quad();
@@ -412,7 +463,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
         let oriented_edges_with_valency_1_correct = vec![
             OrientedEdge::new(0, 1),
@@ -424,9 +475,9 @@ mod tests {
             vec![OrientedEdge::new(2, 0), OrientedEdge::new(0, 2)];
 
         let oriented_edges_with_valency_1: Vec<_> =
-            find_edges_with_valency(&edge_valency_map, 1).collect();
+            find_edges_with_valency(&edge_sharing_map, 1).collect();
         let oriented_edges_with_valency_2: Vec<_> =
-            find_edges_with_valency(&edge_valency_map, 2).collect();
+            find_edges_with_valency(&edge_sharing_map, 2).collect();
 
         assert_eq!(oriented_edges_with_valency_1.len(), 4);
         assert_eq!(oriented_edges_with_valency_2.len(), 2);
@@ -449,7 +500,7 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
         let oriented_edges_border_correct = vec![
             OrientedEdge::new(0, 1),
@@ -458,7 +509,7 @@ mod tests {
             OrientedEdge::new(3, 0),
         ];
 
-        let oriented_edges_border_check: Vec<_> = border_edges(&edge_valency_map).collect();
+        let oriented_edges_border_check: Vec<_> = border_edges(&edge_sharing_map).collect();
 
         for o_e in &oriented_edges_border_correct {
             assert!(oriented_edges_border_check.iter().any(|e| e == o_e));
@@ -474,12 +525,12 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
         let oriented_edges_manifold_correct =
             vec![OrientedEdge::new(2, 0), OrientedEdge::new(0, 2)];
 
-        let oriented_edges_manifold_check: Vec<_> = manifold_edges(&edge_valency_map).collect();
+        let oriented_edges_manifold_check: Vec<_> = manifold_edges(&edge_sharing_map).collect();
 
         for o_e in oriented_edges_manifold_correct {
             assert!(oriented_edges_manifold_check.iter().any(|e| *e == o_e));
@@ -495,13 +546,13 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
         let oriented_edges_non_manifold_correct =
             vec![OrientedEdge::new(2, 0), OrientedEdge::new(0, 2)];
 
         let oriented_edges_non_manifold_check: Vec<_> =
-            non_manifold_edges(&edge_valency_map).collect();
+            non_manifold_edges(&edge_sharing_map).collect();
 
         for o_e in &oriented_edges_non_manifold_correct {
             assert!(oriented_edges_non_manifold_check.iter().any(|e| e == o_e));
@@ -519,11 +570,11 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
         let border_vertex_indices_correct = vec![0, 1, 2, 3];
 
-        let border_vertex_indices_check = border_vertex_indices(&edge_valency_map);
+        let border_vertex_indices_check = border_vertex_indices(&edge_sharing_map);
 
         for v_i in border_vertex_indices_correct {
             assert!(border_vertex_indices_check.iter().any(|v| *v == v_i));
@@ -534,9 +585,9 @@ mod tests {
     fn test_mesh_analysis_is_mesh_orientable_returns_true_watertight_mesh() {
         let geometry = geometry::cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
-        assert!(is_mesh_orientable(&edge_valency_map));
+        assert!(is_mesh_orientable(&edge_sharing_map));
     }
 
     #[test]
@@ -548,9 +599,9 @@ mod tests {
             NormalStrategy::Sharp,
         );
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
-        assert!(is_mesh_orientable(&edge_valency_map));
+        assert!(is_mesh_orientable(&edge_sharing_map));
     }
 
     #[test]
@@ -558,18 +609,18 @@ mod tests {
         let geometry = cube_sharp_mismatching_winding([0.0, 0.0, 0.0], 1.0);
 
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
-        assert!(!is_mesh_orientable(&edge_valency_map));
+        assert!(!is_mesh_orientable(&edge_sharing_map));
     }
 
     #[test]
     fn test_mesh_analysis_is_mesh_watertight_returns_true_for_watertight_mesh() {
         let geometry = geometry::cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
-        assert!(is_mesh_watertight(&edge_valency_map));
+        assert!(is_mesh_watertight(&edge_sharing_map));
     }
 
     #[test]
@@ -582,9 +633,9 @@ mod tests {
         );
 
         let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
-        let edge_valency_map = edge_valencies(&oriented_edges);
+        let edge_sharing_map = edge_sharing(&oriented_edges);
 
-        assert!(!is_mesh_watertight(&edge_valency_map));
+        assert!(!is_mesh_watertight(&edge_sharing_map));
     }
 
     #[test]
@@ -652,5 +703,34 @@ mod tests {
             geometry.triangle_faces_iter().count(),
         );
         assert_eq!(genus, 3);
+    }
+
+    #[test]
+    fn test_border_edge_loops() {
+        let (faces, vertices) = tessellated_triangle();
+        let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+            faces.clone(),
+            vertices.clone(),
+            NormalStrategy::Sharp,
+        );
+
+        let oriented_edges: Vec<OrientedEdge> = geometry.oriented_edges_iter().collect();
+        let edge_sharing_map = edge_sharing(&oriented_edges);
+
+        let correct_loop: Vec<UnorientedEdge> = vec![
+            UnorientedEdge(OrientedEdge::new(0, 1)),
+            UnorientedEdge(OrientedEdge::new(1, 2)),
+            UnorientedEdge(OrientedEdge::new(2, 4)),
+            UnorientedEdge(OrientedEdge::new(4, 5)),
+            UnorientedEdge(OrientedEdge::new(5, 3)),
+            UnorientedEdge(OrientedEdge::new(3, 0)),
+        ];
+
+        let calculated_loops = border_edge_loops(&edge_sharing_map);
+
+        assert_eq!(calculated_loops.len(), 1);
+        for edge in correct_loop {
+            assert!(calculated_loops[0].iter().any(|e| *e == edge));
+        }
     }
 }

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -82,9 +82,7 @@ pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
 /// may be unpredictable and erratic.
 #[allow(dead_code)]
 pub fn border_edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<UnorientedEdge>> {
-    let mut border_edges: Vec<_> = border_edges(edge_sharing)
-        .map(|e| UnorientedEdge(e))
-        .collect();
+    let mut border_edges: Vec<_> = border_edges(edge_sharing).map(UnorientedEdge).collect();
 
     let mut edge_loops: Vec<Vec<UnorientedEdge>> = Vec::new();
 


### PR DESCRIPTION
Find mesh border edge loops, which are circular sequences of edges (closed polylines) around the mesh border. Border edges are contained exclusively in a single face. The feature will be later needed for parametrization of meshes before morphing, for splitting into patches and for physical simulations we might need in some morphing algorithms.

A mesh can have:
* no border edge loop, when it's watertight
* single border edge loop, when it's a patch or a mesh with a single hole (topologically also a patch)
* more border edge loops, when it has more holes or consists of more mesh patches.

A border edge loop always consists of 3 or more border edges (for mesh patches made of a single triangular face or for meshes with a single triangle missing).

In an edge case when more border edge loops share a single vertex (checkerboard scenario), there is no resolution strategy, so the result is left unpredictable, yet correct. In the future, the function can detect the case and throw a warning.

Also, in this pull request most of the valency-related types and functions are renamed more suitably.