### PR TITLE
Optimize topology calculation algorithms

### DIFF
--- a/src/mesh_topology_analysis.rs
+++ b/src/mesh_topology_analysis.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 
 use smallvec::SmallVec;
 
-use crate::convert::{cast_u32, cast_usize};
+use crate::convert::cast_u32;
 use crate::geometry::{Face, Geometry, UnorientedEdge};
 
 /// Calculates topological relations (neighborhood) of mesh face -> faces.
 /// Returns a Map (key: face index, value: list of its neighboring faces indices)
 #[allow(dead_code)]
-pub fn face_to_face_topology(geometry: &Geometry) -> HashMap<usize, SmallVec<[usize; 8]>> {
-    let mut f2f: HashMap<usize, SmallVec<[usize; 8]>> = HashMap::new();
+pub fn face_to_face_topology(geometry: &Geometry) -> HashMap<u32, SmallVec<[u32; 8]>> {
+    let mut f2f: HashMap<u32, SmallVec<[u32; 8]>> = HashMap::new();
     for (from_counter, face) in geometry.faces().iter().enumerate() {
         match face {
             Face::Triangle(f) => {
@@ -21,10 +21,11 @@ pub fn face_to_face_topology(geometry: &Geometry) -> HashMap<usize, SmallVec<[us
                                 || t_f.contains_unoriented_edge(f_e_1)
                                 || t_f.contains_unoriented_edge(f_e_2)
                             {
-                                let neighbors =
-                                    f2f.entry(from_counter).or_insert_with(SmallVec::new);
-                                if neighbors.iter().all(|value| *value != to_counter) {
-                                    neighbors.push(to_counter);
+                                let neighbors = f2f
+                                    .entry(cast_u32(from_counter))
+                                    .or_insert_with(SmallVec::new);
+                                if neighbors.iter().all(|value| *value != cast_u32(to_counter)) {
+                                    neighbors.push(cast_u32(to_counter));
                                 }
                             }
                         }
@@ -42,16 +43,18 @@ pub fn face_to_face_topology(geometry: &Geometry) -> HashMap<usize, SmallVec<[us
 pub fn edge_to_face_topology(
     geometry: &Geometry,
     edges: &[UnorientedEdge],
-) -> HashMap<usize, SmallVec<[usize; 8]>> {
-    let mut e2f: HashMap<usize, SmallVec<[usize; 8]>> = HashMap::new();
+) -> HashMap<u32, SmallVec<[u32; 8]>> {
+    let mut e2f: HashMap<u32, SmallVec<[u32; 8]>> = HashMap::new();
     for (from_counter, e) in edges.iter().enumerate() {
         for (to_counter, face) in geometry.faces().iter().enumerate() {
             match face {
                 Face::Triangle(t_f) => {
                     if t_f.contains_unoriented_edge(*e) {
-                        let neighbors = e2f.entry(from_counter).or_insert_with(SmallVec::new);
-                        if neighbors.iter().all(|value| *value != to_counter) {
-                            neighbors.push(to_counter);
+                        let neighbors = e2f
+                            .entry(cast_u32(from_counter))
+                            .or_insert_with(SmallVec::new);
+                        if neighbors.iter().all(|value| *value != cast_u32(to_counter)) {
+                            neighbors.push(cast_u32(to_counter));
                         }
                     }
                 }
@@ -64,17 +67,15 @@ pub fn edge_to_face_topology(
 /// Calculates topological relations (neighborhood) of mesh vertex -> faces.
 /// Returns a Map (key: vertex index, value: list of its neighboring faces indices)
 #[allow(dead_code)]
-pub fn vertex_to_face_topology(geometry: &Geometry) -> HashMap<usize, SmallVec<[usize; 8]>> {
-    let mut v2f: HashMap<usize, SmallVec<[usize; 8]>> = HashMap::new();
-    for from_counter in 0..geometry.vertices().len() {
-        for (to_counter, face) in geometry.faces().iter().enumerate() {
-            match face {
-                Face::Triangle(t_f) => {
-                    if t_f.contains_vertex(cast_u32(from_counter)) {
-                        let neighbors = v2f.entry(from_counter).or_insert_with(SmallVec::new);
-                        if neighbors.iter().all(|value| *value != to_counter) {
-                            neighbors.push(to_counter);
-                        }
+pub fn vertex_to_face_topology(geometry: &Geometry) -> HashMap<u32, SmallVec<[u32; 8]>> {
+    let mut v2f: HashMap<u32, SmallVec<[u32; 8]>> = HashMap::new();
+    for (to_face, face) in geometry.faces().iter().enumerate() {
+        match face {
+            Face::Triangle(t_f) => {
+                for from_vertex in &[t_f.vertices.0, t_f.vertices.1, t_f.vertices.2] {
+                    let neighbors = v2f.entry(*from_vertex).or_insert_with(SmallVec::new);
+                    if neighbors.iter().all(|value| *value != cast_u32(to_face)) {
+                        neighbors.push(cast_u32(to_face));
                     }
                 }
             }
@@ -86,18 +87,14 @@ pub fn vertex_to_face_topology(geometry: &Geometry) -> HashMap<usize, SmallVec<[
 /// Calculates topological relations (neighborhood) of mesh vertex -> edge.
 /// Returns a Map (key: vertex index, value: list of its neighboring edge indices)
 #[allow(dead_code)]
-pub fn vertex_to_edge_topology(
-    geometry: &Geometry,
-    edges: &[UnorientedEdge],
-) -> HashMap<usize, SmallVec<[usize; 8]>> {
-    let mut v2e: HashMap<usize, SmallVec<[usize; 8]>> = HashMap::new();
-    for from_counter in 0..geometry.vertices().len() {
-        for (to_counter, e) in edges.iter().enumerate() {
-            if e.0.contains_vertex(cast_u32(from_counter)) {
-                let neighbors = v2e.entry(from_counter).or_insert_with(SmallVec::new);
-                if neighbors.iter().all(|value| *value != to_counter) {
-                    neighbors.push(to_counter);
-                }
+pub fn vertex_to_edge_topology(edges: &[UnorientedEdge]) -> HashMap<u32, SmallVec<[u32; 8]>> {
+    let mut v2e: HashMap<u32, SmallVec<[u32; 8]>> = HashMap::new();
+
+    for (to_edge, e) in edges.iter().enumerate() {
+        for from_vertex in &[e.0.vertices.0, e.0.vertices.1] {
+            let neighbors = v2e.entry(*from_vertex).or_insert_with(SmallVec::new);
+            if neighbors.iter().all(|value| *value != cast_u32(to_edge)) {
+                neighbors.push(cast_u32(to_edge));
             }
         }
     }
@@ -107,55 +104,26 @@ pub fn vertex_to_edge_topology(
 /// Calculates topological relations (neighborhood) of mesh vertex -> vertex.
 /// Returns a Map (key: vertex index, value: list of its neighboring vertices indices)
 #[allow(dead_code)]
-pub fn vertex_to_vertex_topology(geometry: &Geometry) -> HashMap<usize, SmallVec<[usize; 8]>> {
-    let mut v2v: HashMap<usize, SmallVec<[usize; 8]>> = HashMap::new();
+pub fn vertex_to_vertex_topology(geometry: &Geometry) -> HashMap<u32, SmallVec<[u32; 8]>> {
+    let mut v2v: HashMap<u32, SmallVec<[u32; 8]>> = HashMap::new();
     for face in geometry.faces() {
         match face {
             Face::Triangle(f) => {
-                let neighbors_0 = v2v
-                    .entry(cast_usize(f.vertices.0))
-                    .or_insert_with(SmallVec::new);
-                if neighbors_0
-                    .iter()
-                    .all(|value| *value != cast_usize(f.vertices.1))
-                {
-                    neighbors_0.push(cast_usize(f.vertices.1));
-                }
-                if neighbors_0
-                    .iter()
-                    .all(|value| *value != cast_usize(f.vertices.2))
-                {
-                    neighbors_0.push(cast_usize(f.vertices.2));
-                }
-                let neighbors_1 = v2v
-                    .entry(cast_usize(f.vertices.1))
-                    .or_insert_with(SmallVec::new);
-                if neighbors_1
-                    .iter()
-                    .all(|value| *value != cast_usize(f.vertices.0))
-                {
-                    neighbors_1.push(cast_usize(f.vertices.0));
-                }
-                if neighbors_1
-                    .iter()
-                    .all(|value| *value != cast_usize(f.vertices.2))
-                {
-                    neighbors_1.push(cast_usize(f.vertices.2));
-                }
-                let neighbors_2 = v2v
-                    .entry(cast_usize(f.vertices.2))
-                    .or_insert_with(SmallVec::new);
-                if neighbors_2
-                    .iter()
-                    .all(|value| *value != cast_usize(f.vertices.0))
-                {
-                    neighbors_2.push(cast_usize(f.vertices.0));
-                }
-                if neighbors_2
-                    .iter()
-                    .all(|value| *value != cast_usize(f.vertices.1))
-                {
-                    neighbors_2.push(cast_usize(f.vertices.1));
+                let vertex_indices = &[f.vertices.0, f.vertices.1, f.vertices.2];
+                for i in 0..vertex_indices.len() {
+                    let neighbors = v2v.entry(vertex_indices[i]).or_insert_with(SmallVec::new);
+                    if neighbors
+                        .iter()
+                        .all(|value| *value != vertex_indices[(i + 1) % 3])
+                    {
+                        neighbors.push(vertex_indices[(i + 1) % 3])
+                    }
+                    if neighbors
+                        .iter()
+                        .all(|value| *value != vertex_indices[(i + 2) % 3])
+                    {
+                        neighbors.push(vertex_indices[(i + 2) % 3])
+                    }
                 }
             }
         }
@@ -196,7 +164,7 @@ mod tests {
             vertices.clone(),
             NormalStrategy::Sharp,
         );
-        let mut face_to_face_topology_correct: HashMap<usize, Vec<usize>> = HashMap::new();
+        let mut face_to_face_topology_correct: HashMap<u32, Vec<u32>> = HashMap::new();
         face_to_face_topology_correct.insert(0, vec![1]);
         face_to_face_topology_correct.insert(1, vec![0, 2, 3]);
         face_to_face_topology_correct.insert(2, vec![1]);
@@ -281,7 +249,7 @@ mod tests {
         let edge_set: HashSet<_> = geometry.unoriented_edges_iter().collect();
         let edges: Vec<_> = edge_set.iter().cloned().collect();
 
-        let vertex_to_edge_topology_calculated = vertex_to_edge_topology(&geometry, &edges);
+        let vertex_to_edge_topology_calculated = vertex_to_edge_topology(&edges);
 
         let in_two_edges_count = vertex_to_edge_topology_calculated
             .iter()

--- a/src/mesh_topology_analysis.rs
+++ b/src/mesh_topology_analysis.rs
@@ -13,6 +13,7 @@ pub fn face_to_face_topology(geometry: &Geometry) -> HashMap<u32, SmallVec<[u32;
     for (from_counter, face) in geometry.faces().iter().enumerate() {
         match face {
             Face::Triangle(f) => {
+                let from_counter_u32 = cast_u32(from_counter);
                 let [f_e_0, f_e_1, f_e_2] = f.to_unoriented_edges();
                 for (to_counter, to_face) in geometry.faces().iter().enumerate() {
                     match to_face {
@@ -21,9 +22,8 @@ pub fn face_to_face_topology(geometry: &Geometry) -> HashMap<u32, SmallVec<[u32;
                                 || t_f.contains_unoriented_edge(f_e_1)
                                 || t_f.contains_unoriented_edge(f_e_2)
                             {
-                                let neighbors = f2f
-                                    .entry(cast_u32(from_counter))
-                                    .or_insert_with(SmallVec::new);
+                                let neighbors =
+                                    f2f.entry(from_counter_u32).or_insert_with(SmallVec::new);
                                 if neighbors.iter().all(|value| *value != cast_u32(to_counter)) {
                                     neighbors.push(cast_u32(to_counter));
                                 }
@@ -72,10 +72,11 @@ pub fn vertex_to_face_topology(geometry: &Geometry) -> HashMap<u32, SmallVec<[u3
     for (to_face, face) in geometry.faces().iter().enumerate() {
         match face {
             Face::Triangle(t_f) => {
+                let to_face_u32 = cast_u32(to_face);
                 for from_vertex in &[t_f.vertices.0, t_f.vertices.1, t_f.vertices.2] {
                     let neighbors = v2f.entry(*from_vertex).or_insert_with(SmallVec::new);
-                    if neighbors.iter().all(|value| *value != cast_u32(to_face)) {
-                        neighbors.push(cast_u32(to_face));
+                    if neighbors.iter().all(|value| *value != to_face_u32) {
+                        neighbors.push(to_face_u32);
                     }
                 }
             }
@@ -91,10 +92,11 @@ pub fn vertex_to_edge_topology(edges: &[UnorientedEdge]) -> HashMap<u32, SmallVe
     let mut v2e: HashMap<u32, SmallVec<[u32; 8]>> = HashMap::new();
 
     for (to_edge, e) in edges.iter().enumerate() {
+        let to_edge_u32 = cast_u32(to_edge);
         for from_vertex in &[e.0.vertices.0, e.0.vertices.1] {
             let neighbors = v2e.entry(*from_vertex).or_insert_with(SmallVec::new);
-            if neighbors.iter().all(|value| *value != cast_u32(to_edge)) {
-                neighbors.push(cast_u32(to_edge));
+            if neighbors.iter().all(|value| *value != to_edge_u32) {
+                neighbors.push(to_edge_u32);
             }
         }
     }


### PR DESCRIPTION
Reduce complexity of vertex_to_face_topology() and vertex_to_edge_topology() from O(n*m) to O(n).
Shorten vertex_to_vertex_topology() to improve readability.
Change return type from usize to u32 for all topology calculators to match the existing convention.