### PR TITLE
Change meaning of MSAA disabled to 1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
     let msaa = env::var("HS_MSAA")
         .ok()
         .map(|msaa| match msaa.as_str() {
-            "0" => hs::Msaa::Disabled,
+            "1" => hs::Msaa::Disabled,
             "4" => hs::Msaa::X4,
             "8" => hs::Msaa::X8,
             "16" => hs::Msaa::X16,


### PR DESCRIPTION
Just noticed this in `main.rs` - 1 sample means MSAA is disabled, not 0. Readme is correct though.