### PR TITLE
Compare visually similar geometries

### DIFF
--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -7,8 +7,9 @@ use crate::convert::{cast_i32, cast_usize};
 use crate::edge_analysis::EdgeSharingMap;
 use crate::geometry::{Face, Geometry, OrientedEdge, UnorientedEdge};
 
-/// Finds edges with a certain valency in a mesh edge collection
-/// Valency indicates how many faces share the edge
+/// Finds edges with a certain valency in a mesh edge collection 
+///
+/// An edge valency indicates how many faces share the edge.
 fn find_edges_with_valency<'a>(
     edge_sharing: &'a EdgeSharingMap,
     valency: usize,
@@ -28,6 +29,7 @@ fn find_edges_with_valency<'a>(
 }
 
 /// Finds border edges in a mesh edge collection
+///
 /// An edge is border when its valency is 1
 #[allow(dead_code)]
 pub fn border_edges<'a>(
@@ -37,6 +39,7 @@ pub fn border_edges<'a>(
 }
 
 /// Finds manifold (inner) edges in a mesh edge collection
+///
 /// An edge is manifold when its valency is 2
 #[allow(dead_code)]
 pub fn manifold_edges<'a>(
@@ -45,7 +48,7 @@ pub fn manifold_edges<'a>(
     find_edges_with_valency(edge_sharing, 2)
 }
 
-/// Finds non-manifold (errorneous) edges in a mesh edge collection
+/// Finds non-manifold (erroneous) edges in a mesh edge collection
 #[allow(dead_code)]
 pub fn non_manifold_edges<'a>(
     edge_sharing: &'a EdgeSharingMap,
@@ -64,7 +67,8 @@ pub fn non_manifold_edges<'a>(
         })
 }
 
-/// Finds border vertex indices in a mesh edge collection.
+/// Finds border vertex indices in a mesh edge collection
+///
 /// A vertex is border when its edge's valency is 1
 #[allow(dead_code)]
 pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
@@ -77,11 +81,11 @@ pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
     border_vertices
 }
 
-/// Finds continuous loops of border edges, starting from a random edge.
+/// Finds continuous loops of border edges, starting from a random edge
 ///
-/// The mesh may contain holes or islands, therefore it may have an
-/// unknown number of edge loops. If two edge loops meet at a single vertex,
-/// the result may be unpredictable and erratic.
+/// The mesh may contain holes or islands, therefore it may have an unknown
+/// number of edge loops. If two edge loops meet at a single vertex, the result
+/// may be unpredictable and erratic.
 #[allow(dead_code)]
 pub fn border_edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<UnorientedEdge>> {
     let mut border_edges: Vec<_> = border_edges(edge_sharing).map(UnorientedEdge).collect();
@@ -108,26 +112,25 @@ pub fn border_edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<UnorientedEdg
     edge_loops
 }
 
-/// Check if all the face normals point the same way.
-/// In a proper watertight orientable mesh each oriented edge
-/// should have a single counterpart in a reverted oriented edge.
-/// In an open orientable mesh each internal edge has its counterpart
-/// in a single reverted oriented edge and
-/// the border edges don't have any counterpart.
+/// Check if all the face normals point the same way. 
+///
+/// In a proper watertight orientable mesh each oriented edge should have a
+/// single counterpart in a reverted oriented edge. In an open orientable mesh
+/// each internal edge has its counterpart in a single reverted oriented edge
+/// and the border edges don't have any counterpart.
 #[allow(dead_code)]
 pub fn is_mesh_orientable(edge_sharing: &EdgeSharingMap) -> bool {
     edge_sharing.iter().all(|(_, edge_count)| {
-        // Ascending_count and descending_count can never be both 0
-        // at the same time because there is never a case that the
-        // edge doesn't exist in any direction.
-        // Even if this happens, it means that the tested edge
-        // is non-existing and therefore doesn't affect edge winding.
+        // Ascending_count and descending_count can never be both 0 at the same
+        // time because there is never a case that the edge doesn't exist in any
+        // direction. Even if this happens, it means that the tested edge is
+        // non-existing and therefore doesn't affect edge winding.
         edge_count.ascending_edges.len() <= 1 && edge_count.descending_edges.len() <= 1
     })
 }
 
-/// The mesh is watertight if there is no border or non-manifold edge,
-/// in other words, all edge valencies are 2
+/// The mesh is watertight if there is no border or non-manifold edge, which
+/// means all the edge valencies are 2.
 #[allow(dead_code)]
 pub fn is_mesh_watertight(edge_sharing: &EdgeSharingMap) -> bool {
     edge_sharing.iter().all(|(_, edge_count)| {
@@ -135,11 +138,10 @@ pub fn is_mesh_watertight(edge_sharing: &EdgeSharingMap) -> bool {
     })
 }
 
-/// Computes the mesh genus of a triangulated mesh.
+/// Computes the mesh genus of a triangulated mesh geometry
 ///
-/// Genus of a mesh is the number of holes in topology / connectivity.
-/// The mesh **must** be triangulated and watertight for this to produce
-/// usable results.
+/// Genus of a mesh is the number of holes in topology / connectivity. The mesh
+/// **must** be triangulated and watertight for this to produce usable results.
 ///
 /// The genus (G) is computed as: `V - E + F = 2*(1 - G)`.
 #[allow(dead_code)]
@@ -147,12 +149,17 @@ pub fn triangulated_mesh_genus(vertex_count: usize, edge_count: usize, face_coun
     1 - (cast_i32(vertex_count) - cast_i32(edge_count) + cast_i32(face_count)) / 2
 }
 
-/// Checks if two geometries are visually identical.
+/// Checks if two geometries are visually identical
 ///
-/// The two geometries can
-/// possibly contain the same vertices and normals bound to the same faces, but all
-/// of these can be in different order, including shifts in face winding. This
-/// function takes all these cases in consideration. Therefore it is slow.
+/// Two mesh geometries are identical when the position of each vertex in one
+/// mesh geometry matches a position of exactly one vertex in the other mesh
+/// geometry, when the direction of each normal in one mesh geometry matches a
+/// direction of exactly one normal in the other mesh geometry and each face in
+/// one mesh geometry refers vertices with the same position and normals with
+/// the same direction, both in the same circular order, as exactly one face in
+/// the other mesh geometry. The indices (order in which they are stored) of
+/// vertices, normals and faces can differ but as long as the previous
+/// conditions are met, the mesh geometries are identical.
 #[allow(dead_code)]
 pub fn are_visually_identical(g_1: &Geometry, g_2: &Geometry) -> bool {
     struct UnpackedFace {

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -184,7 +184,7 @@ pub fn are_visually_identical(g_1: &Geometry, g_2: &Geometry) -> bool {
     }
 
     let mut unpacked_faces_1 = g_1.faces().iter().map(|face| match face {
-        Face::Triangle(f) => Some(UnpackedFace {
+        Face::Triangle(f) => UnpackedFace {
             vertices: (
                 g_1.vertices()[cast_usize(f.vertices.0)],
                 g_1.vertices()[cast_usize(f.vertices.1)],
@@ -195,11 +195,11 @@ pub fn are_visually_identical(g_1: &Geometry, g_2: &Geometry) -> bool {
                 g_1.normals()[cast_usize(f.normals.1)],
                 g_1.normals()[cast_usize(f.normals.2)],
             ),
-        }),
+        },
     });
 
     let mut unpacked_faces_2 = g_2.faces().iter().map(|face| match face {
-        Face::Triangle(f) => Some(UnpackedFace {
+        Face::Triangle(f) => UnpackedFace {
             vertices: (
                 g_2.vertices()[cast_usize(f.vertices.0)],
                 g_2.vertices()[cast_usize(f.vertices.1)],
@@ -210,7 +210,7 @@ pub fn are_visually_identical(g_1: &Geometry, g_2: &Geometry) -> bool {
                 g_2.normals()[cast_usize(f.normals.1)],
                 g_2.normals()[cast_usize(f.normals.2)],
             ),
-        }),
+        },
     });
 
     g_1.faces().len() == g_2.faces().len()

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -7,7 +7,7 @@ use crate::convert::{cast_i32, cast_usize};
 use crate::edge_analysis::EdgeSharingMap;
 use crate::geometry::{Face, Geometry, OrientedEdge, UnorientedEdge};
 
-/// Finds edges with a certain valency in a mesh edge collection 
+/// Finds edges with a certain valency in a mesh edge collection
 ///
 /// An edge valency indicates how many faces share the edge.
 fn find_edges_with_valency<'a>(
@@ -112,7 +112,7 @@ pub fn border_edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<UnorientedEdg
     edge_loops
 }
 
-/// Check if all the face normals point the same way. 
+/// Check if all the face normals point the same way
 ///
 /// In a proper watertight orientable mesh each oriented edge should have a
 /// single counterpart in a reverted oriented edge. In an open orientable mesh


### PR DESCRIPTION
Check if two mesh geometries are visually similar. They can differ in vertex and normal order and the start of face winding.