### PR TITLE
Stop Laplacian smoothing with anchors when the geometry becomes stable

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,18 +1,6 @@
 use std::convert::TryInto;
 use std::fmt::Debug;
 
-/// Convert `n` to `u8` using `TryFrom` or panic.
-///
-/// # Panics
-/// Panics if the conversion returns an error.
-pub fn cast_u8<T>(n: T) -> u8
-where
-    T: TryInto<u8>,
-    <T as TryInto<u8>>::Error: Debug,
-{
-    n.try_into().expect("Expected N to fit in u8")
-}
-
 /// Convert `n` to `u32` using `TryFrom` or panic.
 ///
 /// # Panics

--- a/src/interpreter_funcs.rs
+++ b/src/interpreter_funcs.rs
@@ -168,7 +168,7 @@ impl Func for FuncImplLaplacianSmoothing {
         let iterations = args[1].unwrap_uint();
         let vertex_to_vertex_topology = mesh_topology_analysis::vertex_to_vertex_topology(geometry);
 
-        let (g, _, _) = mesh_smoothing::laplacian_smoothing_with_anchors_full(
+        let (g, _, _) = mesh_smoothing::laplacian_smoothing(
             geometry,
             vertex_to_vertex_topology,
             cmp::min(255, iterations),

--- a/src/interpreter_funcs.rs
+++ b/src/interpreter_funcs.rs
@@ -170,7 +170,7 @@ impl Func for FuncImplLaplacianSmoothing {
         let (g, _, _) = mesh_smoothing::laplacian_smoothing_with_anchors_full(
             geometry,
             vertex_to_vertex_topology,
-            cast_u32(cmp::min(255, iterations)),
+            cmp::min(255, iterations),
             &[],
             false,
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,6 @@ pub use crate::renderer::{GpuBackend, Msaa, PresentMode};
 
 use std::time::{Duration, Instant};
 
-#[macro_use]
-extern crate approx;
-
 use nalgebra::geometry::Point3;
 
 use crate::camera::{Camera, CameraOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@ pub use crate::renderer::{GpuBackend, Msaa, PresentMode};
 
 use std::time::{Duration, Instant};
 
+#[macro_use]
+extern crate approx;
+
 use nalgebra::geometry::Point3;
 
 use crate::camera::{Camera, CameraOptions};

--- a/src/mesh_smoothing.rs
+++ b/src/mesh_smoothing.rs
@@ -32,7 +32,7 @@ use crate::geometry::Geometry;
 ///   iterations
 ///
 /// returns (smooth_geometry: Geometry, executed_iterations: u32, stable: bool)
-pub fn laplacian_smoothing_with_anchors_full(
+pub fn laplacian_smoothing(
     geometry: &Geometry,
     vertex_to_vertex_topology: HashMap<u32, SmallVec<[u32; 8]>>,
     iterations: u32,
@@ -438,27 +438,12 @@ mod tests {
 
         let vertex_to_vertex_topology =
             mesh_topology_analysis::vertex_to_vertex_topology(&geometry);
-        let (relaxed_geometry_0, _, _) = laplacian_smoothing_with_anchors_full(
-            &geometry,
-            vertex_to_vertex_topology.clone(),
-            0,
-            &[],
-            false,
-        );
-        let (relaxed_geometry_1, _, _) = laplacian_smoothing_with_anchors_full(
-            &geometry,
-            vertex_to_vertex_topology.clone(),
-            1,
-            &[],
-            false,
-        );
-        let (relaxed_geometry_10, _, _) = laplacian_smoothing_with_anchors_full(
-            &geometry,
-            vertex_to_vertex_topology.clone(),
-            10,
-            &[],
-            false,
-        );
+        let (relaxed_geometry_0, _, _) =
+            laplacian_smoothing(&geometry, vertex_to_vertex_topology.clone(), 0, &[], false);
+        let (relaxed_geometry_1, _, _) =
+            laplacian_smoothing(&geometry, vertex_to_vertex_topology.clone(), 1, &[], false);
+        let (relaxed_geometry_10, _, _) =
+            laplacian_smoothing(&geometry, vertex_to_vertex_topology.clone(), 10, &[], false);
 
         assert_eq!(relaxed_geometry_0.faces().len(), geometry.faces().len(),);
         assert_eq!(relaxed_geometry_1.faces().len(), geometry.faces().len(),);
@@ -508,27 +493,12 @@ mod tests {
 
         let vertex_to_vertex_topology =
             mesh_topology_analysis::vertex_to_vertex_topology(&geometry);
-        let (relaxed_geometry_0_i, _, _) = laplacian_smoothing_with_anchors_full(
-            &geometry,
-            vertex_to_vertex_topology.clone(),
-            0,
-            &[],
-            false,
-        );
-        let (relaxed_geometry_1_i, _, _) = laplacian_smoothing_with_anchors_full(
-            &geometry,
-            vertex_to_vertex_topology.clone(),
-            1,
-            &[],
-            false,
-        );
-        let (relaxed_geometry_3_i, _, _) = laplacian_smoothing_with_anchors_full(
-            &geometry,
-            vertex_to_vertex_topology.clone(),
-            3,
-            &[],
-            false,
-        );
+        let (relaxed_geometry_0_i, _, _) =
+            laplacian_smoothing(&geometry, vertex_to_vertex_topology.clone(), 0, &[], false);
+        let (relaxed_geometry_1_i, _, _) =
+            laplacian_smoothing(&geometry, vertex_to_vertex_topology.clone(), 1, &[], false);
+        let (relaxed_geometry_3_i, _, _) =
+            laplacian_smoothing(&geometry, vertex_to_vertex_topology.clone(), 3, &[], false);
 
         let relaxed_geometry_0_i_faces = relaxed_geometry_0_i.faces();
         let relaxed_geometry_1_i_faces = relaxed_geometry_1_i.faces();
@@ -601,7 +571,7 @@ mod tests {
 
         let vertex_to_vertex_topology =
             mesh_topology_analysis::vertex_to_vertex_topology(&geometry);
-        let (relaxed_geometry, _, _) = laplacian_smoothing_with_anchors_full(
+        let (relaxed_geometry, _, _) = laplacian_smoothing(
             &geometry,
             vertex_to_vertex_topology,
             50,
@@ -652,7 +622,7 @@ mod tests {
             );
         let vertex_to_vertex_topology =
             mesh_topology_analysis::vertex_to_vertex_topology(&geometry);
-        let (relaxed_geometry, _, _) = laplacian_smoothing_with_anchors_full(
+        let (relaxed_geometry, _, _) = laplacian_smoothing(
             &geometry,
             vertex_to_vertex_topology,
             50,
@@ -701,7 +671,7 @@ mod tests {
 
         let vertex_to_vertex_topology =
             mesh_topology_analysis::vertex_to_vertex_topology(&geometry);
-        let (relaxed_geometry, _, _) = laplacian_smoothing_with_anchors_full(
+        let (relaxed_geometry, _, _) = laplacian_smoothing(
             &geometry,
             vertex_to_vertex_topology,
             255,

--- a/src/mesh_smoothing.rs
+++ b/src/mesh_smoothing.rs
@@ -1,6 +1,6 @@
 use nalgebra::geometry::Point3;
 
-use crate::convert::{cast_u32, cast_usize};
+use crate::convert::cast_usize;
 use crate::geometry::Geometry;
 use crate::mesh_topology_analysis::vertex_to_vertex_topology;
 
@@ -77,7 +77,6 @@ fn laplacian_smoothing_with_anchors_full(
     if max_iterations == 0 {
         return geometry.clone();
     }
-    println!("Stop when stable: {}", stop_when_stable);
 
     let vertex_to_vertex_topology = vertex_to_vertex_topology(geometry);
     let mut vertices: Vec<Point3<f32>> = Vec::from(geometry.vertices());
@@ -92,7 +91,7 @@ fn laplacian_smoothing_with_anchors_full(
         for (current_vertex_index, neighbors_indices) in vertex_to_vertex_topology.iter() {
             if fixed_vertex_indices
                 .iter()
-                .all(|i| *i != cast_u32(*current_vertex_index))
+                .all(|i| i != current_vertex_index)
                 && !neighbors_indices.is_empty()
             {
                 let mut average_position: Point3<f32> = Point3::origin();
@@ -101,7 +100,7 @@ fn laplacian_smoothing_with_anchors_full(
                 }
                 average_position /= neighbors_indices.len() as f32;
                 if stop_when_stable {
-                    stable &= relative_eq!(
+                    stable &= approx::relative_eq!(
                         &average_position.coords,
                         &vertices[cast_usize(*current_vertex_index)].coords,
                     );

--- a/src/mesh_smoothing.rs
+++ b/src/mesh_smoothing.rs
@@ -5,7 +5,6 @@ use smallvec::SmallVec;
 
 use crate::convert::cast_usize;
 use crate::geometry::Geometry;
-use crate::mesh_topology_analysis;
 
 /// Relaxes angles between mesh edges, resulting in a smoother geometry
 ///
@@ -101,6 +100,7 @@ mod tests {
     use crate::edge_analysis;
     use crate::geometry::{Geometry, NormalStrategy, OrientedEdge, Vertices};
     use crate::mesh_analysis;
+    use crate::mesh_topology_analysis;
 
     use super::*;
 


### PR DESCRIPTION
The Laplacian smoothing with anchors can be used to paramterize a mesh patch into a flat disc. Once the edge loop is transformed into the circumference of the target disc, the iterative algorithm of Laplacian smoothing is applied until the mesh reaches a stable spatial configuration.

This function will be later used in more complex operations, therefore it's not exposed as a distinct operation.