### PR TITLE
Distinct between identical, similar and visually similar mesh geometries

### DIFF
--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -149,19 +149,54 @@ pub fn triangulated_mesh_genus(vertex_count: usize, edge_count: usize, face_coun
     1 - (cast_i32(vertex_count) - cast_i32(edge_count) + cast_i32(face_count)) / 2
 }
 
-/// Checks if two geometries are visually identical
+/// Checks if two geometries are similar
 ///
-/// Two mesh geometries are identical when the position of each vertex in one
-/// mesh geometry matches a position of exactly one vertex in the other mesh
-/// geometry, when the direction of each normal in one mesh geometry matches a
-/// direction of exactly one normal in the other mesh geometry and each face in
-/// one mesh geometry refers vertices with the same position and normals with
-/// the same direction, both in the same circular order, as exactly one face in
-/// the other mesh geometry. The indices (order in which they are stored) of
-/// vertices, normals and faces can differ but as long as the previous
-/// conditions are met, the mesh geometries are identical.
+/// Two mesh geometries are similar when the position of each vertex in one mesh
+/// geometry matches a position of some vertex in the other mesh geometry, when
+/// the direction of each normal in one mesh geometry matches a direction of
+/// some normal in the other mesh geometry and each face in one mesh geometry
+/// refers vertices with the same position and normals with the same direction,
+/// both in the same circular order, as exactly one face in the other mesh
+/// geometry.
+///
+/// The indices (order in which they are stored) of vertices, normals and faces
+/// can differ but as long as the previous conditions are met, and the count of
+/// vertices, normals and faces are identical, the mesh geometries are similar.
+///
+/// The mesh geometries are not necessarily identical in the memory but they
+/// look the same and are treated the same by all functions of this software and
+/// all their transformations result in similar mesh geometries.
 #[allow(dead_code)]
-pub fn are_visually_identical(g_1: &Geometry, g_2: &Geometry) -> bool {
+pub fn are_similar(geometry_1: &Geometry, geometry_2: &Geometry) -> bool {
+    geometry_1.vertices().len() == geometry_2.vertices().len()
+        && geometry_1.normals().len() == geometry_2.normals().len()
+        && are_visually_similar(geometry_1, geometry_2)
+}
+
+/// Checks if two geometries are visually similar
+///
+/// Two mesh geometries are visually similar when the position of each vertex in
+/// one mesh geometry matches a position of some vertex in the other mesh
+/// geometry, when the direction of each normal in one mesh geometry matches a
+/// direction of some normal in the other mesh geometry and each face in one
+/// mesh geometry refers vertices with the same position and normals with the
+/// same direction, both in the same circular order, as exactly one face in the
+/// other mesh geometry.
+///
+/// The indices (order in which they are stored) of vertices, normals and faces
+/// can differ but as long as the previous conditions are met, the mesh
+/// geometries are similar. It is not necessary that the count of vertices and
+/// normals are identical, because one mesh may reuse (share) vertices and
+/// normals in more faces and the other doesn't (applies to all or some faces).
+///
+/// They mesh geometries are not necessarily identical in the memory but they
+/// look the same. If the number of vertices differs, the mesh geometries don't
+/// share the same qualities (they are not welded in the same places and at
+/// least one of them is not watertight) are not going to be treated the same by
+/// some functions of this software and all their transformations result in
+/// different mesh geometries.
+#[allow(dead_code)]
+pub fn are_visually_similar(geometry_1: &Geometry, geometry_2: &Geometry) -> bool {
     struct UnpackedFace {
         vertices: (Point3<f32>, Point3<f32>, Point3<f32>),
         normals: (Vector3<f32>, Vector3<f32>, Vector3<f32>),
@@ -190,39 +225,37 @@ pub fn are_visually_identical(g_1: &Geometry, g_2: &Geometry) -> bool {
         }
     }
 
-    let mut unpacked_faces_1 = g_1.faces().iter().map(|face| match face {
+    let mut unpacked_faces_1 = geometry_1.faces().iter().map(|face| match face {
         Face::Triangle(f) => UnpackedFace {
             vertices: (
-                g_1.vertices()[cast_usize(f.vertices.0)],
-                g_1.vertices()[cast_usize(f.vertices.1)],
-                g_1.vertices()[cast_usize(f.vertices.2)],
+                geometry_1.vertices()[cast_usize(f.vertices.0)],
+                geometry_1.vertices()[cast_usize(f.vertices.1)],
+                geometry_1.vertices()[cast_usize(f.vertices.2)],
             ),
             normals: (
-                g_1.normals()[cast_usize(f.normals.0)],
-                g_1.normals()[cast_usize(f.normals.1)],
-                g_1.normals()[cast_usize(f.normals.2)],
+                geometry_1.normals()[cast_usize(f.normals.0)],
+                geometry_1.normals()[cast_usize(f.normals.1)],
+                geometry_1.normals()[cast_usize(f.normals.2)],
             ),
         },
     });
 
-    let mut unpacked_faces_2 = g_2.faces().iter().map(|face| match face {
+    let mut unpacked_faces_2 = geometry_2.faces().iter().map(|face| match face {
         Face::Triangle(f) => UnpackedFace {
             vertices: (
-                g_2.vertices()[cast_usize(f.vertices.0)],
-                g_2.vertices()[cast_usize(f.vertices.1)],
-                g_2.vertices()[cast_usize(f.vertices.2)],
+                geometry_2.vertices()[cast_usize(f.vertices.0)],
+                geometry_2.vertices()[cast_usize(f.vertices.1)],
+                geometry_2.vertices()[cast_usize(f.vertices.2)],
             ),
             normals: (
-                g_2.normals()[cast_usize(f.normals.0)],
-                g_2.normals()[cast_usize(f.normals.1)],
-                g_2.normals()[cast_usize(f.normals.2)],
+                geometry_2.normals()[cast_usize(f.normals.0)],
+                geometry_2.normals()[cast_usize(f.normals.1)],
+                geometry_2.normals()[cast_usize(f.normals.2)],
             ),
         },
     });
 
-    g_1.faces().len() == g_2.faces().len()
-        && g_1.vertices().len() == g_2.vertices().len()
-        && g_1.normals().len() == g_2.normals().len()
+    geometry_1.faces().len() == geometry_2.faces().len()
         && unpacked_faces_1.all(|f| unpacked_faces_2.any(|g| f == g))
 }
 
@@ -277,6 +310,31 @@ mod tests {
         ];
 
         let faces = vec![TriangleFace::new(0, 1, 2), TriangleFace::new(2, 3, 0)];
+
+        Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
+    }
+
+    pub fn quad_not_watertight_with_normals() -> Geometry {
+        let vertices = vec![
+            v(-1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
+            v(1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
+            v(1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
+            v(1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
+            v(-1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
+        ];
+
+        let vertex_normals = vec![
+            n(-1.0, -1.0, 1.0),
+            n(-1.0, -1.0, 1.0),
+            n(1.0, -1.0, 1.0),
+            n(1.0, 1.0, 1.0),
+            n(-1.0, 1.0, 1.0),
+        ];
+
+        let faces = vec![
+            TriangleFace::new_separate(0, 1, 2, 1, 2, 3),
+            TriangleFace::new_separate(3, 4, 0, 3, 4, 0),
+        ];
 
         Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
     }
@@ -946,7 +1004,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mesh_analysis_are_visually_identical_returns_true_for_same() {
+    fn test_mesh_analysis_are_similar_returns_true_for_same() {
         let (faces, vertices) = quad();
         let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
             faces.clone(),
@@ -954,19 +1012,35 @@ mod tests {
             NormalStrategy::Sharp,
         );
 
-        assert!(are_visually_identical(&geometry, &geometry));
+        assert!(are_similar(&geometry, &geometry));
     }
 
     #[test]
-    fn test_mesh_analysis_are_visually_identical_returns_true_for_renumbered() {
+    fn test_mesh_analysis_are_similar_returns_true_for_renumbered() {
         let geometry = quad_with_normals();
         let geometry_r = quad_renumbered_with_normals();
 
-        assert!(are_visually_identical(&geometry, &geometry_r));
+        assert!(are_similar(&geometry, &geometry_r));
     }
 
     #[test]
-    fn test_mesh_analysis_are_visually_identical_returns_false_for_different() {
+    fn test_mesh_analysis_are_visually_similar_returns_true_for_not_watertight() {
+        let geometry = quad_with_normals();
+        let geometry_not_watertight = quad_not_watertight_with_normals();
+
+        assert!(are_visually_similar(&geometry, &geometry_not_watertight));
+    }
+
+    #[test]
+    fn test_mesh_analysis_are_similar_returns_false_for_not_watertight() {
+        let geometry = quad_with_normals();
+        let geometry_not_watertight = quad_not_watertight_with_normals();
+
+        assert!(!are_similar(&geometry, &geometry_not_watertight));
+    }
+
+    #[test]
+    fn test_mesh_analysis_are_similar_returns_false_for_different() {
         let geometry = quad_with_normals();
         let (faces_d, vertices_d) = tessellated_triangle();
         let geometry_d = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
@@ -975,6 +1049,6 @@ mod tests {
             NormalStrategy::Sharp,
         );
 
-        assert!(!are_visually_identical(&geometry, &geometry_d));
+        assert!(!are_similar(&geometry, &geometry_d));
     }
 }

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -163,9 +163,9 @@ pub fn triangulated_mesh_genus(vertex_count: usize, edge_count: usize, face_coun
 /// can differ but as long as the previous conditions are met, and the count of
 /// vertices, normals and faces are identical, the mesh geometries are similar.
 ///
-/// The mesh geometries are not necessarily identical in the memory but they
-/// look the same and are treated the same by all functions of this software and
-/// all their transformations result in similar mesh geometries.
+/// The mesh geometries are not necessarily identical in memory but they look
+/// the same and are treated the same by all functions of this software and all
+/// their transformations result in similar mesh geometries.
 #[allow(dead_code)]
 pub fn are_similar(geometry_1: &Geometry, geometry_2: &Geometry) -> bool {
     geometry_1.vertices().len() == geometry_2.vertices().len()
@@ -189,12 +189,12 @@ pub fn are_similar(geometry_1: &Geometry, geometry_2: &Geometry) -> bool {
 /// normals are identical, because one mesh may reuse (share) vertices and
 /// normals in more faces and the other doesn't (applies to all or some faces).
 ///
-/// They mesh geometries are not necessarily identical in the memory but they
-/// look the same. If the number of vertices differs, the mesh geometries don't
-/// share the same qualities (they are not welded in the same places and at
-/// least one of them is not watertight) are not going to be treated the same by
-/// some functions of this software and all their transformations result in
-/// different mesh geometries.
+/// They mesh geometries are not necessarily identical in memory but they look
+/// the same. If the number of vertices differs, the mesh geometries don't share
+/// the same qualities (they are not welded in the same places and at least one
+/// of them is not watertight) are not going to be treated the same by some
+/// functions of this software and all their transformations result in different
+/// mesh geometries.
 #[allow(dead_code)]
 pub fn are_visually_similar(geometry_1: &Geometry, geometry_2: &Geometry) -> bool {
     struct UnpackedFace {
@@ -314,18 +314,18 @@ mod tests {
         Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
     }
 
-    pub fn quad_not_watertight_with_normals() -> Geometry {
+    pub fn quad_with_extra_vertices_and_normals() -> Geometry {
         let vertices = vec![
             v(-1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
             v(1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
-            v(1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
-            v(1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
+            v(1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0), // first copy of the same vertex
+            v(1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0), // second copy of the same vertex
             v(-1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0),
         ];
 
         let vertex_normals = vec![
-            n(-1.0, -1.0, 1.0),
-            n(-1.0, -1.0, 1.0),
+            n(-1.0, -1.0, 1.0), // first copy of the same normal
+            n(-1.0, -1.0, 1.0), // second copy of the same normal
             n(1.0, -1.0, 1.0),
             n(1.0, 1.0, 1.0),
             n(-1.0, 1.0, 1.0),
@@ -1026,7 +1026,7 @@ mod tests {
     #[test]
     fn test_mesh_analysis_are_visually_similar_returns_true_for_not_watertight() {
         let geometry = quad_with_normals();
-        let geometry_not_watertight = quad_not_watertight_with_normals();
+        let geometry_not_watertight = quad_with_extra_vertices_and_normals();
 
         assert!(are_visually_similar(&geometry, &geometry_not_watertight));
     }
@@ -1034,7 +1034,7 @@ mod tests {
     #[test]
     fn test_mesh_analysis_are_similar_returns_false_for_not_watertight() {
         let geometry = quad_with_normals();
-        let geometry_not_watertight = quad_not_watertight_with_normals();
+        let geometry_not_watertight = quad_with_extra_vertices_and_normals();
 
         assert!(!are_similar(&geometry, &geometry_not_watertight));
     }


### PR DESCRIPTION
This is a more rigorous comparison of two mesh geometries.

Let's consider two mesh geometries IDENTICAL when the data structure looks the same and they look the same in the memory. A simple Eq function should suffice for this comparison.

Let's consider two mesh geometries SIMILAR when they look exaclty the same, have the same features and behave the same but don't necesarilly look the same in memory. Such mesh geometries share the same count of vertices, normals and faces but they can be sotred in different orders. Faces may reference the vertices in different order but identical winding (0->1->2 = 1->2->0 = 2->0->1).

Let's consider two mesh geometries VISUALLY SIMILAR when they look exaclty the same, but neither necesarilly have the same features, nor behave the same, nor look the same in memory. This is usually the case when faces don't reuse (share) the same vertex more times but rather reference an individual vertex with the same coordinates for each of the faces. This can be the case for all the faces/vertices or just some. Such meshes look exactly the same but they are treated differently by this software's functions and have different features - usually at least one of them is not watertight. Not reusing normals doesn't result in different behavior or features but for the sake of this distinction two meshes with different counts of normals are also considered VISUALLY SIMILAR but not SIMILAR.

This distinction is important when using some of our mesh tools. separate_isolated_meshes applied to a mesh geometry, which consists of two or more isolated chunks sharing the same normals, yields two geometires with some of the normals copied to both geometries. Using join_meshes on these separated chings later on doesn't yield the original mesh but rather one with the originally shared normals now copied as individual elemnts referenced by only one chunk. Such joined mesh is VISUALLY SIMILAR to the original one but is not SIMILAR. The same would apply to vertices when a mesh geometry is being chopped into more pieces and then joined again or to unwelded and welded versions of the same geometry.