### PR TITLE
Operation/join meshes

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -89,15 +89,15 @@ impl Geometry {
 
                             assert!(
                                 vertices_range.contains(&v1),
-                                "Faces reference out of bounds position data: Vertex 1 at from_triangle_faces_with_vertices_and_computed_normals"
+                                "Faces reference out of bounds position data"
                             );
                             assert!(
                                 vertices_range.contains(&v2),
-                                "Faces reference out of bounds position data: Vertex 2 at from_triangle_faces_with_vertices_and_computed_normals"
+                                "Faces reference out of bounds position data"
                             );
                             assert!(
                                 vertices_range.contains(&v3),
-                                "Faces reference out of bounds position data: Vertex 3 at from_triangle_faces_with_vertices_and_computed_normals"
+                                "Faces reference out of bounds position data"
                             );
 
                             let face_normal = compute_triangle_normal(
@@ -222,15 +222,15 @@ impl Geometry {
                     let n = triangle_face.normals;
                     assert!(
                         vertices_range.contains(&v.0),
-                        "Faces reference out of bounds position data: Vertex 1 at from_faces_with_vertices_and_normals"
+                        "Faces reference out of bounds position data"
                     );
                     assert!(
                         vertices_range.contains(&v.1),
-                        "Faces reference out of bounds position data: Vertex 2 at from_faces_with_vertices_and_normals"
+                        "Faces reference out of bounds position data"
                     );
                     assert!(
                         vertices_range.contains(&v.2),
-                        "Faces reference out of bounds position data: Vertex 3 at from_faces_with_vertices_and_normals"
+                        "Faces reference out of bounds position data"
                     );
                     assert!(
                         normals_range.contains(&n.0),
@@ -1268,9 +1268,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "Faces reference out of bounds position data: Vertex 3 at from_triangle_faces_with_vertices_and_computed_normals"
-    )]
+    #[should_panic(expected = "Faces reference out of bounds position data")]
     fn test_geometry_from_triangle_faces_with_vertices_and_computed_normals_bounds_check() {
         let (_, vertices) = quad();
         #[rustfmt::skip]
@@ -1311,9 +1309,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "Faces reference out of bounds position data: Vertex 3 at from_faces_with_vertices_and_normals"
-    )]
+    #[should_panic(expected = "Faces reference out of bounds position data")]
     fn test_geometry_from_triangle_faces_with_vertices_and_normals_bounds_check() {
         let (_, vertices, normals) = quad_with_normals();
         #[rustfmt::skip]

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -371,17 +371,23 @@ impl fmt::Display for Geometry {
             .enumerate()
             .map(|(i, f)| format!("{}: {}", i, f))
             .collect();
-        // TODO: Display vectors properly
+        let normals: Vec<_> = self
+            .normals
+            .iter()
+            .enumerate()
+            .map(|(i, n)| format!("{}: ({}, {}, {})", i, n.x, n.y, n.z))
+            .collect();
         write!(
             f,
             "Vertex count: {}, Normal count: {}, Face count: {}\n\
              Vertices: {:?}\n\
-             Normals not formatted yet\n\
+             Normals: {:?}\n\
              Faces: {:?}",
             self.vertices.len(),
             self.normals.len(),
             self.faces.len(),
             vertices,
+            normals,
             faces,
         )
     }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -358,7 +358,7 @@ impl Geometry {
 }
 
 impl fmt::Display for Geometry {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let vertices: Vec<_> = self
             .vertices
             .iter()
@@ -379,15 +379,12 @@ impl fmt::Display for Geometry {
             .collect();
         write!(
             f,
-            "Vertex count: {}, Normal count: {}, Face count: {}\n\
-             Vertices: {:?}\n\
-             Normals: {:?}\n\
-             Faces: {:?}",
+            "G( V({}): {:?}, N({}): {:?}, F({}): {:?} )",
             self.vertices.len(),
-            self.normals.len(),
-            self.faces.len(),
             vertices,
+            self.normals.len(),
             normals,
+            self.faces.len(),
             faces,
         )
     }
@@ -406,9 +403,9 @@ impl From<TriangleFace> for Face {
 }
 
 impl fmt::Display for Face {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Face::Triangle(face) => write!(f, "T({})", face),
+            Face::Triangle(face) => write!(f, "{}", face),
         }
     }
 }
@@ -490,10 +487,10 @@ impl From<(u32, u32, u32)> for TriangleFace {
 }
 
 impl fmt::Display for TriangleFace {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "V: ({}, {}, {}); N: ({}, {}, {})",
+            "T(V: ({}, {}, {}); N: ({}, {}, {}))",
             self.vertices.0,
             self.vertices.1,
             self.vertices.2,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -88,15 +88,15 @@ impl Geometry {
 
                             assert!(
                                 vertices_range.contains(&v1),
-                                "Faces reference out of bounds position data"
+                                "Faces reference out of bounds position data: Vertex 1 at from_triangle_faces_with_vertices_and_computed_normals"
                             );
                             assert!(
                                 vertices_range.contains(&v2),
-                                "Faces reference out of bounds position data"
+                                "Faces reference out of bounds position data: Vertex 2 at from_triangle_faces_with_vertices_and_computed_normals"
                             );
                             assert!(
                                 vertices_range.contains(&v3),
-                                "Faces reference out of bounds position data"
+                                "Faces reference out of bounds position data: Vertex 3 at from_triangle_faces_with_vertices_and_computed_normals"
                             );
 
                             let face_normal = compute_triangle_normal(
@@ -221,15 +221,15 @@ impl Geometry {
                     let n = triangle_face.normals;
                     assert!(
                         vertices_range.contains(&v.0),
-                        "Faces reference out of bounds position data"
+                        "Faces reference out of bounds position data: Vertex 1 at from_faces_with_vertices_and_normals"
                     );
                     assert!(
                         vertices_range.contains(&v.1),
-                        "Faces reference out of bounds position data"
+                        "Faces reference out of bounds position data: Vertex 2 at from_faces_with_vertices_and_normals"
                     );
                     assert!(
                         vertices_range.contains(&v.2),
-                        "Faces reference out of bounds position data"
+                        "Faces reference out of bounds position data: Vertex 3 at from_faces_with_vertices_and_normals"
                     );
                     assert!(
                         normals_range.contains(&n.0),
@@ -1211,7 +1211,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Faces reference out of bounds position data")]
+    #[should_panic(
+        expected = "Faces reference out of bounds position data: Vertex 3 at from_triangle_faces_with_vertices_and_computed_normals"
+    )]
     fn test_geometry_from_triangle_faces_with_vertices_and_computed_normals_bounds_check() {
         let (_, vertices) = quad();
         #[rustfmt::skip]
@@ -1252,7 +1254,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Faces reference out of bounds position data")]
+    #[should_panic(
+        expected = "Faces reference out of bounds position data: Vertex 3 at from_faces_with_vertices_and_normals"
+    )]
     fn test_geometry_from_triangle_faces_with_vertices_and_normals_bounds_check() {
         let (_, vertices, normals) = quad_with_normals();
         #[rustfmt::skip]

--- a/src/interpreter_funcs.rs
+++ b/src/interpreter_funcs.rs
@@ -178,7 +178,7 @@ impl Func for FuncImplLaplacianSmoothing {
 pub struct FuncImplSeparateIsolatedMeshes;
 impl Func for FuncImplSeparateIsolatedMeshes {
     fn flags(&self) -> FuncFlags {
-        FuncFlags::PURE
+        FuncFlags::empty()
     }
     fn param_info(&self) -> &[ParamInfo] {
         &[ParamInfo {

--- a/src/interpreter_funcs.rs
+++ b/src/interpreter_funcs.rs
@@ -201,6 +201,38 @@ impl Func for FuncImplSeparateIsolatedMeshes {
     }
 }
 
+pub struct FuncImplJoinMeshes;
+impl Func for FuncImplJoinMeshes {
+    fn flags(&self) -> FuncFlags {
+        FuncFlags::PURE
+    }
+    fn param_info(&self) -> &[ParamInfo] {
+        &[
+            ParamInfo {
+                ty: Ty::Geometry,
+                optional: false,
+            },
+            ParamInfo {
+                ty: Ty::Geometry,
+                optional: false,
+            },
+        ]
+    }
+
+    fn return_ty(&self) -> Ty {
+        Ty::Geometry
+    }
+
+    fn call(&self, args: &[Value]) -> Value {
+        let first_geometry = args[0].unwrap_geometry();
+        let second_geometry = args[1].unwrap_geometry();
+
+        let value = mesh_tools::join_meshes(first_geometry, second_geometry);
+
+        Value::Geometry(Arc::new(value))
+    }
+}
+
 // IMPORTANT: Do not change these IDs, ever! When adding a new
 // function, always create a new, unique function identifier for it.
 
@@ -209,6 +241,7 @@ pub const FUNC_ID_SHRINK_WRAP: FuncIdent = FuncIdent(1);
 pub const FUNC_ID_TRANSFORM: FuncIdent = FuncIdent(2);
 pub const FUNC_ID_LAPLACIAN_SMOOTHING: FuncIdent = FuncIdent(3);
 pub const FUNC_ID_SEPARATE_ISOLATED_MESHES: FuncIdent = FuncIdent(4);
+pub const FUNC_ID_JOIN_MESHES: FuncIdent = FuncIdent(5);
 
 /// The global set of function definitions available to the
 /// interpreter and it's clients.
@@ -226,6 +259,7 @@ pub fn global_definitions() -> HashMap<FuncIdent, Box<dyn Func>> {
         FUNC_ID_SEPARATE_ISOLATED_MESHES,
         Box::new(FuncImplSeparateIsolatedMeshes),
     );
+    funcs.insert(FUNC_ID_JOIN_MESHES, Box::new(FuncImplJoinMeshes));
 
     funcs
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod interpreter_funcs;
 mod interpreter_server;
 mod math;
 mod mesh_analysis;
+mod mesh_tools;
 mod mesh_topology_analysis;
 mod platform;
 mod ui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub struct Options {
 
 /// Initialize the window and run in infinite loop.
 ///
-/// Will continue running until a close request is recieved from the
+/// Will continue running until a close request is received from the
 /// created window.
 pub fn init_and_run(options: Options) -> ! {
     let event_loop = winit::event_loop::EventLoop::new();
@@ -394,7 +394,7 @@ pub fn init_and_run(options: Options) -> ! {
                 //
                 // 2) ImGui produces a draw list with `render()`. The
                 //    drawlist shares the lifetime of the `Ui` frame
-                //    contex, which is dropped at the end of "events
+                //    context, which is dropped at the end of "events
                 //    cleared". We could copy the draw list and stash
                 //    it for our subsequent handling of redraw
                 //    requests, but it contains raw pointers to the

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -301,6 +301,26 @@ mod tests {
         Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
     }
 
+    pub fn quad_renumbered_more_with_normals() -> Geometry {
+        let vertices = vec![
+            v(1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0),  //1
+            v(-1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0),  //3
+            v(-1.0, -1.0, 0.0, [0.0, 0.0, 0.0], 1.0), //0
+            v(1.0, 1.0, 0.0, [0.0, 0.0, 0.0], 1.0),   //2
+        ];
+
+        let vertex_normals = vec![
+            n(1.0, -1.0, 1.0),  //1
+            n(-1.0, 1.0, 1.0),  //3
+            n(-1.0, -1.0, 1.0), //0
+            n(1.0, 1.0, 1.0),   //2
+        ];
+
+        let faces = vec![TriangleFace::new(2, 0, 3), TriangleFace::new(2, 3, 1)];
+
+        Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
+    }
+
     fn torus() -> (Vec<(u32, u32, u32)>, Vertices) {
         let vertices = vec![
             Point3::new(0.566987, -1.129e-11, 0.25),
@@ -961,6 +981,14 @@ mod tests {
     fn test_mesh_analysis_are_visually_identical_returns_true_for_renumbered() {
         let geometry = quad_with_normals();
         let geometry_r = quad_renumbered_with_normals();
+
+        assert!(are_visually_identical(&geometry, &geometry_r));
+    }
+
+    #[test]
+    fn test_mesh_analysis_are_visually_identical_returns_true_for_renumbered_more() {
+        let geometry = quad_with_normals();
+        let geometry_r = quad_renumbered_more_with_normals();
 
         assert!(are_visually_identical(&geometry, &geometry_r));
     }

--- a/src/mesh_analysis.rs
+++ b/src/mesh_analysis.rs
@@ -205,7 +205,7 @@ pub fn are_visually_identical(g_1: &Geometry, g_2: &Geometry) -> bool {
         },
     });
 
-    let mut unpacked_faces_2 = g_2.faces().iter().map(|face| match face {
+    let unpacked_faces_2 = g_2.faces().iter().map(|face| match face {
         Face::Triangle(f) => UnpackedFace {
             vertices: (
                 g_2.vertices()[cast_usize(f.vertices.0)],
@@ -223,7 +223,7 @@ pub fn are_visually_identical(g_1: &Geometry, g_2: &Geometry) -> bool {
     g_1.faces().len() == g_2.faces().len()
         && g_1.vertices().len() == g_2.vertices().len()
         && g_1.normals().len() == g_2.normals().len()
-        && unpacked_faces_1.all(|f| unpacked_faces_2.any(|g| f == g))
+        && unpacked_faces_1.all(|f| unpacked_faces_2.clone().any(|g| f == g))
 }
 
 #[cfg(test)]

--- a/src/mesh_tools.rs
+++ b/src/mesh_tools.rs
@@ -6,72 +6,32 @@ use crate::convert::{cast_u32, cast_usize};
 use crate::geometry::Geometry;
 use crate::mesh_topology_analysis::face_to_face_topology;
 
-fn crawl_faces(
-    current_face_index: u32,
-    face_to_face: &HashMap<u32, SmallVec<[u32; 8]>>,
-    available_faces: &mut Vec<u32>,
-    separate_faces: &mut Vec<u32>,
-) {
-    separate_faces.push(current_face_index);
-
-    if let Some(all_neighbors) = face_to_face.get(&current_face_index) {
-        let neighbors: Vec<u32> = all_neighbors
-            .iter()
-            .copied()
-            .filter(|n| available_faces.iter().any(|a_f| a_f == n))
-            .collect();
-        let af: Vec<_> = available_faces
-            .iter()
-            .copied()
-            .filter(|f| neighbors.iter().all(|n| n != f))
-            .collect();
-        *available_faces = af;
-        for neighbor_index in neighbors {
-            crawl_faces(
-                neighbor_index,
-                face_to_face,
-                available_faces,
-                separate_faces,
-            );
-        }
-    }
-}
-
 /// Crawls the geometry to find continuous patches of geometry.
 /// Returns a vector of new separated geometries.
 #[allow(dead_code)]
 pub fn separate_isolated_meshes(geometry: &Geometry) -> Vec<Geometry> {
     let face_to_face = face_to_face_topology(geometry);
-    let faces = geometry.faces();
-    let vertices: Vec<_> = geometry.vertices().to_vec();
-    let normals: Vec<_> = geometry.normals().to_vec();
-
-    let mut available_faces: Vec<u32> = face_to_face.keys().map(|key| cast_u32(*key)).collect();
-
+    let mut available_face_indices: Vec<u32> =
+        face_to_face.keys().map(|key| cast_u32(*key)).collect();
     let mut patches: Vec<Geometry> = Vec::new();
 
-    while !available_faces.is_empty() {
-        let mut separate_faces: Vec<u32> = Vec::new();
+    while let Some(first_face_index) = available_face_indices.pop() {
+        let mut separate_face_indices: Vec<u32> = Vec::new();
 
-        if let Some(first_face_index) = available_faces.pop() {
-            crawl_faces(
-                first_face_index,
-                &face_to_face,
-                &mut available_faces,
-                &mut separate_faces,
-            );
-        }
-
-        let faces: Vec<_> = separate_faces
-            .iter()
-            .map(|face_index| faces[cast_usize(*face_index)])
-            .collect();
+        crawl_faces(
+            first_face_index,
+            &face_to_face,
+            &mut available_face_indices,
+            &mut separate_face_indices,
+        );
 
         patches.push(
             Geometry::from_faces_with_vertices_and_normals_remove_orphans(
-                faces,
-                vertices.clone(),
-                normals.clone(),
+                separate_face_indices
+                    .iter()
+                    .map(|face_index| geometry.faces()[cast_usize(*face_index)]),
+                geometry.vertices().to_vec(),
+                geometry.normals().to_vec(),
             ),
         );
     }
@@ -79,23 +39,41 @@ pub fn separate_isolated_meshes(geometry: &Geometry) -> Vec<Geometry> {
     patches
 }
 
+fn crawl_faces(
+    current_face_index: u32,
+    face_to_face: &HashMap<u32, SmallVec<[u32; 8]>>,
+    available_face_indices: &mut Vec<u32>,
+    separate_face_indices: &mut Vec<u32>,
+) {
+    separate_face_indices.push(current_face_index);
+
+    if let Some(all_neighbors) = face_to_face.get(&current_face_index) {
+        let neighbors: Vec<_> = all_neighbors
+            .iter()
+            .copied()
+            .filter(|n| available_face_indices.iter().any(|a_f| a_f == n))
+            .collect();
+        available_face_indices.retain(|f| neighbors.iter().all(|n| n != f));
+        for neighbor_index in neighbors {
+            crawl_faces(
+                neighbor_index,
+                face_to_face,
+                available_face_indices,
+                separate_face_indices,
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use nalgebra::base::Vector3;
     use nalgebra::geometry::Point3;
 
-    use crate::geometry::{Geometry, TriangleFace};
+    use crate::geometry::{self, Geometry, TriangleFace};
     use crate::mesh_analysis;
 
     use super::*;
-
-    fn v(x: f32, y: f32, z: f32, translation: [f32; 3], scale: f32) -> Point3<f32> {
-        Point3::new(
-            scale * x + translation[0],
-            scale * y + translation[1],
-            scale * z + translation[2],
-        )
-    }
 
     fn n(x: f32, y: f32, z: f32) -> Vector3<f32> {
         Vector3::new(x, y, z)
@@ -163,63 +141,6 @@ mod tests {
         Geometry::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
     }
 
-    pub fn cube_sharp_var_len(position: [f32; 3], scale: f32) -> Geometry {
-        let vertex_positions = vec![
-            // back
-            v(-1.0, 1.0, -1.0, position, scale),
-            v(-1.0, 1.0, 1.0, position, scale),
-            v(1.0, 1.0, 1.0, position, scale),
-            v(1.0, 1.0, -1.0, position, scale),
-            // front
-            v(-1.0, -1.0, -1.0, position, scale),
-            v(1.0, -1.0, -1.0, position, scale),
-            v(1.0, -1.0, 1.0, position, scale),
-            v(-1.0, -1.0, 1.0, position, scale),
-        ];
-
-        let vertex_normals = vec![
-            // back
-            n(0.0, 1.0, 0.0),
-            // front
-            n(0.0, -1.0, 0.0),
-            // top
-            n(0.0, 0.0, 1.0),
-            // bottom
-            n(0.0, 0.0, -1.0),
-            // right
-            n(1.0, 0.0, 0.0),
-            // left
-            n(-1.0, 0.0, 0.0),
-        ];
-
-        let faces = vec![
-            // back
-            TriangleFace::new_separate(0, 1, 2, 0, 0, 0),
-            TriangleFace::new_separate(2, 3, 0, 0, 0, 0),
-            // front
-            TriangleFace::new_separate(4, 5, 6, 1, 1, 1),
-            TriangleFace::new_separate(6, 7, 4, 1, 1, 1),
-            // top
-            TriangleFace::new_separate(7, 6, 2, 2, 2, 2),
-            TriangleFace::new_separate(2, 1, 7, 2, 2, 2),
-            // bottom
-            TriangleFace::new_separate(4, 0, 3, 3, 3, 3),
-            TriangleFace::new_separate(3, 5, 4, 3, 3, 3),
-            // right
-            TriangleFace::new_separate(5, 3, 2, 4, 4, 4),
-            TriangleFace::new_separate(2, 6, 5, 4, 4, 4),
-            // left
-            TriangleFace::new_separate(4, 7, 1, 5, 5, 5),
-            TriangleFace::new_separate(1, 0, 4, 5, 5, 5),
-        ];
-
-        Geometry::from_triangle_faces_with_vertices_and_normals(
-            faces,
-            vertex_positions,
-            vertex_normals,
-        )
-    }
-
     #[test]
     fn test_separate_isolated_meshes_returns_identical_for_tessellated_triangle() {
         let geometry = tessellated_triangle_geometry();
@@ -236,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_separate_isolated_meshes_returns_identical_for_cube() {
-        let geometry = cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
+        let geometry = geometry::cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
 
         let calculated_geometries = separate_isolated_meshes(&geometry);
 

--- a/src/mesh_tools.rs
+++ b/src/mesh_tools.rs
@@ -84,7 +84,7 @@ mod tests {
     use nalgebra::base::Vector3;
     use nalgebra::geometry::Point3;
 
-    use crate::geometry::{Geometry, NormalStrategy, TriangleFace};
+    use crate::geometry::{Geometry, TriangleFace};
     use crate::mesh_analysis;
 
     use super::*;

--- a/src/mesh_tools.rs
+++ b/src/mesh_tools.rs
@@ -1,0 +1,85 @@
+use std::collections::HashMap;
+
+use smallvec::SmallVec;
+
+use crate::convert::{cast_u32, cast_usize};
+use crate::geometry::{Face, Geometry, TriangleFace};
+use crate::mesh_topology_analysis::face_to_face_topology;
+
+fn crawl_faces(
+    current_face_index: u32,
+    face_to_face: &HashMap<usize, SmallVec<[usize; 8]>>,
+    available_faces: &mut Vec<u32>,
+    separate_faces: &mut Vec<u32>,
+) {
+    separate_faces.push(current_face_index);
+
+    if let Some(all_neighbors) = face_to_face.get(&cast_usize(current_face_index)) {
+        let neighbors: Vec<u32> = all_neighbors
+            .iter()
+            .filter(|n| available_faces.iter().any(|a_f| *a_f == cast_u32(**n)))
+            .map(|n| cast_u32(*n))
+            .collect();
+        let af: Vec<_> = available_faces
+            .iter()
+            .filter(|f| neighbors.iter().all(|n| n != *f))
+            .map(|f| *f)
+            .collect();
+        *available_faces = af;
+        for neighbor_index in neighbors {
+            crawl_faces(
+                neighbor_index,
+                face_to_face,
+                available_faces,
+                separate_faces,
+            );
+        }
+    }
+}
+
+/// #Split mesh into isolated geometries
+/// Crawls the geometry to find continuous patches of geometry.
+/// Returns a vector of new separated geometries.
+#[allow(dead_code)]
+pub fn separate_isolated_meshes(geometry: &Geometry) -> Vec<Geometry> {
+    let face_to_face = face_to_face_topology(geometry);
+    let triangular_faces: Vec<TriangleFace> = geometry
+        .faces()
+        .iter()
+        .copied()
+        .map(|face| match face {
+            Face::Triangle(f) => f,
+        })
+        .collect();
+    let vertices: Vec<_> = geometry.vertices().to_vec();
+    let normals: Vec<_> = geometry.normals().to_vec();
+
+    let mut available_faces: Vec<u32> = face_to_face.keys().map(|key| cast_u32(*key)).collect();
+
+    let mut patches: Vec<Geometry> = Vec::new();
+
+    while !available_faces.is_empty() {
+        let mut separate_faces: Vec<u32> = Vec::new();
+
+        if let Some(first_face_index) = available_faces.pop() {
+            crawl_faces(
+                first_face_index,
+                &face_to_face,
+                &mut available_faces,
+                &mut separate_faces,
+            );
+        }
+        patches.push(
+            Geometry::from_triangle_faces_with_vertices_and_normals_remove_orphans(
+                separate_faces
+                    .iter()
+                    .map(|face_index| triangular_faces[cast_usize(*face_index)])
+                    .collect(),
+                vertices.clone(),
+                normals.clone(),
+            ),
+        );
+    }
+
+    patches
+}

--- a/src/mesh_tools.rs
+++ b/src/mesh_tools.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use smallvec::SmallVec;
 
 use crate::convert::{cast_u32, cast_usize};
-use crate::geometry::{Face, Geometry, TriangleFace};
+use crate::geometry::Geometry;
 use crate::mesh_topology_analysis::face_to_face_topology;
 
 fn crawl_faces(
@@ -17,13 +17,13 @@ fn crawl_faces(
     if let Some(all_neighbors) = face_to_face.get(&current_face_index) {
         let neighbors: Vec<u32> = all_neighbors
             .iter()
-            .filter(|n| available_faces.iter().any(|a_f| *a_f == **n))
-            .map(|n| *n)
+            .copied()
+            .filter(|n| available_faces.iter().any(|a_f| a_f == n))
             .collect();
         let af: Vec<_> = available_faces
             .iter()
-            .filter(|f| neighbors.iter().all(|n| n != *f))
-            .map(|f| *f)
+            .copied()
+            .filter(|f| neighbors.iter().all(|n| n != f))
             .collect();
         *available_faces = af;
         for neighbor_index in neighbors {
@@ -42,14 +42,7 @@ fn crawl_faces(
 #[allow(dead_code)]
 pub fn separate_isolated_meshes(geometry: &Geometry) -> Vec<Geometry> {
     let face_to_face = face_to_face_topology(geometry);
-    let triangular_faces: Vec<TriangleFace> = geometry
-        .faces()
-        .iter()
-        .copied()
-        .map(|face| match face {
-            Face::Triangle(f) => f,
-        })
-        .collect();
+    let faces = geometry.faces();
     let vertices: Vec<_> = geometry.vertices().to_vec();
     let normals: Vec<_> = geometry.normals().to_vec();
 
@@ -69,13 +62,13 @@ pub fn separate_isolated_meshes(geometry: &Geometry) -> Vec<Geometry> {
             );
         }
 
-        let faces: Vec<TriangleFace> = separate_faces
+        let faces: Vec<_> = separate_faces
             .iter()
-            .map(|face_index| triangular_faces[cast_usize(*face_index)])
+            .map(|face_index| faces[cast_usize(*face_index)])
             .collect();
 
         patches.push(
-            Geometry::from_triangle_faces_with_vertices_and_normals_remove_orphans(
+            Geometry::from_faces_with_vertices_and_normals_remove_orphans(
                 faces,
                 vertices.clone(),
                 normals.clone(),
@@ -91,7 +84,7 @@ mod tests {
     use nalgebra::base::Vector3;
     use nalgebra::geometry::Point3;
 
-    use crate::geometry::{self, Geometry, NormalStrategy, TriangleFace, UnorientedEdge};
+    use crate::geometry::{Geometry, NormalStrategy, TriangleFace};
 
     use super::*;
 
@@ -226,6 +219,17 @@ mod tests {
     }
 
     #[test]
+    fn test_separate_isolated_meshes_returns_identical_for_cube() {
+        let geometry = cube_sharp_var_len([0.0, 0.0, 0.0], 1.0);
+
+        let calculated_geometries = separate_isolated_meshes(&geometry);
+
+        assert_eq!(calculated_geometries.len(), 1);
+
+        assert_eq!(calculated_geometries[0], geometry);
+    }
+
+    #[test]
     fn test_separate_isolated_meshes_returns_identical_for_tessellated_triangle_with_island() {
         let (faces, vertices) = tessellated_triangle_with_island();
         let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
@@ -254,10 +258,10 @@ mod tests {
 
         assert_eq!(calculated_geometries.len(), 2);
         if calculated_geometries[0] == geometry_triangle_correct {
-            assert_eq!(calculated_geometries[1], geometry_triangle_correct);
+            assert_eq!(calculated_geometries[1], geometry_island_correct);
         } else {
             assert_eq!(calculated_geometries[1], geometry_triangle_correct);
-            assert_eq!(calculated_geometries[0], geometry_triangle_correct);
+            assert_eq!(calculated_geometries[0], geometry_island_correct);
         }
     }
 }

--- a/src/mesh_tools.rs
+++ b/src/mesh_tools.rs
@@ -8,17 +8,17 @@ use crate::mesh_topology_analysis::face_to_face_topology;
 
 fn crawl_faces(
     current_face_index: u32,
-    face_to_face: &HashMap<usize, SmallVec<[usize; 8]>>,
+    face_to_face: &HashMap<u32, SmallVec<[u32; 8]>>,
     available_faces: &mut Vec<u32>,
     separate_faces: &mut Vec<u32>,
 ) {
     separate_faces.push(current_face_index);
 
-    if let Some(all_neighbors) = face_to_face.get(&cast_usize(current_face_index)) {
+    if let Some(all_neighbors) = face_to_face.get(&current_face_index) {
         let neighbors: Vec<u32> = all_neighbors
             .iter()
-            .filter(|n| available_faces.iter().any(|a_f| *a_f == cast_u32(**n)))
-            .map(|n| cast_u32(*n))
+            .filter(|n| available_faces.iter().any(|a_f| *a_f == **n))
+            .map(|n| *n)
             .collect();
         let af: Vec<_> = available_faces
             .iter()
@@ -37,7 +37,6 @@ fn crawl_faces(
     }
 }
 
-/// #Split mesh into isolated geometries
 /// Crawls the geometry to find continuous patches of geometry.
 /// Returns a vector of new separated geometries.
 #[allow(dead_code)]
@@ -69,12 +68,15 @@ pub fn separate_isolated_meshes(geometry: &Geometry) -> Vec<Geometry> {
                 &mut separate_faces,
             );
         }
+
+        let faces: Vec<TriangleFace> = separate_faces
+            .iter()
+            .map(|face_index| triangular_faces[cast_usize(*face_index)])
+            .collect();
+
         patches.push(
             Geometry::from_triangle_faces_with_vertices_and_normals_remove_orphans(
-                separate_faces
-                    .iter()
-                    .map(|face_index| triangular_faces[cast_usize(*face_index)])
-                    .collect(),
+                faces,
                 vertices.clone(),
                 normals.clone(),
             ),
@@ -82,4 +84,180 @@ pub fn separate_isolated_meshes(geometry: &Geometry) -> Vec<Geometry> {
     }
 
     patches
+}
+
+#[cfg(test)]
+mod tests {
+    use nalgebra::base::Vector3;
+    use nalgebra::geometry::Point3;
+
+    use crate::geometry::{self, Geometry, NormalStrategy, TriangleFace, UnorientedEdge};
+
+    use super::*;
+
+    fn v(x: f32, y: f32, z: f32, translation: [f32; 3], scale: f32) -> Point3<f32> {
+        Point3::new(
+            scale * x + translation[0],
+            scale * y + translation[1],
+            scale * z + translation[2],
+        )
+    }
+
+    fn n(x: f32, y: f32, z: f32) -> Vector3<f32> {
+        Vector3::new(x, y, z)
+    }
+
+    fn tessellated_triangle() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+        let vertices = vec![
+            Point3::new(-2.0, -2.0, 0.0),
+            Point3::new(0.0, -2.0, 0.0),
+            Point3::new(2.0, -2.0, 0.0),
+            Point3::new(-1.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 2.0, 0.0),
+        ];
+
+        let faces = vec![(0, 3, 1), (1, 3, 4), (1, 4, 2), (3, 5, 4)];
+
+        (faces, vertices)
+    }
+
+    fn tessellated_triangle_with_island() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+        let vertices = vec![
+            Point3::new(-2.0, -2.0, 0.0),
+            Point3::new(0.0, -2.0, 0.0),
+            Point3::new(2.0, -2.0, 0.0),
+            Point3::new(-1.0, 0.0, 0.0),
+            Point3::new(1.0, 0.0, 0.0),
+            Point3::new(0.0, 2.0, 0.0),
+            Point3::new(-1.0, 0.0, 1.0),
+            Point3::new(1.0, 0.0, 1.0),
+            Point3::new(0.0, 2.0, 1.0),
+        ];
+
+        let faces = vec![(0, 3, 1), (1, 3, 4), (1, 4, 2), (3, 5, 4), (6, 7, 8)];
+
+        (faces, vertices)
+    }
+
+    fn triangular_island() -> (Vec<(u32, u32, u32)>, Vec<Point3<f32>>) {
+        let vertices = vec![
+            Point3::new(-1.0, 0.0, 1.0),
+            Point3::new(1.0, 0.0, 1.0),
+            Point3::new(0.0, 2.0, 1.0),
+        ];
+
+        let faces = vec![(6, 7, 8)];
+
+        (faces, vertices)
+    }
+
+    pub fn cube_sharp_var_len(position: [f32; 3], scale: f32) -> Geometry {
+        let vertex_positions = vec![
+            // back
+            v(-1.0, 1.0, -1.0, position, scale),
+            v(-1.0, 1.0, 1.0, position, scale),
+            v(1.0, 1.0, 1.0, position, scale),
+            v(1.0, 1.0, -1.0, position, scale),
+            // front
+            v(-1.0, -1.0, -1.0, position, scale),
+            v(1.0, -1.0, -1.0, position, scale),
+            v(1.0, -1.0, 1.0, position, scale),
+            v(-1.0, -1.0, 1.0, position, scale),
+        ];
+
+        let vertex_normals = vec![
+            // back
+            n(0.0, 1.0, 0.0),
+            // front
+            n(0.0, -1.0, 0.0),
+            // top
+            n(0.0, 0.0, 1.0),
+            // bottom
+            n(0.0, 0.0, -1.0),
+            // right
+            n(1.0, 0.0, 0.0),
+            // left
+            n(-1.0, 0.0, 0.0),
+        ];
+
+        let faces = vec![
+            // back
+            TriangleFace::new_separate(0, 1, 2, 0, 0, 0),
+            TriangleFace::new_separate(2, 3, 0, 0, 0, 0),
+            // front
+            TriangleFace::new_separate(4, 5, 6, 1, 1, 1),
+            TriangleFace::new_separate(6, 7, 4, 1, 1, 1),
+            // top
+            TriangleFace::new_separate(7, 6, 2, 2, 2, 2),
+            TriangleFace::new_separate(2, 1, 7, 2, 2, 2),
+            // bottom
+            TriangleFace::new_separate(4, 0, 3, 3, 3, 3),
+            TriangleFace::new_separate(3, 5, 4, 3, 3, 3),
+            // right
+            TriangleFace::new_separate(5, 3, 2, 4, 4, 4),
+            TriangleFace::new_separate(2, 6, 5, 4, 4, 4),
+            // left
+            TriangleFace::new_separate(4, 7, 1, 5, 5, 5),
+            TriangleFace::new_separate(1, 0, 4, 5, 5, 5),
+        ];
+
+        Geometry::from_triangle_faces_with_vertices_and_normals(
+            faces,
+            vertex_positions,
+            vertex_normals,
+        )
+    }
+
+    #[test]
+    fn test_separate_isolated_meshes_returns_identical_for_tessellated_triangle() {
+        let (faces, vertices) = tessellated_triangle();
+        let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+            faces.clone(),
+            vertices.clone(),
+            NormalStrategy::Sharp,
+        );
+
+        let calculated_geometries = separate_isolated_meshes(&geometry);
+
+        assert_eq!(calculated_geometries.len(), 1);
+
+        assert_eq!(calculated_geometries[0], geometry);
+    }
+
+    #[test]
+    fn test_separate_isolated_meshes_returns_identical_for_tessellated_triangle_with_island() {
+        let (faces, vertices) = tessellated_triangle_with_island();
+        let geometry = Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+            faces.clone(),
+            vertices.clone(),
+            NormalStrategy::Sharp,
+        );
+
+        let (faces_triangle_correct, vertices_triangle_correct) = tessellated_triangle();
+        let geometry_triangle_correct =
+            Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+                faces_triangle_correct.clone(),
+                vertices_triangle_correct.clone(),
+                NormalStrategy::Sharp,
+            );
+
+        let (faces_island_correct, vertices_island_correct) = triangular_island();
+        let geometry_island_correct =
+            Geometry::from_triangle_faces_with_vertices_and_computed_normals(
+                faces_island_correct.clone(),
+                vertices_island_correct.clone(),
+                NormalStrategy::Sharp,
+            );
+
+        let calculated_geometries = separate_isolated_meshes(&geometry);
+
+        assert_eq!(calculated_geometries.len(), 2);
+        if calculated_geometries[0] == geometry_triangle_correct {
+            assert_eq!(calculated_geometries[1], geometry_triangle_correct);
+        } else {
+            assert_eq!(calculated_geometries[1], geometry_triangle_correct);
+            assert_eq!(calculated_geometries[0], geometry_triangle_correct);
+        }
+    }
 }

--- a/src/mesh_tools.rs
+++ b/src/mesh_tools.rs
@@ -47,14 +47,14 @@ fn crawl_faces(
 ) {
     separate_face_indices.push(current_face_index);
 
-    if let Some(all_neighbors) = face_to_face.get(&current_face_index) {
-        let neighbors: Vec<_> = all_neighbors
+    if let Some(all_neighbors_indices) = face_to_face.get(&current_face_index) {
+        let neighbor_indices: Vec<_> = all_neighbors_indices
             .iter()
             .copied()
             .filter(|n| available_face_indices.iter().any(|a_f| a_f == n))
             .collect();
-        available_face_indices.retain(|f| neighbors.iter().all(|n| n != f));
-        for neighbor_index in neighbors {
+        available_face_indices.retain(|f| neighbor_indices.iter().all(|n| n != f));
+        for neighbor_index in neighbor_indices {
             crawl_faces(
                 neighbor_index,
                 face_to_face,

--- a/src/mesh_tools.rs
+++ b/src/mesh_tools.rs
@@ -11,7 +11,6 @@ use crate::mesh_topology_analysis::face_to_face_topology;
 #[allow(dead_code)]
 pub fn separate_isolated_meshes(geometry: &Geometry) -> Vec<Geometry> {
     let face_to_face = face_to_face_topology(geometry);
-    // NOTE: I have a hunch we can somehow get rid of this set
     let mut available_face_indices: HashSet<u32> = face_to_face.keys().cloned().collect();
     let mut patches: Vec<Geometry> = Vec::new();
 
@@ -40,11 +39,9 @@ fn crawl_faces(
     start_face_index: u32,
     face_to_face: &HashMap<u32, SmallVec<[u32; 8]>>,
 ) -> HashSet<u32> {
-    // NOTE: very random capacity, I bet there's some clever math to figure this out
     let mut index_stack = Vec::with_capacity(face_to_face.len() / 2);
     index_stack.push(start_face_index);
 
-    // NOTE: Worst case scenario capacity (everything is connected)
     let mut connected_face_indices = HashSet::with_capacity(face_to_face.len());
 
     while !index_stack.is_empty() {


### PR DESCRIPTION
Joins two mesh geometries into one

Concatenates vertex and normal slices, while keeping the first mesh geometry's element indices intact and second geometry's indices offset by the length of the respective elements. Reuses first mesh geometry's faces and recomputes the second mesh geometry's faces to match new indices of its elements.
Join two meshes

Joins two mesh geometries into one

Concatenates vertex and normal slices, while keeping the first mesh geometry's element indices intact and second geometry's indices offset by the length of the respective elements. Reuses first mesh geometry's faces and recomputes the second mesh geometry's faces to match new indices of its elements.