### PR TITLE
Add ability to return runtime errors from funcs

### DIFF
--- a/src/interpreter/func.rs
+++ b/src/interpreter/func.rs
@@ -1,6 +1,6 @@
 use bitflags::bitflags;
 
-use super::{Ty, Value};
+use super::{FuncError, Ty, Value};
 
 bitflags! {
     /// Information about the function behaviour.
@@ -71,5 +71,5 @@ pub trait Func {
     ///
     /// [`param_info`]: trait.Func.html#tymethod.param_info
     /// [`return_ty`]: trait.Func.html#tymethod.return_ty
-    fn call(&self, args: &[Value]) -> Value;
+    fn call(&self, args: &[Value]) -> Result<Value, FuncError>;
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -69,6 +69,9 @@ impl FuncError {
 impl PartialEq for FuncError {
     /// Compares whether two func errors are exactly the same instance.
     fn eq(&self, other: &FuncError) -> bool {
+        // FIXME: @Correctness Can we somehow make this equality deep
+        // so we don't have to do downcasting shenanigans when
+        // comparing?
         ptr::eq(&self.0, &other.0)
     }
 }
@@ -771,14 +774,20 @@ mod tests {
 
     use super::*;
 
-    struct TestFunc<F: Fn(&[Value]) -> Value> {
+    struct TestFunc<F>
+    where
+        F: Fn(&[Value]) -> Result<Value, FuncError>,
+    {
         func: F,
         flags: FuncFlags,
         param_info: Vec<ParamInfo>,
         return_ty: Ty,
     }
 
-    impl<F: Fn(&[Value]) -> Value> TestFunc<F> {
+    impl<F> TestFunc<F>
+    where
+        F: Fn(&[Value]) -> Result<Value, FuncError>,
+    {
         pub fn new(func: F, flags: FuncFlags, param_info: Vec<ParamInfo>, return_ty: Ty) -> Self {
             Self {
                 flags,
@@ -789,7 +798,10 @@ mod tests {
         }
     }
 
-    impl<F: Fn(&[Value]) -> Value> Func for TestFunc<F> {
+    impl<F> Func for TestFunc<F>
+    where
+        F: Fn(&[Value]) -> Result<Value, FuncError>,
+    {
         fn flags(&self) -> FuncFlags {
             self.flags
         }
@@ -803,7 +815,7 @@ mod tests {
         }
 
         fn call(&self, values: &[Value]) -> Result<Value, FuncError> {
-            Ok((self.func)(values))
+            ((self.func)(values))
         }
     }
 
@@ -835,7 +847,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |_| Value::Boolean(true),
+                |_| Ok(Value::Boolean(true)),
                 FuncFlags::PURE,
                 vec![],
                 Ty::Boolean,
@@ -862,7 +874,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Boolean(values[0].unwrap_boolean()),
+                |values| Ok(Value::Boolean(values[0].unwrap_boolean())),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Boolean,
@@ -892,7 +904,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |_| Value::Boolean(true),
+                |_| Ok(Value::Boolean(true)),
                 FuncFlags::empty(),
                 vec![],
                 Ty::Boolean,
@@ -919,7 +931,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Boolean(values[0].unwrap_boolean()),
+                |values| Ok(Value::Boolean(values[0].unwrap_boolean())),
                 FuncFlags::empty(),
                 vec![ParamInfo {
                     ty: Ty::Boolean,
@@ -949,7 +961,7 @@ mod tests {
         let (func_id1, func1) = (
             FuncIdent(0),
             TestFunc::new(
-                |_| Value::Boolean(true),
+                |_| Ok(Value::Boolean(true)),
                 FuncFlags::PURE,
                 vec![],
                 Ty::Boolean,
@@ -958,7 +970,7 @@ mod tests {
         let (func_id2, func2) = (
             FuncIdent(1),
             TestFunc::new(
-                |values| Value::Boolean(values[0].unwrap_boolean()),
+                |values| Ok(Value::Boolean(values[0].unwrap_boolean())),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Boolean,
@@ -998,7 +1010,7 @@ mod tests {
         let (func_id1, func1) = (
             FuncIdent(0),
             TestFunc::new(
-                |_| Value::Boolean(true),
+                |_| Ok(Value::Boolean(true)),
                 FuncFlags::empty(),
                 vec![],
                 Ty::Boolean,
@@ -1007,7 +1019,7 @@ mod tests {
         let (func_id2, func2) = (
             FuncIdent(1),
             TestFunc::new(
-                |values| Value::Boolean(values[0].unwrap_boolean()),
+                |values| Ok(Value::Boolean(values[0].unwrap_boolean())),
                 FuncFlags::empty(),
                 vec![ParamInfo {
                     ty: Ty::Boolean,
@@ -1072,7 +1084,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |_| Value::Boolean(true),
+                |_| Ok(Value::Boolean(true)),
                 FuncFlags::PURE,
                 vec![],
                 Ty::Boolean,
@@ -1098,7 +1110,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |_| Value::Boolean(true),
+                |_| Ok(Value::Boolean(true)),
                 FuncFlags::PURE,
                 vec![],
                 Ty::Boolean,
@@ -1138,7 +1150,7 @@ mod tests {
             TestFunc::new(
                 move |values| {
                     c.inc();
-                    Value::Boolean(values[0].unwrap_boolean())
+                    Ok(Value::Boolean(values[0].unwrap_boolean()))
                 },
                 FuncFlags::PURE,
                 vec![ParamInfo {
@@ -1178,7 +1190,7 @@ mod tests {
             TestFunc::new(
                 move |values| {
                     c.inc();
-                    Value::Boolean(values[0].unwrap_boolean())
+                    Ok(Value::Boolean(values[0].unwrap_boolean()))
                 },
                 FuncFlags::empty(),
                 vec![ParamInfo {
@@ -1221,9 +1233,9 @@ mod tests {
                     let value = values[0].unwrap_boolean();
                     let negate = values[1].unwrap_boolean();
                     if negate {
-                        Value::Boolean(!value)
+                        Ok(Value::Boolean(!value))
                     } else {
-                        Value::Boolean(value)
+                        Ok(Value::Boolean(value))
                     }
                 },
                 FuncFlags::PURE,
@@ -1296,9 +1308,9 @@ mod tests {
                     let value = values[0].unwrap_boolean();
                     let negate = values[1].unwrap_boolean();
                     if negate {
-                        Value::Boolean(!value)
+                        Ok(Value::Boolean(!value))
                     } else {
-                        Value::Boolean(value)
+                        Ok(Value::Boolean(value))
                     }
                 },
                 FuncFlags::PURE,
@@ -1324,9 +1336,9 @@ mod tests {
                     let value = values[0].unwrap_boolean();
                     let negate = values[1].unwrap_boolean();
                     if negate {
-                        Value::Boolean(!value)
+                        Ok(Value::Boolean(!value))
                     } else {
-                        Value::Boolean(value)
+                        Ok(Value::Boolean(value))
                     }
                 },
                 FuncFlags::PURE,
@@ -1399,7 +1411,7 @@ mod tests {
             TestFunc::new(
                 move |_| {
                     c1.inc();
-                    Value::Boolean(true)
+                    Ok(Value::Boolean(true))
                 },
                 FuncFlags::empty(),
                 vec![],
@@ -1412,7 +1424,7 @@ mod tests {
             TestFunc::new(
                 move |values| {
                     c2.inc();
-                    Value::Boolean(values[0].unwrap_boolean())
+                    Ok(Value::Boolean(values[0].unwrap_boolean()))
                 },
                 FuncFlags::PURE,
                 vec![ParamInfo {
@@ -1463,7 +1475,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |_| Value::Boolean(true),
+                |_| Ok(Value::Boolean(true)),
                 FuncFlags::PURE,
                 vec![],
                 Ty::Boolean,
@@ -1502,7 +1514,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Boolean(values[0].unwrap_boolean()),
+                |values| Ok(Value::Boolean(values[0].unwrap_boolean())),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Boolean,
@@ -1541,7 +1553,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Boolean(values[0].unwrap_boolean()),
+                |values| Ok(Value::Boolean(values[0].unwrap_boolean())),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Boolean,
@@ -1582,7 +1594,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Boolean(values[0].unwrap_boolean()),
+                |values| Ok(Value::Boolean(values[0].unwrap_boolean())),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Boolean,
@@ -1654,7 +1666,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Float(values[0].unwrap_float() + 1.0),
+                |values| Ok(Value::Float(values[0].unwrap_float() + 1.0)),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Float,
@@ -1699,7 +1711,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Float(values[0].unwrap_float() + 1.0),
+                |values| Ok(Value::Float(values[0].unwrap_float() + 1.0)),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Float,
@@ -1739,7 +1751,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Float(values[0].get_float().unwrap_or(1.0)),
+                |values| Ok(Value::Float(values[0].get_float().unwrap_or(1.0))),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Float,
@@ -1770,7 +1782,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Float(values[0].get_float().unwrap_or(1.0)),
+                |values| Ok(Value::Float(values[0].get_float().unwrap_or(1.0))),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Float,
@@ -1809,7 +1821,7 @@ mod tests {
     fn test_interpreter_interpret_single_func_dynamic_return_ty_error() {
         let (func_id, func) = (
             FuncIdent(0),
-            TestFunc::new(|_| Value::Int(-1), FuncFlags::PURE, vec![], Ty::Float),
+            TestFunc::new(|_| Ok(Value::Int(-1)), FuncFlags::PURE, vec![], Ty::Float),
         );
 
         let call = ast::CallExpr::new(func_id, vec![]);
@@ -1836,6 +1848,64 @@ mod tests {
         );
     }
 
+    // Func runtime erorrs tests
+
+    #[test]
+    fn test_interpreter_interpret_single_func_runtime_error() {
+        #[derive(Debug, PartialEq)]
+        struct ConcreteFuncError(i32);
+
+        impl fmt::Display for ConcreteFuncError {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "Concrete func error with code {}", self.0)
+            }
+        }
+
+        impl error::Error for ConcreteFuncError {}
+
+        let (func_id, func) = (
+            FuncIdent(0),
+            TestFunc::new(
+                |_| Err(FuncError::new(ConcreteFuncError(42))),
+                FuncFlags::empty(),
+                vec![],
+                Ty::Boolean,
+            ),
+        );
+
+        let call = ast::CallExpr::new(func_id, vec![]);
+        let prog = ast::Prog::new(vec![ast::Stmt::VarDecl(ast::VarDeclStmt::new(
+            VarIdent(0),
+            call.clone(),
+        ))]);
+
+        let mut funcs: HashMap<FuncIdent, Box<dyn Func>> = HashMap::new();
+        funcs.insert(func_id, Box::new(func));
+
+        let mut interpreter = Interpreter::new(funcs);
+        interpreter.set_prog(prog);
+
+        let err = interpreter.interpret().unwrap_err();
+
+        match err {
+            InterpretError::Runtime(RuntimeError::Func {
+                stmt_index: runtime_error_stmt_index,
+                call: runtime_error_call,
+                func_error: runtime_error_func_error,
+            }) => {
+                assert_eq!(runtime_error_stmt_index, 0);
+                assert_eq!(runtime_error_call, call);
+
+                let concrete_error = runtime_error_func_error
+                    .0
+                    .downcast_ref::<ConcreteFuncError>()
+                    .unwrap();
+                assert_eq!(concrete_error, &ConcreteFuncError(42));
+            }
+            _ => panic!(),
+        }
+    }
+
     // ValueSet tests
 
     #[test]
@@ -1843,7 +1913,7 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Value::Float(values[0].unwrap_float() * 2.0),
+                |values| Ok(Value::Float(values[0].unwrap_float() * 2.0)),
                 FuncFlags::PURE,
                 vec![ParamInfo {
                     ty: Ty::Float,


### PR DESCRIPTION
This changes the return type of funcs to `Result<Value, FuncError>`,
where `FuncError` wraps a dynamic error type. When a func returns an
error, the whole interpreter session returns the same error under the
newly created `RuntimeError::Func` variant.

Due to the dynamic nature of `FuncError`, `PartialEq` for it is
implemented with strict pointer equality. (If we wanted to implement
this by doing a complete equality check, the fact that trait objects
don't implement `PartialEq` would make it rather challenging).