### PR TITLE
Fix erroneous advancing of PC when setting one prog stmt

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1499,7 +1499,7 @@ mod tests {
         assert_eq!(interpreter.pc, 0);
 
         interpreter.set_prog_stmt_at(
-            0,
+            1,
             ast::Stmt::VarDecl(ast::VarDeclStmt::new(
                 VarIdent(0),
                 ast::CallExpr::new(func_id, vec![]),


### PR DESCRIPTION
This is one small part extracted from the work on UI, so that that PR can be smaller when it lands.