### PR TITLE
Add editor session and its UI

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -36,3 +36,21 @@ where
 {
     n.try_into().expect("Expected N to fit in usize")
 }
+
+/// Convert u32 to i32 clamping to max value of i32 if necessary.
+pub fn clamp_cast_u32_to_i32(n: u32) -> i32 {
+    if n > i32::max_value() as u32 {
+        i32::max_value()
+    } else {
+        n as i32
+    }
+}
+
+/// Convert i32 to u32 clamping to 0 if necessary.
+pub fn clamp_cast_i32_to_u32(n: i32) -> u32 {
+    if n < 0 {
+        0
+    } else {
+        n as u32
+    }
+}

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1004,8 +1004,11 @@ pub fn uv_sphere(position: [f32; 3], scale: f32, n_parallels: u32, n_meridians: 
     )
 }
 
-pub fn compute_bounding_sphere(geometries: &[Geometry]) -> (Point3<f32>, f32) {
-    let centroid = compute_centroid(geometries);
+pub fn compute_bounding_sphere<'a, I>(geometries: I) -> (Point3<f32>, f32)
+where
+    I: IntoIterator<Item = &'a Geometry> + Clone,
+{
+    let centroid = compute_centroid(geometries.clone());
     let mut max_distance_squared = 0.0;
 
     for geometry in geometries {
@@ -1020,7 +1023,10 @@ pub fn compute_bounding_sphere(geometries: &[Geometry]) -> (Point3<f32>, f32) {
     (centroid, max_distance_squared.sqrt())
 }
 
-pub fn compute_centroid(geometries: &[Geometry]) -> Point3<f32> {
+pub fn compute_centroid<'a, I>(geometries: I) -> Point3<f32>
+where
+    I: IntoIterator<Item = &'a Geometry>,
+{
     let mut vertex_count = 0;
     let mut centroid = Point3::origin();
     for geometry in geometries {

--- a/src/interpreter/ast.rs
+++ b/src/interpreter/ast.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 ///
 /// Has to stay stable for the lifetime of the interpreter and program
 /// using it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FuncIdent(pub(crate) u64);
 
 impl fmt::Display for FuncIdent {
@@ -46,12 +46,12 @@ impl Prog {
         self.stmts.pop();
     }
 
-    pub fn stmts(&self) -> &[Stmt] {
-        &self.stmts
+    pub fn set_stmt_at(&mut self, index: usize, stmt: Stmt) {
+        self.stmts[index] = stmt;
     }
 
-    pub fn stmts_mut(&mut self) -> &mut [Stmt] {
-        &mut self.stmts
+    pub fn stmts(&self) -> &[Stmt] {
+        &self.stmts
     }
 }
 
@@ -99,6 +99,13 @@ impl VarDeclStmt {
         Self { ident, init_expr }
     }
 
+    pub fn clone_with_init_expr(&self, init_expr: CallExpr) -> Self {
+        Self {
+            ident: self.ident,
+            init_expr,
+        }
+    }
+
     pub fn ident(&self) -> VarIdent {
         self.ident
     }
@@ -130,6 +137,15 @@ pub enum Expr {
     Index(IndexExpr),
 }
 
+impl Expr {
+    pub fn unwrap_literal(&self) -> &LitExpr {
+        match self {
+            Expr::Lit(lit) => lit,
+            _ => panic!("Expression not literal"),
+        }
+    }
+}
+
 impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -156,6 +172,74 @@ pub enum LitExpr {
     #[allow(dead_code)]
     Float3([f32; 3]),
     String(Arc<String>),
+}
+
+impl LitExpr {
+    /// Get the literal value if boolean, otherwise panic.
+    ///
+    /// # Panics
+    /// This function panics when value is not a boolean.
+    pub fn unwrap_boolean(&self) -> bool {
+        match self {
+            LitExpr::Boolean(boolean) => *boolean,
+            _ => panic!("Literal expression not boolean"),
+        }
+    }
+
+    /// Get the literal value if int, otherwise panic.
+    ///
+    /// # Panics
+    /// This function panics when literal value is not an int.
+    pub fn unwrap_int(&self) -> i32 {
+        match self {
+            LitExpr::Int(int) => *int,
+            _ => panic!("Literal expression not int"),
+        }
+    }
+
+    /// Get the literal value if uint, otherwise panic.
+    ///
+    /// # Panics
+    /// This function panics when literal value is not an uint.
+    pub fn unwrap_uint(&self) -> u32 {
+        match self {
+            LitExpr::Uint(uint) => *uint,
+            _ => panic!("Literal expression not uint"),
+        }
+    }
+
+    /// Get the literal value if float, otherwise panic.
+    ///
+    /// # Panics
+    /// This function panics when literal value is not a float.
+    pub fn unwrap_float(&self) -> f32 {
+        match self {
+            LitExpr::Float(float) => *float,
+            _ => panic!("Literal expression not float"),
+        }
+    }
+
+    /// Get the literal value if float3, otherwise panic.
+    ///
+    /// # Panics
+    /// This function panics when literal value is not a float3.
+    pub fn unwrap_float3(&self) -> [f32; 3] {
+        match self {
+            LitExpr::Float3(float3) => *float3,
+            _ => panic!("Literal expression not float3"),
+        }
+    }
+
+    /// Get the literal value if string, otherwise panic.
+    ///
+    /// # Panics
+    /// This function panics when literal value is not a string.
+    pub fn unwrap_string(&self) -> &str {
+        match self {
+            LitExpr::String(string) => string,
+            _ => panic!("Literal expression not string"),
+        }
+    }
 }
 
 impl fmt::Display for LitExpr {
@@ -225,6 +309,15 @@ pub struct CallExpr {
 impl CallExpr {
     pub fn new(ident: FuncIdent, args: Vec<Expr>) -> Self {
         Self { ident, args }
+    }
+
+    pub fn clone_with_arg_at(&self, index: usize, arg: Expr) -> Self {
+        let mut new_args = self.args.clone();
+        new_args[index] = arg;
+        Self {
+            ident: self.ident,
+            args: new_args,
+        }
     }
 
     pub fn ident(&self) -> FuncIdent {

--- a/src/interpreter/value.rs
+++ b/src/interpreter/value.rs
@@ -232,7 +232,14 @@ impl fmt::Display for Value {
             }
             Value::String(string) => write!(f, "<string {}>", string),
             Value::Geometry(geometry) => {
-                write!(f, "<geometry (vertices: {})>", geometry.vertices().len())
+                let vertex_count = geometry.vertices().len();
+                let face_count = geometry.faces().len();
+
+                write!(
+                    f,
+                    "<geometry (vertices: {}, faces: {})>",
+                    vertex_count, face_count
+                )
             }
         }
     }

--- a/src/interpreter_server.rs
+++ b/src/interpreter_server.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::thread;
 
 use crossbeam_channel as channel;
@@ -8,6 +9,12 @@ use crate::interpreter_funcs;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RequestId(u64);
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "REQ({})", self.0)
+    }
+}
 
 /// A possible error when polling for an interpreter response.
 #[derive(Debug)]
@@ -21,14 +28,12 @@ pub enum PollResponseError {
 /// the interpreter.
 #[derive(Debug)]
 pub enum InterpreterRequest {
+    #[allow(dead_code)]
     SetProg(Prog),
     #[allow(dead_code)]
     ClearProg,
-    #[allow(dead_code)]
     PushProgStmt(Stmt),
-    #[allow(dead_code)]
     PopProgStmt,
-    #[allow(dead_code)]
     SetProgStmtAt(usize, Stmt),
     Interpret,
     #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,19 @@
 pub use crate::renderer::{GpuBackend, Msaa, PresentMode};
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use nalgebra::geometry::Point3;
 
 use crate::camera::{Camera, CameraOptions};
+use crate::geometry::Geometry;
 use crate::input::InputManager;
-use crate::interpreter::ast;
-use crate::interpreter_funcs as funcs;
-use crate::interpreter_server::{InterpreterRequest, InterpreterResponse, InterpreterServer};
-use crate::renderer::{DrawGeometryMode, GpuGeometry, Options as RendererOptions, Renderer};
+use crate::interpreter::VarIdent;
+use crate::renderer::{
+    DrawGeometryMode, GpuGeometry, GpuGeometryId, Options as RendererOptions, Renderer,
+};
+use crate::session::{PollInterpreterResponseNotification, Session};
 use crate::ui::Ui;
 
 pub mod geometry;
@@ -32,6 +35,7 @@ mod mesh_smoothing;
 mod mesh_tools;
 mod mesh_topology_analysis;
 mod platform;
+mod session;
 mod ui;
 
 const CAMERA_INTERPOLATION_DURATION: Duration = Duration::from_millis(1000);
@@ -55,13 +59,13 @@ pub fn init_and_run(options: Options) -> ! {
     // let monitor_id = event_loop.primary_monitor();
     let window = winit::window::WindowBuilder::new()
         .with_title("H.U.R.B.A.N. Selector")
-        // .with_fullscreen(Some(monitor_id))
+        .with_inner_size(winit::dpi::LogicalSize::new(1280.0, 720.0))
         .build(&event_loop)
         .expect("Failed to create window");
 
     let window_size = window.inner_size().to_physical(window.hidpi_factor());
 
-    let mut interpreter_server = InterpreterServer::new();
+    let mut session = Session::new();
     let mut input_manager = InputManager::new();
     let mut ui = Ui::new(&window);
 
@@ -102,16 +106,8 @@ pub fn init_and_run(options: Options) -> ! {
         },
     );
 
-    let mut scene_geometries = Vec::new();
-    let mut scene_renderer_geometry_ids = Vec::new();
-
-    for geometry in &scene_geometries {
-        let renderer_geometry = GpuGeometry::from_geometry(geometry);
-        let renderer_geometry_id = renderer
-            .add_scene_geometry(&renderer_geometry)
-            .expect("Failed to add geometry to renderer");
-        scene_renderer_geometry_ids.push(renderer_geometry_id);
-    }
+    let mut scene_geometries: HashMap<VarIdent, Arc<Geometry>> = HashMap::new();
+    let mut scene_gpu_geometry_ids: HashMap<VarIdent, GpuGeometryId> = HashMap::new();
 
     let cubic_bezier = math::CubicBezierEasing::new([0.7, 0.0], [0.3, 1.0]);
 
@@ -163,50 +159,17 @@ pub fn init_and_run(options: Options) -> ! {
                 camera.zoom(input_state.camera_zoom);
                 camera.zoom_step(input_state.camera_zoom_steps);
 
-                if input_state.camera_reset_viewport {
-                    camera_interpolation =
-                        Some(CameraInterpolation::new(&camera, &scene_geometries, time));
-                }
+                let ui_reset_viewport =
+                    ui_frame.draw_viewport_settings_window(&mut renderer_draw_geometry_mode);
+                ui_frame.draw_pipeline_window(&mut session);
+                ui_frame.draw_operations_window(&mut session);
 
-                if input_state.tmp_submit_prog_and_run {
-                    let prog = ast::Prog::new(vec![ast::Stmt::VarDecl(ast::VarDeclStmt::new(
-                        ast::VarIdent(0),
-                        ast::CallExpr::new(
-                            funcs::FUNC_ID_IMPORT_OBJ_MESH,
-                            vec![ast::Expr::Lit(ast::LitExpr::String(Arc::new(
-                                "./tests/fixtures/triangle.obj".to_string(),
-                            )))],
-                        ),
-                    ))]);
-
-                    interpreter_server.submit_request(InterpreterRequest::SetProg(prog));
-                    interpreter_server.submit_request(InterpreterRequest::Interpret);
-                }
-
-                while let Ok((request_id, response)) = interpreter_server.poll_response() {
-                    match response {
-                        InterpreterResponse::Completed => {
-                            log::info!("Interpreter completed request {:?}", request_id,)
-                        }
-                        InterpreterResponse::CompletedWithResult(result) => {
-                            log::info!(
-                                "Interpreter completed request {:?} with result",
-                                request_id,
-                            );
-
-                            let value_set = result.unwrap();
-
-                            for (_, value) in &value_set.unused_values {
-                                let geometry = value.unwrap_geometry().clone();
-                                let renderer_geometry = GpuGeometry::from_geometry(&geometry);
-                                let renderer_geometry_id =
-                                    renderer.add_scene_geometry(&renderer_geometry).unwrap();
-
-                                scene_geometries.push(geometry);
-                                scene_renderer_geometry_ids.push(renderer_geometry_id);
-                            }
-                        }
-                    }
+                if input_state.camera_reset_viewport || ui_reset_viewport {
+                    camera_interpolation = Some(CameraInterpolation::new(
+                        &camera,
+                        scene_geometries.values().map(Arc::as_ref),
+                        time,
+                    ));
                 }
 
                 if input_state.close_requested {
@@ -227,6 +190,26 @@ pub fn init_and_run(options: Options) -> ! {
                     renderer.set_window_size(physical_size);
                 }
 
+                session.poll_interpreter_response(|callback_value| match callback_value {
+                    PollInterpreterResponseNotification::Add(var_ident, geometry) => {
+                        let gpu_geometry = GpuGeometry::from_geometry(&geometry);
+                        let gpu_geometry_id = renderer
+                            .add_scene_geometry(&gpu_geometry)
+                            .expect("Failed to upload scene geometry");
+
+                        scene_geometries.insert(var_ident, geometry);
+                        scene_gpu_geometry_ids.insert(var_ident, gpu_geometry_id);
+                    }
+                    PollInterpreterResponseNotification::Remove(var_ident) => {
+                        scene_geometries.remove(&var_ident);
+                        let gpu_geometry_id = scene_gpu_geometry_ids
+                            .remove(&var_ident)
+                            .expect("Gpu geometry ID was not tracked");
+
+                        renderer.remove_scene_geometry(gpu_geometry_id);
+                    }
+                });
+
                 if let Some(interp) = camera_interpolation {
                     if interp.target_time > time {
                         let (sphere_origin, sphere_radius) = interp.update(time, &cubic_bezier);
@@ -238,21 +221,16 @@ pub fn init_and_run(options: Options) -> ! {
                     }
                 }
 
+                let imgui_draw_data = ui_frame.render(&window);
+
                 // Camera matrices have to be uploaded when either window
                 // resizes or the camera moves. We do it every frame for
                 // simplicity.
                 renderer.set_camera_matrices(&camera.projection_matrix(), &camera.view_matrix());
-
-                ui_frame.draw_renderer_settings_window(&mut renderer_draw_geometry_mode);
-
-                let imgui_draw_data = ui_frame.render(&window);
-
                 let mut render_pass = renderer.begin_render_pass();
 
-                render_pass.draw_geometry(
-                    &scene_renderer_geometry_ids[..],
-                    renderer_draw_geometry_mode,
-                );
+                render_pass
+                    .draw_geometry(scene_gpu_geometry_ids.values(), renderer_draw_geometry_mode);
                 render_pass.draw_ui(imgui_draw_data);
 
                 render_pass.submit();
@@ -304,9 +282,12 @@ struct CameraInterpolation {
 }
 
 impl CameraInterpolation {
-    fn new(camera: &Camera, scene_geometries: &[geometry::Geometry], time: Instant) -> Self {
+    fn new<'a, I>(camera: &Camera, scene_geometries: I, time: Instant) -> Self
+    where
+        I: IntoIterator<Item = &'a Geometry> + Clone,
+    {
         let (source_origin, source_radius) = camera.visible_sphere();
-        let (target_origin, target_radius) = geometry::compute_bounding_sphere(&scene_geometries);
+        let (target_origin, target_radius) = geometry::compute_bounding_sphere(scene_geometries);
 
         CameraInterpolation {
             source_origin,

--- a/src/operations/shrink_wrap.rs
+++ b/src/operations/shrink_wrap.rs
@@ -1,4 +1,4 @@
-use std::slice;
+use std::iter;
 use std::u32;
 
 use crate::geometry::{self, Geometry};
@@ -9,7 +9,7 @@ pub struct ShrinkWrapParams<'a> {
 }
 
 pub fn shrink_wrap(params: ShrinkWrapParams) -> Geometry {
-    let (center, radius) = geometry::compute_bounding_sphere(slice::from_ref(&params.geometry));
+    let (center, radius) = geometry::compute_bounding_sphere(iter::once(params.geometry));
     let mut sphere_geometry = geometry::uv_sphere(
         center.coords.into(),
         radius,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -345,7 +345,10 @@ impl RenderPass<'_> {
     /// Record a geometry drawing operation to the command
     /// buffer. Geometries with provided ids must be present in the
     /// renderer.
-    pub fn draw_geometry(&mut self, ids: &[GpuGeometryId], mode: DrawGeometryMode) {
+    pub fn draw_geometry<'a, I>(&mut self, ids: I, mode: DrawGeometryMode)
+    where
+        I: IntoIterator<Item = &'a GpuGeometryId> + Clone,
+    {
         let mut clear_flags = SceneRendererClearFlags::empty();
         if self.color_needs_clearing {
             clear_flags.insert(SceneRendererClearFlags::COLOR);

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,375 @@
+use std::collections::hash_map::{Entry, HashMap};
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+
+use crate::geometry::Geometry;
+use crate::interpreter::ast::{FuncIdent, Prog, Stmt, VarIdent};
+use crate::interpreter::Func;
+use crate::interpreter_funcs;
+use crate::interpreter_server::{
+    InterpreterRequest, InterpreterResponse, InterpreterServer, PollResponseError, RequestId,
+};
+
+/// A notification from the session to the surrounding environment
+/// about what values have been added since the last poll, and what
+/// values have been removed are no longer required.
+pub enum PollInterpreterResponseNotification {
+    Add(VarIdent, Arc<Geometry>),
+    Remove(VarIdent),
+}
+
+/// An editing session.
+///
+/// Contains the current definition of the pipeline program and can
+/// execute it via the interpreter running in a separete thread.
+///
+/// All program mutations are non-blocking (the session does not wait
+/// for the interpreter to acknowledge them), and polling the session
+/// for interpreter results is also non-blocking - if there is no
+/// response, nothing happens.
+pub struct Session {
+    interpreter_server: InterpreterServer,
+    interpreter_requests_in_flight: HashSet<RequestId>,
+
+    prog: Prog,
+
+    unused_values: HashMap<VarIdent, Arc<Geometry>>,
+
+    /// Auxiliary side-array for prog. Determines the vars visible
+    /// from the statement. The value is read by producing a slice
+    /// from the begining of the array to the current stmt's index
+    /// (exclusive), e.g. 0th stmt can not see any vars, 1st stmt can
+    /// see vars produced by the 0th stmt, etc.
+    var_visibility: Vec<VarIdent>,
+    var_count: u64,
+
+    function_table: BTreeMap<FuncIdent, Box<dyn Func>>,
+}
+
+impl Session {
+    pub fn new() -> Self {
+        let prog = Prog::new(Vec::new());
+        let var_visibility = Vec::new();
+
+        assert_eq!(prog.stmts().len(), var_visibility.len());
+
+        Self {
+            interpreter_server: InterpreterServer::new(),
+            interpreter_requests_in_flight: HashSet::new(),
+
+            prog,
+
+            unused_values: HashMap::new(),
+
+            var_visibility,
+            var_count: 0,
+
+            // FIXME: @Correctness this is a hack, there should be
+            // just one instance of the table. Fortunately we don't
+            // ever use it mutable from here. Find a way to split out
+            // the mutable part of the table (the funcs' state) and
+            // make sure that one is only instantiated once, while the
+            // descriptors can be instantiated multiple times and
+            // shared.
+            function_table: interpreter_funcs::create_function_table(),
+        }
+    }
+
+    /// Pushes a new statement onto the program.
+    pub fn push_prog_stmt(&mut self, stmt: Stmt) {
+        // This is because the current session could want to report
+        // errors and we would like to show them somewhere
+        assert!(
+            !self.interpreter_busy(),
+            "Can't submit a request while the interpreter is already interpreting",
+        );
+
+        self.prog.push_stmt(stmt.clone());
+        self.submit(InterpreterRequest::PushProgStmt(stmt));
+
+        self.var_count += 1;
+
+        self.recompute_var_visibility();
+    }
+
+    /// Pops a statement from the program.
+    pub fn pop_prog_stmt(&mut self) {
+        // This is because the current session could want to report
+        // errors and we would like to show them somewhere
+        assert!(
+            !self.interpreter_busy(),
+            "Can't submit a request while the interpreter is already interpreting",
+        );
+
+        self.prog.pop_stmt();
+        self.submit(InterpreterRequest::PopProgStmt);
+
+        self.var_count -= 1;
+
+        self.recompute_var_visibility();
+    }
+
+    /// Edits a program statement at the index.
+    pub fn set_prog_stmt_at(&mut self, index: usize, stmt: Stmt) {
+        // This is because the current session could want to report
+        // errors and we would like to show them somewhere
+        assert!(
+            !self.interpreter_busy(),
+            "Can't submit a request while the interpreter is already interpreting",
+        );
+
+        self.prog.set_stmt_at(index, stmt.clone());
+
+        self.submit(InterpreterRequest::SetProgStmtAt(index, stmt));
+        self.recompute_var_visibility();
+    }
+
+    /// Returns the statements currently contained in the current pipeline's
+    /// program.
+    pub fn stmts(&self) -> &[Stmt] {
+        self.prog.stmts()
+    }
+
+    /// Returns the definitions of all known functions.
+    pub fn function_table(&self) -> &BTreeMap<FuncIdent, Box<dyn Func>> {
+        &self.function_table
+    }
+
+    /// Returns the next free variable identifier for the current
+    /// program definition.
+    pub fn next_free_var_ident(&self) -> VarIdent {
+        VarIdent(self.var_count)
+    }
+
+    /// Returns human readable variable name for a variable identifier
+    /// or `None` if the variable identifier does not exist in the
+    /// current program.
+    pub fn var_name_for_ident(&self, var_ident: VarIdent) -> Option<&str> {
+        // FIXME: @Optimization Don't iterate all the time
+        self.stmts()
+            .iter()
+            .find_map(|stmt| match stmt {
+                Stmt::VarDecl(var_decl) => {
+                    if var_decl.ident() == var_ident {
+                        Some(var_decl)
+                    } else {
+                        None
+                    }
+                }
+            })
+            .map(|var_decl| {
+                self.function_table[&var_decl.init_expr().ident()]
+                    .info()
+                    .return_value_name
+            })
+    }
+
+    /// Returns all visible variable identifiers from a position
+    /// (index) in the program.
+    pub fn var_visibility_at_stmt(&self, index: usize) -> &[VarIdent] {
+        &self.var_visibility[0..index]
+    }
+
+    /// Returns whether the interpreter is currently running. Program
+    /// modifications and running the interpreter (again) are
+    /// disallowed in this state.
+    pub fn interpreter_busy(&self) -> bool {
+        !self.interpreter_requests_in_flight.is_empty()
+    }
+
+    /// Starts the interpreter on the current program.
+    pub fn interpret(&mut self) {
+        // This is because the current session could want to report
+        // errors and we would like to show them somewhere
+        assert!(
+            !self.interpreter_busy(),
+            "Can't submit a request while the interpreter is already interpreting",
+        );
+
+        self.submit(InterpreterRequest::Interpret);
+    }
+
+    /// Poll the interpreter for responses and call the callback for
+    /// each notification generated this way.
+    ///
+    /// The notifications can ask the surrounding environment to start
+    /// or stop tracking a value with a variable identifier.
+    ///
+    /// Polls the interpreter until there are no more messages in the
+    /// response channel.
+    pub fn poll_interpreter_response<C>(&mut self, mut callback: C)
+    where
+        C: FnMut(PollInterpreterResponseNotification),
+    {
+        // Loop over all responses
+
+        // This is allowed, because we might add other kinds of errors
+        // to `poll_response()` besides `Pending` and satisfying
+        // clippy would mean this will still compile, when in fact we
+        // don't want it to.
+        #[allow(clippy::while_let_loop)]
+        loop {
+            match self.interpreter_server.poll_response() {
+                Ok((request_id, response)) => {
+                    let tracked = self.interpreter_requests_in_flight.remove(&request_id);
+                    assert!(tracked, "Each request must have been tracked");
+
+                    match response {
+                        InterpreterResponse::Completed => {
+                            log::info!("Interpreter completed request {}", request_id);
+                        }
+                        InterpreterResponse::CompletedWithResult(result) => {
+                            log::info!("Interpreter completed request {} with result", request_id);
+
+                            match result {
+                                Ok(value_set) => {
+                                    // Now we track whether the usage of
+                                    // any value changed. Adding an
+                                    // operation to the pipeline can:
+                                    // - create a new unused_value
+                                    // - create a new used_value
+                                    // - change an existing unused_value to used_value
+                                    //
+                                    // Removing an operation from the pipeline can:
+                                    // - remove an existing unused_value
+                                    // - remove an existing used_value
+                                    // - change an existing used_value to unused_value
+                                    //
+                                    // We diff the old and new sets and
+                                    // perform the following operations:
+                                    // - Detect which values should be
+                                    //   removed and `Remove` them
+                                    // - Detect which values should be
+                                    //   retained, but they changed, we both
+                                    //   `Remove` and `Add` them to notify
+                                    //   the outside of the change
+                                    // - Detect which values should be
+                                    //   added and `Add` them
+
+                                    // FIXME: Currently, we only call the
+                                    // add/remove handlers with when a
+                                    // value enters or leaves the
+                                    // unused_values set. This can be
+                                    // easily copy-paste extended to
+                                    // handle used_values the same way.
+
+                                    let mut to_remove =
+                                        Vec::with_capacity(self.unused_values.len());
+                                    let mut to_reinsert =
+                                        Vec::with_capacity(self.unused_values.len());
+                                    for (current_var_ident, current_geometry) in &self.unused_values
+                                    {
+                                        if let Some((var_ident, value)) = value_set
+                                            .unused_values
+                                            .iter()
+                                            .find(|(var_ident, _)| var_ident == current_var_ident)
+                                        {
+                                            // The value is present under
+                                            // the same identifier in both
+                                            // new and old value set, but
+                                            // it could have changed! If
+                                            // it did, we both remove the
+                                            // old value and add the new.
+                                            let geometry = value.unwrap_refcounted_geometry();
+
+                                            if geometry != *current_geometry {
+                                                to_remove.push(*var_ident);
+                                                to_reinsert
+                                                    .push((*var_ident, Arc::clone(&geometry)));
+                                            }
+                                        } else {
+                                            // The value is no longer
+                                            // present in the new value
+                                            // set, let's remove it!
+                                            to_remove.push(*current_var_ident);
+                                        }
+                                    }
+
+                                    // Process values to remove and values to reinsert
+                                    for var_ident in to_remove {
+                                        self.unused_values.remove(&var_ident).expect(
+                                            "Value must be present if we want to remove it",
+                                        );
+                                        callback(PollInterpreterResponseNotification::Remove(
+                                            var_ident,
+                                        ));
+                                    }
+                                    for (var_ident, geometry) in to_reinsert {
+                                        let inserted = self
+                                            .unused_values
+                                            .insert(var_ident, Arc::clone(&geometry))
+                                            .is_none();
+                                        assert!(
+                                        inserted,
+                                        "Value must have been removed previously for reinsertion",
+                                    );
+                                        callback(PollInterpreterResponseNotification::Add(
+                                            var_ident, geometry,
+                                        ))
+                                    }
+
+                                    for (var_ident, value) in value_set.unused_values {
+                                        let geometry = value.unwrap_refcounted_geometry();
+                                        // Only add and emit events for
+                                        // values that we didn't have
+                                        // before. We handled
+                                        // re-insertions earlier by
+                                        // comparing the values.
+                                        if let Entry::Vacant(vacant) =
+                                            self.unused_values.entry(var_ident)
+                                        {
+                                            vacant.insert(Arc::clone(&geometry));
+                                            callback(PollInterpreterResponseNotification::Add(
+                                                var_ident, geometry,
+                                            ));
+                                        }
+                                    }
+                                }
+                                Err(interpret_error) => {
+                                    // FIXME: Display error on UI
+                                    log::error!(
+                                        "Interpreter failed with error {}",
+                                        interpret_error
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    self.recompute_var_visibility();
+                }
+                Err(PollResponseError::Pending) => {
+                    // No more responses, break out of the loop
+                    break;
+                }
+            }
+        }
+    }
+
+    fn recompute_var_visibility(&mut self) {
+        self.var_visibility.clear();
+
+        for stmt in self.prog.stmts() {
+            match stmt {
+                Stmt::VarDecl(var_decl) => {
+                    self.var_visibility.push(var_decl.ident());
+                }
+            }
+        }
+
+        assert_eq!(
+            self.var_visibility.len(),
+            self.prog.stmts().len(),
+            "Each stmt is a var decl and must produce a variable",
+        );
+    }
+
+    fn submit(&mut self, request: InterpreterRequest) {
+        let request_id = self.interpreter_server.submit_request(request);
+        let tracked = self.interpreter_requests_in_flight.insert(request_id);
+        assert!(
+            tracked,
+            "Interpreter server must provide unique request ids"
+        );
+    }
+}

--- a/src/session.rs
+++ b/src/session.rs
@@ -57,18 +57,30 @@ impl Session {
 
             var_visibility: Vec::new(),
 
-            // FIXME: @Correctness this is a hack, there should be
-            // just one instance of the table. Fortunately we don't
-            // ever use it mutable from here. Find a way to split out
-            // the mutable part of the table (the funcs' state) and
-            // make sure that one is only instantiated once, while the
-            // descriptors can be instantiated multiple times and
-            // shared.
+            // FIXME: @Correctness this is a hack that is currently
+            // harmless, but should eventually be cleaned up. Some
+            // funcs have internal state (at the time of writing this
+            // is only the import obj func with its importer
+            // cache). If we create multiple instances of the function
+            // table as we do here (the interpreter has its own
+            // instance), this state will not be shared, which could
+            // lead to unexpected behavior, if the state is mutated
+            // from multiple places. Fortunately, we currenly don't
+            // mutate the state here in the session (nor do we need
+            // to), that's why the hack is harmless. The most clean
+            // solution would be to split the stateful part of funcs
+            // away from the stateless func descriptors, so that the
+            // state only exists in the interpreter and this table
+            // would just contain the function descriptors, which we
+            // wouldn't have to care there are multiple copies of.
             function_table: interpreter_funcs::create_function_table(),
         }
     }
 
     /// Pushes a new statement onto the program.
+    ///
+    /// # Panics
+    /// Panics if the interpreter is busy.
     pub fn push_prog_stmt(&mut self, stmt: Stmt) {
         // This is because the current session could want to report
         // errors and we would like to show them somewhere
@@ -84,6 +96,9 @@ impl Session {
     }
 
     /// Pops a statement from the program.
+    ///
+    /// # Panics
+    /// Panics if the interpreter is busy.
     pub fn pop_prog_stmt(&mut self) {
         // This is because the current session could want to report
         // errors and we would like to show them somewhere
@@ -99,6 +114,9 @@ impl Session {
     }
 
     /// Edits a program statement at the index.
+    ///
+    /// # Panics
+    /// Panics if the interpreter is busy.
     pub fn set_prog_stmt_at(&mut self, index: usize, stmt: Stmt) {
         // This is because the current session could want to report
         // errors and we would like to show them somewhere

--- a/src/session.rs
+++ b/src/session.rs
@@ -21,7 +21,7 @@ pub enum PollInterpreterResponseNotification {
 /// An editing session.
 ///
 /// Contains the current definition of the pipeline program and can
-/// execute it via the interpreter running in a separete thread.
+/// execute it via the interpreter running in a separate thread.
 ///
 /// All program mutations are non-blocking (the session does not wait
 /// for the interpreter to acknowledge them), and polling the session
@@ -223,9 +223,8 @@ impl Session {
 
                             match result {
                                 Ok(value_set) => {
-                                    // Now we track whether the usage of
-                                    // any value changed. Adding an
-                                    // operation to the pipeline can:
+                                    // Now we track whether the usage of any value changed. Adding
+                                    // an operation to the pipeline can:
                                     // - create a new unused_value
                                     // - create a new used_value
                                     // - change an existing unused_value to used_value
@@ -235,23 +234,18 @@ impl Session {
                                     // - remove an existing used_value
                                     // - change an existing used_value to unused_value
                                     //
-                                    // We diff the old and new sets and
-                                    // perform the following operations:
-                                    // - Detect which values should be
-                                    //   removed and `Remove` them
-                                    // - Detect which values should be
-                                    //   retained, but they changed, we both
-                                    //   `Remove` and `Add` them to notify
+                                    // We diff the old and new sets and perform the following
+                                    // operations:
+                                    // - Detect which values should be removed and `Remove` them
+                                    // - Detect which values should be retained, but they
+                                    //   changed, we both `Remove` and `Add` them to notify
                                     //   the outside of the change
-                                    // - Detect which values should be
-                                    //   added and `Add` them
+                                    // - Detect which values should be added and `Add` them
 
-                                    // FIXME: Currently, we only call the
-                                    // add/remove handlers with when a
-                                    // value enters or leaves the
-                                    // unused_values set. This can be
-                                    // easily copy-paste extended to
-                                    // handle used_values the same way.
+                                    // FIXME: Currently, we only call the add/remove
+                                    // handlers with when a value enters or leaves the
+                                    // unused_values set. This can be easily copy-paste
+                                    // extended to handle used_values the same way.
 
                                     let mut to_remove =
                                         Vec::with_capacity(self.unused_values.len());
@@ -264,12 +258,10 @@ impl Session {
                                             .iter()
                                             .find(|(var_ident, _)| var_ident == current_var_ident)
                                         {
-                                            // The value is present under
-                                            // the same identifier in both
-                                            // new and old value set, but
-                                            // it could have changed! If
-                                            // it did, we both remove the
-                                            // old value and add the new.
+                                            // The value is present under the same
+                                            // identifier in both new and old value set,
+                                            // but it could have changed! If it did, we
+                                            // both remove the old value and add the new.
                                             let geometry = value.unwrap_refcounted_geometry();
 
                                             if geometry != *current_geometry {
@@ -278,9 +270,8 @@ impl Session {
                                                     .push((*var_ident, Arc::clone(&geometry)));
                                             }
                                         } else {
-                                            // The value is no longer
-                                            // present in the new value
-                                            // set, let's remove it!
+                                            // The value is no longer present in the new
+                                            // value set, let's remove it!
                                             to_remove.push(*current_var_ident);
                                         }
                                     }
@@ -310,11 +301,9 @@ impl Session {
 
                                     for (var_ident, value) in value_set.unused_values {
                                         let geometry = value.unwrap_refcounted_geometry();
-                                        // Only add and emit events for
-                                        // values that we didn't have
-                                        // before. We handled
-                                        // re-insertions earlier by
-                                        // comparing the values.
+                                        // Only add and emit events for values that we
+                                        // didn't have before. We handled re-insertions
+                                        // earlier by comparing the values.
                                         if let Entry::Vacant(vacant) =
                                             self.unused_values.entry(var_ident)
                                         {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,19 @@
+use std::f32;
+use std::sync::Arc;
+
 use imgui_winit_support::{HiDpiMode, WinitPlatform};
 
+use crate::convert::{clamp_cast_i32_to_u32, clamp_cast_u32_to_i32};
+use crate::interpreter::ast;
+use crate::interpreter::ParamRefinement;
 use crate::renderer::DrawGeometryMode;
+use crate::session::Session;
 
 const OPENSANS_REGULAR_BYTES: &[u8] = include_bytes!("../resources/OpenSans-Regular.ttf");
 const OPENSANS_BOLD_BYTES: &[u8] = include_bytes!("../resources/OpenSans-Bold.ttf");
 const OPENSANS_LIGHT_BYTES: &[u8] = include_bytes!("../resources/OpenSans-Light.ttf");
+
+const MARGIN: f32 = 10.0;
 
 pub struct FontIds {
     _regular: imgui::FontId,
@@ -25,7 +34,20 @@ impl Ui {
     pub fn new(window: &winit::window::Window) -> Self {
         let mut imgui_context = imgui::Context::create();
         let mut style = imgui_context.style_mut();
-        style.window_padding = [10.0, 10.0];
+
+        style.window_padding = [4.0, 4.0];
+        style.frame_padding = [4.0, 2.0];
+        style.item_spacing = [2.0, 2.0];
+        style.item_inner_spacing = [2.0, 2.0];
+        style.indent_spacing = 8.0;
+
+        style.scrollbar_size = 8.0;
+        style.grab_min_size = 4.0;
+
+        style.window_rounding = 3.0;
+        style.frame_rounding = 3.0;
+        style.scrollbar_rounding = 3.0;
+        style.grab_rounding = 3.0;
 
         imgui_context.set_ini_filename(None);
 
@@ -34,7 +56,7 @@ impl Ui {
         platform.attach_window(imgui_context.io_mut(), window, HiDpiMode::Default);
 
         let hidpi_factor = platform.hidpi_factor();
-        let font_size = (20.0 * hidpi_factor) as f32;
+        let font_size = (15.0 * hidpi_factor) as f32;
 
         let regular_font_id = imgui_context
             .fonts()
@@ -136,13 +158,30 @@ impl<'a> UiFrame<'a> {
         self.imgui_ui.render()
     }
 
-    pub fn draw_renderer_settings_window(&self, draw_mode: &mut DrawGeometryMode) {
+    pub fn draw_viewport_settings_window(&self, draw_mode: &mut DrawGeometryMode) -> bool {
         let ui = &self.imgui_ui;
 
-        imgui::Window::new(imgui::im_str!("Renderer Settings"))
-            .size([250.0, 200.0], imgui::Condition::Once)
+        const VIEWPORT_WINDOW_WIDTH: f32 = 150.0;
+        const VIEWPORT_WINDOW_HEIGHT: f32 = 150.0;
+        let window_logical_size = ui.io().display_size;
+        let window_inner_width = window_logical_size[0] - 2.0 * MARGIN;
+
+        let mut reset_viewport_clicked = false;
+
+        imgui::Window::new(imgui::im_str!("Viewport Settings"))
+            .movable(false)
+            .resizable(false)
+            .size(
+                [VIEWPORT_WINDOW_WIDTH, VIEWPORT_WINDOW_HEIGHT],
+                imgui::Condition::Always,
+            )
+            .position(
+                [window_inner_width + MARGIN - VIEWPORT_WINDOW_WIDTH, MARGIN],
+                imgui::Condition::Always,
+            )
             .build(ui, || {
                 ui.text(imgui::im_str!("{:.3} fps", ui.io().framerate));
+
                 ui.radio_button(
                     imgui::im_str!("Shaded"),
                     draw_mode,
@@ -155,10 +194,506 @@ impl<'a> UiFrame<'a> {
                     DrawGeometryMode::ShadedEdges,
                 );
                 ui.radio_button(
-                    imgui::im_str!("Shaded with Edges (X-RAY)"),
+                    imgui::im_str!("X-RAY"),
                     draw_mode,
                     DrawGeometryMode::ShadedEdgesXray,
                 );
+
+                reset_viewport_clicked = ui.button(imgui::im_str!("Reset Viewport"), [0.0, 0.0]);
             });
+
+        reset_viewport_clicked
     }
+
+    pub fn draw_pipeline_window(&self, session: &mut Session) {
+        let ui = &self.imgui_ui;
+        let function_table = session.function_table();
+
+        const PIPELINE_WINDOW_WIDTH: f32 = 400.0;
+        const PIPELINE_WINDOW_HEIGHT_MULT: f32 = 0.8;
+
+        let window_logical_size = ui.io().display_size;
+        let window_inner_height = window_logical_size[1] - 2.0 * MARGIN;
+
+        let pipeline_window_height = window_inner_height * PIPELINE_WINDOW_HEIGHT_MULT;
+
+        let interpreter_busy = session.interpreter_busy();
+        let mut change = None;
+
+        imgui::Window::new(imgui::im_str!("Pipeline"))
+            .movable(false)
+            .resizable(false)
+            .size([PIPELINE_WINDOW_WIDTH, pipeline_window_height], imgui::Condition::Always)
+            .position([MARGIN, MARGIN], imgui::Condition::Always)
+            .build(ui, || {
+                for (stmt_index, stmt) in session.stmts().iter().enumerate() {
+                    match stmt {
+                        ast::Stmt::VarDecl(var_decl) => {
+                            let call_expr = var_decl.init_expr();
+                            let func_ident = call_expr.ident();
+                            let func = &function_table[&func_ident];
+
+                            if ui
+                                .collapsing_header(&imgui::im_str!(
+                                    "#{} {} ##{}",
+                                    stmt_index + 1,
+                                    func.info().name,
+                                    stmt_index
+                                ))
+                                .default_open(true)
+                                .build()
+                            {
+                                ui.indent();
+
+                                assert_eq!(
+                                    call_expr.args().len(),
+                                    func.param_info().len(),
+                                    "Function call must be generated with correct number of arguments",
+                                );
+
+                                let operation_arg_style_tokens = if interpreter_busy {
+                                    Some(push_disabled_style(ui))
+                                } else {
+                                    None
+                                };
+
+                                for (arg_index, (param_info, arg)) in func
+                                    .param_info()
+                                    .iter()
+                                    .zip(call_expr.args().iter())
+                                    .enumerate()
+                                {
+                                    let input_label = imgui::im_str!(
+                                        "{}##{}-{}",
+                                        &param_info.name,
+                                        stmt_index,
+                                        arg_index
+                                    );
+
+                                    match param_info.refinement {
+                                        ParamRefinement::Boolean(_) => {
+                                            let mut boolean_lit =
+                                                arg.unwrap_literal().unwrap_boolean();
+
+                                            if ui.checkbox(&input_label, &mut boolean_lit) {
+                                                change = Some((
+                                                    stmt_index,
+                                                    arg_index,
+                                                    ast::Expr::Lit(ast::LitExpr::Boolean(
+                                                        boolean_lit,
+                                                    )),
+                                                ));
+                                            }
+                                        }
+                                        ParamRefinement::Int(param_refinement_int) => {
+                                            let mut int_lit = arg.unwrap_literal().unwrap_int();
+
+                                            if ui.input_int(&input_label, &mut int_lit)
+                                                .read_only(interpreter_busy)
+                                                .build()
+                                            {
+                                                int_lit = param_refinement_int.clamp(int_lit);
+                                                change = Some((
+                                                    stmt_index,
+                                                    arg_index,
+                                                    ast::Expr::Lit(ast::LitExpr::Int(int_lit)),
+                                                ));
+                                            }
+                                        }
+                                        ParamRefinement::Uint(param_refinement_uint) => {
+                                            let uint_lit = arg.unwrap_literal().unwrap_uint();
+                                            let mut int_value = clamp_cast_u32_to_i32(uint_lit);
+
+                                            if ui.input_int(&input_label, &mut int_value)
+                                                .read_only(interpreter_busy)
+                                                .build()
+                                            {
+                                                let uint_value = clamp_cast_i32_to_u32(int_value);
+                                                let uint_value = param_refinement_uint.clamp(uint_value);
+                                                change = Some((
+                                                    stmt_index,
+                                                    arg_index,
+                                                    ast::Expr::Lit(ast::LitExpr::Uint(uint_value)),
+                                                ));
+                                            }
+                                        }
+                                        ParamRefinement::Float(param_refinement_float) => {
+                                            let mut float_lit = arg.unwrap_literal().unwrap_float();
+
+                                            if ui.input_float(&input_label, &mut float_lit)
+                                                .read_only(interpreter_busy)
+                                                .build()
+                                            {
+                                                float_lit = param_refinement_float.clamp(float_lit);
+                                                change = Some((
+                                                    stmt_index,
+                                                    arg_index,
+                                                    ast::Expr::Lit(ast::LitExpr::Float(float_lit)),
+                                                ));
+                                            }
+                                        }
+                                        ParamRefinement::Float3(param_refinement_float3) => {
+                                            let mut float3_lit =
+                                                arg.unwrap_literal().unwrap_float3();
+
+                                            if ui
+                                                .input_float3(&input_label, &mut float3_lit)
+                                                .read_only(interpreter_busy)
+                                                .build()
+                                            {
+                                                float3_lit = param_refinement_float3.clamp(float3_lit);
+                                                change = Some((
+                                                    stmt_index,
+                                                    arg_index,
+                                                    ast::Expr::Lit(ast::LitExpr::Float3(
+                                                        float3_lit,
+                                                    )),
+                                                ));
+                                            }
+                                        }
+                                        ParamRefinement::String => {
+                                            let string_lit = arg.unwrap_literal().unwrap_string();
+                                            let mut imstring_value = imgui::ImString::new(string_lit);
+                                            imstring_value.reserve(128);
+
+                                            if ui
+                                                .input_text(&input_label, &mut imstring_value)
+                                                .read_only(interpreter_busy)
+                                                .build() {
+                                                    let string_value = format!("{}", imstring_value);
+                                                    let string_value = Arc::new(string_value);
+                                                    change = Some((
+                                                        stmt_index,
+                                                        arg_index,
+                                                        ast::Expr::Lit(ast::LitExpr::String(string_value)),
+                                                    ));
+                                                }
+                                        }
+                                        ParamRefinement::Geometry => {
+                                            let visible_vars =
+                                                session.var_visibility_at_stmt(stmt_index);
+
+                                            let mut selected_var_index = match arg {
+                                                ast::Expr::Lit(ast::LitExpr::Nil) => None,
+                                                ast::Expr::Var(var) => visible_vars
+                                                    .iter()
+                                                    .position(|var_ident| *var_ident == var.ident())
+                                                    .map(Some)
+                                                    .unwrap_or(None),
+                                                _ => panic!("Arg can either be a variable or nil"),
+                                            };
+
+                                            // FIXME: Show used var idents
+                                            // differently from unused,
+                                            // e.g. grayed-out
+
+                                            let combo_changed = {
+                                                // FIXME: find a way to make combo boxes read-only
+                                                let mut combo = imgui::ComboBox::new(&input_label);
+
+                                                let mut result = false;
+                                                let preview_value = selected_var_index
+                                                    .map(|index| visible_vars.get(index).unwrap())
+                                                    .map(|var_ident| {
+                                                        format_var_name(
+                                                            session
+                                                                .var_name_for_ident(*var_ident)
+                                                                .expect(
+                                                                    "Failed to find name to ident",
+                                                                ),
+                                                            *var_ident,
+                                                        )
+                                                    })
+                                                    .unwrap_or_else(|| imgui::ImString::new("<Nil>"));
+
+                                                combo = combo.preview_value(&preview_value);
+
+                                                if let Some(combo_token) = combo.begin(ui) {
+                                                    for (index, var_ident) in
+                                                        visible_vars.iter().enumerate()
+                                                    {
+                                                        let text = format_var_name(
+                                                            session
+                                                                .var_name_for_ident(*var_ident)
+                                                                .expect(
+                                                                    "Failed to find name for ident",
+                                                                ),
+                                                            *var_ident,
+                                                        );
+                                                        let selected =
+                                                            if let Some(selected_var_index) =
+                                                                selected_var_index
+                                                            {
+                                                                index == selected_var_index
+                                                            } else {
+                                                                false
+                                                            };
+
+                                                        if imgui::Selectable::new(&text)
+                                                            .selected(selected)
+                                                            .build(ui)
+                                                        {
+                                                            selected_var_index = Some(index);
+                                                            result = true;
+                                                        }
+                                                    }
+
+                                                    if imgui::Selectable::new(imgui::im_str!(
+                                                        "<Nil>"
+                                                    ))
+                                                    .selected(selected_var_index.is_none())
+                                                    .build(ui)
+                                                    {
+                                                        selected_var_index = None;
+                                                        result = true;
+                                                    }
+
+                                                    combo_token.end(ui);
+                                                }
+
+                                                result
+                                            };
+
+                                            if combo_changed {
+                                                if let Some(selected_var_index) = selected_var_index
+                                                {
+                                                    change = Some((
+                                                        stmt_index,
+                                                        arg_index,
+                                                        ast::Expr::Var(ast::VarExpr::new(
+                                                            visible_vars[selected_var_index],
+                                                        )),
+                                                    ))
+                                                } else {
+                                                    change = Some((
+                                                        stmt_index,
+                                                        arg_index,
+                                                        ast::Expr::Lit(ast::LitExpr::Nil),
+                                                    ))
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                let token = ui.push_style_color(
+                                    imgui::StyleColor::FrameBg,
+                                    [0.080, 0.080, 0.080, 0.940],
+                                );
+
+                                imgui::InputTextMultiline::new(
+                                    ui,
+                                    &imgui::im_str!("##console{}", stmt_index),
+                                    &mut imgui::ImString::new("Lorem Ipsum Dolor Sit Amet"),
+                                    [0.0, 60.0],
+                                )
+                                    .read_only(true)
+                                    .build();
+
+                                token.pop(ui);
+
+                                if let Some((color_token, style_token)) = operation_arg_style_tokens {
+                                    color_token.pop(ui);
+                                    style_token.pop(ui);
+                                }
+
+                                ui.unindent();
+                            }
+                        }
+                    }
+                }
+            });
+
+        // FIXME: Debounce changes to parameters
+
+        // Only submit the change if interpreter is not busy. Not all
+        // imgui components can be made read-only, so we can not trust
+        // it.
+        if !interpreter_busy {
+            if let Some((stmt_index, arg_index, expr)) = change {
+                let stmt = &session.stmts()[stmt_index];
+                match stmt {
+                    ast::Stmt::VarDecl(var_decl) => {
+                        let init_expr = var_decl.init_expr();
+                        let new_var_decl = var_decl
+                            .clone_with_init_expr(init_expr.clone_with_arg_at(arg_index, expr));
+
+                        session.set_prog_stmt_at(stmt_index, ast::Stmt::VarDecl(new_var_decl));
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn draw_operations_window(&self, session: &mut Session) {
+        let ui = &self.imgui_ui;
+        let function_table = session.function_table();
+
+        const OPERATIONS_WINDOW_WIDTH: f32 = 400.0;
+        const OPERATIONS_WINDOW_HEIGHT_MULT: f32 = 0.2;
+
+        let window_logical_size = ui.io().display_size;
+        let window_inner_height = window_logical_size[1] - 2.0 * MARGIN;
+
+        let operations_window_height = window_inner_height * OPERATIONS_WINDOW_HEIGHT_MULT - MARGIN;
+        let operations_window_vertical_position =
+            MARGIN * 2.0 + (1.0 - OPERATIONS_WINDOW_HEIGHT_MULT) * window_inner_height;
+
+        let running_enabled = !session.interpreter_busy() && !session.stmts().is_empty();
+        let popping_enabled = !session.interpreter_busy() && !session.stmts().is_empty();
+        let pushing_enabled = !session.interpreter_busy();
+
+        let mut function_clicked = None;
+        let mut interpret_clicked = false;
+        let mut pop_stmt_clicked = false;
+
+        imgui::Window::new(imgui::im_str!("Operations"))
+            .movable(false)
+            .resizable(false)
+            .size(
+                [OPERATIONS_WINDOW_WIDTH, operations_window_height],
+                imgui::Condition::Always,
+            )
+            .position(
+                [MARGIN, operations_window_vertical_position],
+                imgui::Condition::Always,
+            )
+            .build(ui, || {
+                ui.columns(2, imgui::im_str!("Controls columns"), false);
+
+                let running_tokens = if running_enabled {
+                    None
+                } else {
+                    Some(push_disabled_style(ui))
+                };
+                if ui.button(imgui::im_str!("Run pipeline"), [-f32::MIN_POSITIVE, 25.0])
+                    && running_enabled
+                {
+                    interpret_clicked = true;
+                }
+                if let Some((color_token, style_token)) = running_tokens {
+                    color_token.pop(ui);
+                    style_token.pop(ui);
+                }
+
+                ui.next_column();
+
+                let popping_tokens = if popping_enabled {
+                    None
+                } else {
+                    Some(push_disabled_style(ui))
+                };
+                if ui.button(
+                    imgui::im_str!("Remove last operation"),
+                    [-f32::MIN_POSITIVE, 25.0],
+                ) && popping_enabled
+                {
+                    pop_stmt_clicked = true;
+                }
+                if let Some((color_token, style_token)) = popping_tokens {
+                    color_token.pop(ui);
+                    style_token.pop(ui);
+                }
+
+                ui.separator();
+
+                let pushing_tokens = if pushing_enabled {
+                    None
+                } else {
+                    Some(push_disabled_style(ui))
+                };
+                ui.columns(3, imgui::im_str!("Add operations columns"), false);
+                for (func_ident, func) in function_table {
+                    if ui.button(
+                        &imgui::im_str!("{}", func.info().name),
+                        [-f32::MIN_POSITIVE, 20.0],
+                    ) && pushing_enabled
+                    {
+                        function_clicked = Some(func_ident);
+                    }
+                    ui.next_column();
+                }
+                if let Some((color_token, style_token)) = pushing_tokens {
+                    color_token.pop(ui);
+                    style_token.pop(ui);
+                }
+            });
+
+        if let Some(func_ident) = function_clicked {
+            let func = &function_table[&func_ident];
+            let mut args = Vec::with_capacity(func.param_info().len());
+
+            for param_info in func.param_info() {
+                let expr = match param_info.refinement {
+                    ParamRefinement::Boolean(boolean_refinement) => {
+                        ast::Expr::Lit(ast::LitExpr::Boolean(boolean_refinement.default_value))
+                    }
+                    ParamRefinement::Int(int_param_refinement) => ast::Expr::Lit(
+                        ast::LitExpr::Int(int_param_refinement.default_value.unwrap_or_default()),
+                    ),
+                    ParamRefinement::Uint(uint_param_refinement) => ast::Expr::Lit(
+                        ast::LitExpr::Uint(uint_param_refinement.default_value.unwrap_or_default()),
+                    ),
+                    ParamRefinement::Float(float_param_refinement) => {
+                        ast::Expr::Lit(ast::LitExpr::Float(
+                            float_param_refinement.default_value.unwrap_or_default(),
+                        ))
+                    }
+                    ParamRefinement::Float3(float3_param_refinement) => {
+                        ast::Expr::Lit(ast::LitExpr::Float3([
+                            float3_param_refinement.default_value_x.unwrap_or_default(),
+                            float3_param_refinement.default_value_y.unwrap_or_default(),
+                            float3_param_refinement.default_value_z.unwrap_or_default(),
+                        ]))
+                    }
+                    ParamRefinement::String => {
+                        ast::Expr::Lit(ast::LitExpr::String(Arc::new(String::new())))
+                    }
+                    ParamRefinement::Geometry => {
+                        let visible_vars = session.var_visibility_at_stmt(session.stmts().len());
+                        if visible_vars.is_empty() {
+                            ast::Expr::Lit(ast::LitExpr::Nil)
+                        } else {
+                            ast::Expr::Var(ast::VarExpr::new(visible_vars[0]))
+                        }
+                    }
+                };
+
+                args.push(expr);
+            }
+
+            let init_expr = ast::CallExpr::new(*func_ident, args);
+            let stmt = ast::Stmt::VarDecl(ast::VarDeclStmt::new(
+                session.next_free_var_ident(),
+                init_expr,
+            ));
+
+            session.push_prog_stmt(stmt);
+        }
+
+        if interpret_clicked {
+            session.interpret();
+        }
+
+        if pop_stmt_clicked {
+            session.pop_prog_stmt();
+        }
+    }
+}
+
+fn format_var_name(name: &str, ident: ast::VarIdent) -> imgui::ImString {
+    imgui::im_str!("{} #{}", name, ident.0 + 1)
+}
+
+fn push_disabled_style(ui: &imgui::Ui) -> (imgui::ColorStackToken, imgui::StyleStackToken) {
+    let frame_color = ui.style_color(imgui::StyleColor::Button);
+
+    let color_token = ui.push_style_colors(&[
+        (imgui::StyleColor::Button, frame_color),
+        (imgui::StyleColor::ButtonHovered, frame_color),
+        (imgui::StyleColor::ButtonActive, frame_color),
+    ]);
+    let style_token = ui.push_style_vars(&[imgui::StyleVar::Alpha(0.5)]);
+
+    (color_token, style_token)
 }


### PR DESCRIPTION
The editor session keeps track of the current pipeline program,
notifies the interpreter of changes, and can also trigger running the
pipeline program in the interpreter. It can poll for responses from
the interpreter, and update its state accordingly.

The UI communicates directly with the session. UI actions modify the
program in the session, and the session transmits the changes to the
interpreter. Running the pipeline can be triggered in the UI.

The UI for editing (push/pop/set) operations is disabled whenever the
interpreter is busy, so that we can later add error reporting to
either the operation console, or as a tooltip over an operation. The
interpreter is considered busy when there still exists at least one
request in flight with the interpreter server.