### PR TITLE
Join multiple meshes at once

### DIFF
--- a/src/interpreter/value.rs
+++ b/src/interpreter/value.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::convert::{cast_u32, cast_usize};
@@ -255,8 +256,14 @@ impl MeshArrayValue {
         self.0.is_empty()
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = Arc<Mesh>> + 'a {
+    pub fn iter_refcounted<'a>(&'a self) -> impl Iterator<Item = Arc<Mesh>> + 'a {
         self.0.iter().cloned()
+    }
+
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a Mesh> + 'a {
+        self.0
+            .iter()
+            .map(|refcounted_mesh| Arc::deref(refcounted_mesh))
     }
 }
 

--- a/src/interpreter_funcs/join_group.rs
+++ b/src/interpreter_funcs/join_group.rs
@@ -34,7 +34,6 @@ impl Func for FuncJoinGroup {
     fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
         let mesh_arc_array = args[0].unwrap_mesh_array();
 
-        // TODO: this doesn't work :(
         let meshes = mesh_arc_array.iter();
         let value = tools::join_multiple_meshes(meshes);
         Ok(Value::Mesh(Arc::new(value)))

--- a/src/interpreter_funcs/join_group.rs
+++ b/src/interpreter_funcs/join_group.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use crate::interpreter::{
+    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, Value,
+};
+use crate::mesh::tools;
+
+pub struct FuncJoinGroup;
+
+impl Func for FuncJoinGroup {
+    fn info(&self) -> &FuncInfo {
+        &FuncInfo {
+            name: "Join Group",
+            return_value_name: "Joined Meshes",
+        }
+    }
+
+    fn flags(&self) -> FuncFlags {
+        FuncFlags::PURE
+    }
+
+    fn param_info(&self) -> &[ParamInfo] {
+        &[ParamInfo {
+            name: "Group",
+            refinement: ParamRefinement::MeshArray,
+            optional: false,
+        }]
+    }
+
+    fn return_ty(&self) -> Ty {
+        Ty::Mesh
+    }
+
+    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+        let mesh_arc_array = args[0].unwrap_mesh_array();
+
+        // TODO: this doesn't work :(
+        let meshes = mesh_arc_array.iter();
+        let value = tools::join_multiple_meshes(meshes);
+        Ok(Value::Mesh(Arc::new(value)))
+    }
+}

--- a/src/interpreter_funcs/join_group.rs
+++ b/src/interpreter_funcs/join_group.rs
@@ -11,7 +11,7 @@ impl Func for FuncJoinGroup {
     fn info(&self) -> &FuncInfo {
         &FuncInfo {
             name: "Join Group",
-            return_value_name: "Joined Meshes",
+            return_value_name: "Joined Mesh",
         }
     }
 

--- a/src/interpreter_funcs/join_meshes.rs
+++ b/src/interpreter_funcs/join_meshes.rs
@@ -42,7 +42,7 @@ impl Func for FuncJoinMeshes {
         let first_mesh = args[0].unwrap_mesh();
         let second_mesh = args[1].unwrap_mesh();
 
-        let value = tools::join_meshes(first_mesh, second_mesh);
+        let value = tools::join_multiple_meshes(vec![first_mesh, second_mesh]);
         Ok(Value::Mesh(Arc::new(value)))
     }
 }

--- a/src/interpreter_funcs/join_meshes.rs
+++ b/src/interpreter_funcs/join_meshes.rs
@@ -39,10 +39,9 @@ impl Func for FuncJoinMeshes {
     }
 
     fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
-        let first_mesh = args[0].unwrap_mesh();
-        let second_mesh = args[1].unwrap_mesh();
+        let meshes = args.iter().map(|a| a.unwrap_mesh());
 
-        let value = tools::join_multiple_meshes(vec![first_mesh, second_mesh]);
+        let value = tools::join_multiple_meshes(meshes);
         Ok(Value::Mesh(Arc::new(value)))
     }
 }

--- a/src/interpreter_funcs/mod.rs
+++ b/src/interpreter_funcs/mod.rs
@@ -8,6 +8,7 @@ use self::create_uv_sphere::FuncCreateUvSphere;
 use self::disjoint_mesh::FuncDisjointMesh;
 use self::extract::FuncExtract;
 use self::import_obj_mesh::FuncImportObjMesh;
+use self::join_group::FuncJoinGroup;
 use self::join_meshes::FuncJoinMeshes;
 use self::laplacian_smoothing::FuncLaplacianSmoothing;
 use self::loop_subdivision::FuncLoopSubdivision;
@@ -22,6 +23,7 @@ mod create_uv_sphere;
 mod disjoint_mesh;
 mod extract;
 mod import_obj_mesh;
+mod join_group;
 mod join_meshes;
 mod laplacian_smoothing;
 mod loop_subdivision;
@@ -58,6 +60,7 @@ pub const FUNC_ID_JOIN_MESHES: FuncIdent = FuncIdent(9002);
 pub const FUNC_ID_WELD: FuncIdent = FuncIdent(9003);
 pub const FUNC_ID_REVERT_MESH_FACES: FuncIdent = FuncIdent(9004);
 pub const FUNC_ID_SYNCHRONIZE_MESH_FACES: FuncIdent = FuncIdent(9005);
+pub const FUNC_ID_JOIN_GROUP: FuncIdent = FuncIdent(9006);
 
 /// Returns the global set of function definitions available to the
 /// editor.
@@ -101,6 +104,7 @@ pub fn create_function_table() -> BTreeMap<FuncIdent, Box<dyn Func>> {
         FUNC_ID_SYNCHRONIZE_MESH_FACES,
         Box::new(FuncSynchronizeMeshFaces),
     );
+    funcs.insert(FUNC_ID_JOIN_GROUP, Box::new(FuncJoinGroup));
 
     funcs
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ pub fn init_and_run(options: Options) -> ! {
                             scene_gpu_mesh_ids.insert(path, gpu_mesh_id);
                         }
                         Value::MeshArray(mesh_array) => {
-                            for (index, mesh) in mesh_array.iter().enumerate() {
+                            for (index, mesh) in mesh_array.iter_refcounted().enumerate() {
                                 let gpu_mesh = GpuMesh::from_mesh(&mesh);
                                 let gpu_mesh_id = renderer
                                     .add_scene_mesh(&gpu_mesh)


### PR DESCRIPTION
Replace the original `join_meshes` function with `join_multiple_meshes`, which will also get an operation. This is useful after importing an OBJ with many separate meshes and is crucial for voxelization.

There is still an error, though, and I'm too inexperienced (stupid) to fix it. Could you please have a look?

`src/interpreter_funcs/join_group.rs` lines 35 to 39

```
let mesh_arc_array = args[0].unwrap_mesh_array();

let meshes = mesh_arc_array.iter();
let value = tools::join_multiple_meshes(meshes);
```

```
type mismatch resolving `<impl std::iter::Iterator as std::iter::IntoIterator>::Item == &mesh::Mesh`
expected type `std::sync::Arc<mesh::Mesh>`
   found type `&mesh::Mesh`rustc(E0271)
```