### PR TITLE
Work around exclusive fullscreen issues on macOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,23 +78,47 @@ pub fn init_and_run(options: Options) -> ! {
 
     let event_loop = winit::event_loop::EventLoop::new();
     let window = if options.fullscreen {
-        log::info!("Running in fullscreen mode, looking for compatible video modes...");
         let monitor = event_loop.primary_monitor();
 
-        if let Some(video_mode) = monitor.video_modes().next() {
-            log::info!("Found fullscreen video mode: {}", video_mode);
-            winit::window::WindowBuilder::new()
-                .with_title("H.U.R.B.A.N. Selector")
-                .with_fullscreen(Some(winit::window::Fullscreen::Exclusive(video_mode)))
-                .build(&event_loop)
-                .expect("Failed to create window")
-        } else {
-            log::info!("Didn't find compatible video mode, falling back to borderless");
+        // Exclusive fullscreen on macOS has 2 problems:
+        // - winit does not report correct DPI once the window
+        //   switches to fullscreen,
+        // - wgpu on vulkan on metal can not allocate a large enough
+        //   backbuffer.
+        //
+        // Neither of these happen on borderless fullscreen on macOS.
+        // FIXME: Fix these issues in winit and wgpu.
+        #[cfg(target_os = "macos")]
+        {
+            log::info!("Running in fullscreen mode on macOS, opening borderless fullscreen");
             winit::window::WindowBuilder::new()
                 .with_title("H.U.R.B.A.N. Selector")
                 .with_fullscreen(Some(winit::window::Fullscreen::Borderless(monitor)))
                 .build(&event_loop)
                 .expect("Failed to create window")
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            log::info!("Running in fullscreen mode, looking for exclusive fullscreen video modes");
+            if let Some(video_mode) = monitor.video_modes().next() {
+                log::info!(
+                    "Found video mode: {}, opening exclusive fullscreen",
+                    video_mode,
+                );
+                winit::window::WindowBuilder::new()
+                    .with_title("H.U.R.B.A.N. Selector")
+                    .with_fullscreen(Some(winit::window::Fullscreen::Exclusive(video_mode)))
+                    .build(&event_loop)
+                    .expect("Failed to create window")
+            } else {
+                log::info!("Didn't find compatible video mode, opening borderless fullscreen");
+                winit::window::WindowBuilder::new()
+                    .with_title("H.U.R.B.A.N. Selector")
+                    .with_fullscreen(Some(winit::window::Fullscreen::Borderless(monitor)))
+                    .build(&event_loop)
+                    .expect("Failed to create window")
+            }
         }
     } else {
         log::info!("Running in windowed mode");


### PR DESCRIPTION
Simply do not try to do exclusive fullscreen on macOS at all until
the issues are resolved upstream.

Note: this is not reviewable until #97 lands, as that contains a fix that makes fullscreen on macOS not crash your computer 🐈 