### PR TITLE
Unify primitive generators and add box func

### DIFF
--- a/src/interpreter/ast.rs
+++ b/src/interpreter/ast.rs
@@ -156,17 +156,14 @@ impl fmt::Display for Expr {
 /// An expression that evaluates to a constant, literal value.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LitExpr {
-    #[allow(dead_code)]
     Nil,
     #[allow(dead_code)]
     Boolean(bool),
     #[allow(dead_code)]
     Int(i32),
-    #[allow(dead_code)]
     Uint(u32),
-    #[allow(dead_code)]
     Float(f32),
-    #[allow(dead_code)]
+    Float2([f32; 2]),
     Float3([f32; 3]),
     String(Arc<String>),
 }
@@ -216,6 +213,17 @@ impl LitExpr {
         }
     }
 
+    /// Get the literal value if float2, otherwise panic.
+    ///
+    /// # Panics
+    /// This function panics when literal value is not a float2.
+    pub fn unwrap_float2(&self) -> [f32; 2] {
+        match self {
+            LitExpr::Float2(float2) => *float2,
+            _ => panic!("Literal expression not float2"),
+        }
+    }
+
     /// Get the literal value if float3, otherwise panic.
     ///
     /// # Panics
@@ -247,6 +255,7 @@ impl fmt::Display for LitExpr {
             LitExpr::Int(int) => write!(f, "<int {}>", int),
             LitExpr::Uint(uint) => write!(f, "<uint {}>", uint),
             LitExpr::Float(float) => write!(f, "<float {}>", float),
+            LitExpr::Float2(float2) => write!(f, "<float2 [{}, {}]>", float2[0], float2[1]),
             LitExpr::Float3(float3) => {
                 write!(f, "<float3 [{}, {}, {}]>", float3[0], float3[1], float3[2])
             }

--- a/src/interpreter/func.rs
+++ b/src/interpreter/func.rs
@@ -53,6 +53,7 @@ pub enum ParamRefinement {
     Int(IntParamRefinement),
     Uint(UintParamRefinement),
     Float(FloatParamRefinement),
+    Float2(Float2ParamRefinement),
     Float3(Float3ParamRefinement),
     String(StringParamRefinement),
     Mesh,
@@ -66,6 +67,7 @@ impl ParamRefinement {
             Self::Int(_) => Ty::Int,
             Self::Uint(_) => Ty::Uint,
             Self::Float(_) => Ty::Float,
+            Self::Float2(_) => Ty::Float2,
             Self::Float3(_) => Ty::Float3,
             Self::String(_) => Ty::String,
             Self::Mesh => Ty::Mesh,
@@ -148,6 +150,42 @@ impl FloatParamRefinement {
         }
 
         value
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Float2ParamRefinement {
+    pub default_value_x: Option<f32>,
+    pub min_value_x: Option<f32>,
+    pub max_value_x: Option<f32>,
+    pub default_value_y: Option<f32>,
+    pub min_value_y: Option<f32>,
+    pub max_value_y: Option<f32>,
+}
+
+impl Float2ParamRefinement {
+    pub fn clamp(&self, value: [f32; 2]) -> [f32; 2] {
+        let x = if let Some(min_x) = self.min_value_x {
+            if value[0] < min_x {
+                min_x
+            } else {
+                value[0]
+            }
+        } else {
+            value[0]
+        };
+
+        let y = if let Some(min_y) = self.min_value_y {
+            if value[1] < min_y {
+                min_y
+            } else {
+                value[1]
+            }
+        } else {
+            value[1]
+        };
+
+        [x, y]
     }
 }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -8,8 +8,9 @@ use std::time::Instant;
 
 pub use self::ast::{FuncIdent, VarIdent};
 pub use self::func::{
-    BooleanParamRefinement, Float3ParamRefinement, FloatParamRefinement, Func, FuncFlags, FuncInfo,
-    IntParamRefinement, ParamInfo, ParamRefinement, StringParamRefinement, UintParamRefinement,
+    BooleanParamRefinement, Float2ParamRefinement, Float3ParamRefinement, FloatParamRefinement,
+    Func, FuncFlags, FuncInfo, IntParamRefinement, ParamInfo, ParamRefinement,
+    StringParamRefinement, UintParamRefinement,
 };
 pub use self::value::{MeshArrayValue, Ty, Value};
 
@@ -699,6 +700,7 @@ fn eval_lit_expr(lit: &ast::LitExpr) -> Result<Value, RuntimeError> {
         ast::LitExpr::Int(int) => Value::Int(*int),
         ast::LitExpr::Uint(uint) => Value::Uint(*uint),
         ast::LitExpr::Float(float) => Value::Float(*float),
+        ast::LitExpr::Float2(float2) => Value::Float2(*float2),
         ast::LitExpr::Float3(float3) => Value::Float3(*float3),
         ast::LitExpr::String(string) => Value::String(Arc::clone(&string)),
         ast::LitExpr::Nil => Value::Nil,
@@ -804,6 +806,7 @@ mod tests {
                 Ty::Int => ParamRefinement::Int(IntParamRefinement::default()),
                 Ty::Uint => ParamRefinement::Uint(UintParamRefinement::default()),
                 Ty::Float => ParamRefinement::Float(FloatParamRefinement::default()),
+                Ty::Float2 => ParamRefinement::Float2(Float2ParamRefinement::default()),
                 Ty::Float3 => ParamRefinement::Float3(Float3ParamRefinement::default()),
                 Ty::String => ParamRefinement::String(StringParamRefinement::default()),
                 Ty::Mesh => ParamRefinement::Mesh,
@@ -1773,7 +1776,10 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Ok(Value::Float(values[0].get_float().unwrap_or(1.0))),
+                |values| match &values[0] {
+                    Value::Float(float_value) => Ok(Value::Float(*float_value)),
+                    _ => Ok(Value::Float(1.0)),
+                },
                 FuncFlags::PURE,
                 vec![param_info(Ty::Float, true)],
                 Ty::Float,
@@ -1801,7 +1807,10 @@ mod tests {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
-                |values| Ok(Value::Float(values[0].get_float().unwrap_or(1.0))),
+                |values| match &values[0] {
+                    Value::Float(float_value) => Ok(Value::Float(*float_value)),
+                    _ => Ok(Value::Float(1.0)),
+                },
                 FuncFlags::PURE,
                 vec![param_info(Ty::Float, true)],
                 Ty::Float,

--- a/src/interpreter/value.rs
+++ b/src/interpreter/value.rs
@@ -16,6 +16,7 @@ pub enum Ty {
     Int,
     Uint,
     Float,
+    Float2,
     Float3,
     String,
     Mesh,
@@ -30,6 +31,7 @@ impl fmt::Display for Ty {
             Ty::Int => f.write_str("Int"),
             Ty::Uint => f.write_str("Uint"),
             Ty::Float => f.write_str("Float"),
+            Ty::Float2 => f.write_str("Float2"),
             Ty::Float3 => f.write_str("Float3"),
             Ty::String => f.write_str("String"),
             Ty::Mesh => f.write_str("Mesh"),
@@ -46,6 +48,7 @@ pub enum Value {
     Int(i32),
     Uint(u32),
     Float(f32),
+    Float2([f32; 2]),
     Float3([f32; 3]),
     String(Arc<String>),
     Mesh(Arc<Mesh>),
@@ -61,75 +64,11 @@ impl Value {
             Value::Int(_) => Ty::Int,
             Value::Uint(_) => Ty::Uint,
             Value::Float(_) => Ty::Float,
+            Value::Float2(_) => Ty::Float2,
             Value::Float3(_) => Ty::Float3,
             Value::String(_) => Ty::String,
             Value::Mesh(_) => Ty::Mesh,
             Value::MeshArray(_) => Ty::MeshArray,
-        }
-    }
-
-    /// Get the value if boolean, otherwise `None`.
-    ///
-    /// Useful for getting a value of an optional parameter.
-    #[allow(dead_code)]
-    pub fn get_boolean(&self) -> Option<bool> {
-        match self {
-            Value::Boolean(boolean) => Some(*boolean),
-            _ => None,
-        }
-    }
-
-    /// Get the value if int, otherwise `None`.
-    ///
-    /// Useful for getting a value of an optional parameter.
-    #[allow(dead_code)]
-    pub fn get_int(&self) -> Option<i32> {
-        match self {
-            Value::Int(int) => Some(*int),
-            _ => None,
-        }
-    }
-
-    /// Get the value if uint, otherwise `None`.
-    ///
-    /// Useful for getting a value of an optional parameter.
-    #[allow(dead_code)]
-    pub fn get_uint(&self) -> Option<u32> {
-        match self {
-            Value::Uint(uint) => Some(*uint),
-            _ => None,
-        }
-    }
-
-    /// Get the value if float, otherwise `None`.
-    ///
-    /// Useful for getting a value of an optional parameter.
-    #[allow(dead_code)]
-    pub fn get_float(&self) -> Option<f32> {
-        match self {
-            Value::Float(float) => Some(*float),
-            _ => None,
-        }
-    }
-
-    /// Get the value if float3, otherwise `None`.
-    ///
-    /// Useful for getting a value of an optional parameter.
-    pub fn get_float3(&self) -> Option<[f32; 3]> {
-        match self {
-            Value::Float3(flaot3) => Some(*flaot3),
-            _ => None,
-        }
-    }
-
-    /// Get the value if mesh, otherwise `None`.
-    ///
-    /// Useful for getting a value of an optional parameter.
-    #[allow(dead_code)]
-    pub fn get_mesh(&self) -> Option<&Mesh> {
-        match self {
-            Value::Mesh(mesh_ptr) => Some(mesh_ptr),
-            _ => None,
         }
     }
 
@@ -179,11 +118,21 @@ impl Value {
         }
     }
 
+    /// Get the value if float2, otherwise panic.
+    ///
+    /// # Panics
+    /// This function panics when value is not a float2.
+    pub fn unwrap_float2(&self) -> [f32; 2] {
+        match self {
+            Value::Float2(float2) => *float2,
+            _ => panic!("Value not float2"),
+        }
+    }
+
     /// Get the value if float3, otherwise panic.
     ///
     /// # Panics
     /// This function panics when value is not a float3.
-    #[allow(dead_code)]
     pub fn unwrap_float3(&self) -> [f32; 3] {
         match self {
             Value::Float3(float3) => *float3,
@@ -275,6 +224,7 @@ impl fmt::Display for Value {
             Value::Int(int) => write!(f, "<int {}>", int),
             Value::Uint(uint) => write!(f, "<uint {}>", uint),
             Value::Float(float) => write!(f, "<float {}>", float),
+            Value::Float2(float2) => write!(f, "<float2 [{}, {}]>", float2[0], float2[1]),
             Value::Float3(float3) => {
                 write!(f, "<float3 [{}, {}, {}]>", float3[0], float3[1], float3[2])
             }

--- a/src/interpreter_funcs/create_uv_sphere.rs
+++ b/src/interpreter_funcs/create_uv_sphere.rs
@@ -2,9 +2,11 @@ use std::error;
 use std::fmt;
 use std::sync::Arc;
 
+use nalgebra::{Point3, Rotation3, Vector3};
+
 use crate::interpreter::{
-    Float3ParamRefinement, FloatParamRefinement, Func, FuncError, FuncFlags, FuncInfo, ParamInfo,
-    ParamRefinement, Ty, UintParamRefinement, Value,
+    Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty,
+    UintParamRefinement, Value,
 };
 use crate::mesh::primitive;
 
@@ -55,7 +57,22 @@ impl Func for FuncCreateUvSphere {
     fn param_info(&self) -> &[ParamInfo] {
         &[
             ParamInfo {
-                name: "Position",
+                name: "Center",
+                refinement: ParamRefinement::Float3(Float3ParamRefinement {
+                    default_value_x: Some(0.0),
+                    min_value_x: None,
+                    max_value_x: None,
+                    default_value_y: Some(0.0),
+                    min_value_y: None,
+                    max_value_y: None,
+                    default_value_z: Some(0.0),
+                    min_value_z: None,
+                    max_value_z: None,
+                }),
+                optional: false,
+            },
+            ParamInfo {
+                name: "Rotate (deg)",
                 refinement: ParamRefinement::Float3(Float3ParamRefinement {
                     default_value_x: Some(0.0),
                     min_value_x: None,
@@ -71,10 +88,16 @@ impl Func for FuncCreateUvSphere {
             },
             ParamInfo {
                 name: "Scale",
-                refinement: ParamRefinement::Float(FloatParamRefinement {
-                    default_value: Some(1.0),
-                    min_value: Some(0.0),
-                    max_value: None,
+                refinement: ParamRefinement::Float3(Float3ParamRefinement {
+                    default_value_x: Some(1.0),
+                    min_value_x: None,
+                    max_value_x: None,
+                    default_value_y: Some(1.0),
+                    min_value_y: None,
+                    max_value_y: None,
+                    default_value_z: Some(1.0),
+                    min_value_z: None,
+                    max_value_z: None,
                 }),
                 optional: false,
             },
@@ -104,10 +127,11 @@ impl Func for FuncCreateUvSphere {
     }
 
     fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
-        let position = args[0].unwrap_float3();
-        let scale = args[1].unwrap_float();
-        let n_parallels = args[2].unwrap_uint();
-        let n_meridians = args[3].unwrap_uint();
+        let center = args[0].unwrap_float3();
+        let rotate = args[1].unwrap_float3();
+        let scale = args[2].unwrap_float3();
+        let n_parallels = args[3].unwrap_uint();
+        let n_meridians = args[4].unwrap_uint();
 
         if n_parallels < Self::MIN_PARALLELS {
             return Err(FuncError::new(FuncCreateUvSphereError::TooFewParallels {
@@ -121,7 +145,17 @@ impl Func for FuncCreateUvSphere {
             }));
         }
 
-        let value = primitive::create_uv_sphere(position, scale, n_parallels, n_meridians);
+        let value = primitive::create_uv_sphere(
+            Point3::from(center),
+            Rotation3::from_euler_angles(
+                rotate[0].to_radians(),
+                rotate[1].to_radians(),
+                rotate[2].to_radians(),
+            ),
+            Vector3::from(scale),
+            n_parallels,
+            n_meridians,
+        );
         Ok(Value::Mesh(Arc::new(value)))
     }
 }

--- a/src/interpreter_funcs/mod.rs
+++ b/src/interpreter_funcs/mod.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use crate::importer::{EndlessCache, Importer};
 use crate::interpreter::{Func, FuncIdent};
 
+use self::create_box::FuncCreateBox;
 use self::create_plane::FuncCreatePlane;
 use self::create_uv_sphere::FuncCreateUvSphere;
 use self::disjoint_mesh::FuncDisjointMesh;
@@ -18,6 +19,7 @@ use self::synchronize_mesh_faces::FuncSynchronizeMeshFaces;
 use self::transform::FuncTransform;
 use self::weld::FuncWeld;
 
+mod create_box;
 mod create_plane;
 mod create_uv_sphere;
 mod disjoint_mesh;
@@ -45,6 +47,7 @@ pub const FUNC_ID_EXTRACT: FuncIdent = FuncIdent(1);
 // Create funcs
 pub const FUNC_ID_CREATE_UV_SPHERE: FuncIdent = FuncIdent(1000);
 pub const FUNC_ID_CREATE_PLANE: FuncIdent = FuncIdent(1001);
+pub const FUNC_ID_CREATE_BOX: FuncIdent = FuncIdent(1002);
 
 // Import/Export funcs
 pub const FUNC_ID_IMPORT_OBJ_MESH: FuncIdent = FuncIdent(2000);
@@ -78,6 +81,7 @@ pub fn create_function_table() -> BTreeMap<FuncIdent, Box<dyn Func>> {
     // Create funcs
     funcs.insert(FUNC_ID_CREATE_UV_SPHERE, Box::new(FuncCreateUvSphere));
     funcs.insert(FUNC_ID_CREATE_PLANE, Box::new(FuncCreatePlane));
+    funcs.insert(FUNC_ID_CREATE_BOX, Box::new(FuncCreateBox));
 
     // Import/Export funcs
     funcs.insert(

--- a/src/interpreter_funcs/shrink_wrap.rs
+++ b/src/interpreter_funcs/shrink_wrap.rs
@@ -1,6 +1,8 @@
 use std::iter;
 use std::sync::Arc;
 
+use nalgebra::{Rotation3, Vector3};
+
 use crate::interpreter::{
     Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, UintParamRefinement,
     Value,
@@ -52,7 +54,12 @@ impl Func for FuncShrinkWrap {
         let bounding_box = BoundingBox::from_meshes(iter::once(mesh));
         let mut value = primitive::create_uv_sphere(
             bounding_box.center().coords.into(),
-            bounding_box.diagonal_length() / 2.0,
+            Rotation3::identity(),
+            Vector3::new(
+                bounding_box.diagonal_length() / 2.0,
+                bounding_box.diagonal_length() / 2.0,
+                bounding_box.diagonal_length() / 2.0,
+            ),
             sphere_density,
             sphere_density,
         );

--- a/src/mesh/analysis.rs
+++ b/src/mesh/analysis.rs
@@ -434,6 +434,8 @@ pub fn are_visually_similar(mesh1: &Mesh, mesh2: &Mesh) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use nalgebra::Rotation3;
+
     use crate::mesh::{primitive, NormalStrategy, TriangleFace};
 
     use super::*;
@@ -721,7 +723,7 @@ mod tests {
         (faces, vertices)
     }
 
-    pub fn cube_sharp_mismatching_winding() -> Mesh {
+    pub fn box_sharp_mismatching_winding() -> Mesh {
         let vertex_positions = vec![
             // back
             Point3::new(-1.0, 1.0, -1.0),
@@ -1025,7 +1027,11 @@ mod tests {
 
     #[test]
     fn test_is_mesh_orientable_returns_true_watertight_mesh() {
-        let mesh = primitive::create_box(Point3::origin(), [1.0; 3]);
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(1.0, 1.0, 1.0),
+        );
         let oriented_edges: Vec<OrientedEdge> = mesh.oriented_edges_iter().collect();
         let edge_sharing_map = edge_sharing(&oriented_edges);
 
@@ -1048,7 +1054,7 @@ mod tests {
 
     #[test]
     fn test_is_mesh_orientable_returns_false_for_nonorientable_mesh() {
-        let mesh = cube_sharp_mismatching_winding();
+        let mesh = box_sharp_mismatching_winding();
 
         let oriented_edges: Vec<OrientedEdge> = mesh.oriented_edges_iter().collect();
         let edge_sharing_map = edge_sharing(&oriented_edges);
@@ -1058,7 +1064,11 @@ mod tests {
 
     #[test]
     fn test_is_mesh_watertight_returns_true_for_watertight_mesh() {
-        let mesh = primitive::create_box(Point3::origin(), [1.0; 3]);
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(1.0, 1.0, 1.0),
+        );
         let oriented_edges: Vec<OrientedEdge> = mesh.oriented_edges_iter().collect();
         let edge_sharing_map = edge_sharing(&oriented_edges);
 
@@ -1082,7 +1092,11 @@ mod tests {
 
     #[test]
     fn test_triangulated_mesh_genus_box_should_be_0() {
-        let mesh = primitive::create_box(Point3::origin(), [1.0; 3]);
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(1.0, 1.0, 1.0),
+        );
         assert!(mesh.is_triangulated());
 
         let edges: HashSet<UnorientedEdge> = mesh.unoriented_edges_iter().collect();
@@ -1171,7 +1185,11 @@ mod tests {
 
     #[test]
     fn test_border_edge_loops_returns_one_for_box() {
-        let mesh = primitive::create_box(Point3::origin(), [1.0; 3]);
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(1.0, 1.0, 1.0),
+        );
 
         let oriented_edges: Vec<OrientedEdge> = mesh.oriented_edges_iter().collect();
         let edge_sharing_map = edge_sharing(&oriented_edges);

--- a/src/mesh/primitive.rs
+++ b/src/mesh/primitive.rs
@@ -1,25 +1,25 @@
-use nalgebra::{Point3, Vector3};
+use nalgebra::{Matrix4, Point3, Rotation3, Vector2, Vector3};
 
 use crate::convert::{cast_u32, cast_usize};
 use crate::plane::Plane;
 
 use super::{Mesh, NormalStrategy, TriangleFace};
 
-pub fn create_mesh_plane(plane: Plane, scale: [f32; 2]) -> Mesh {
+pub fn create_mesh_plane(plane: Plane, scale: Vector2<f32>) -> Mesh {
     #[rustfmt::skip]
     let vertex_positions = vec![
         plane.origin()
-            + (-0.5 * plane.x_vector() * scale[0])
-            + (-0.5 * plane.y_vector() * scale[1]),
+            + (-0.5 * plane.x_vector() * scale.x)
+            + (-0.5 * plane.y_vector() * scale.y),
         plane.origin()
-            + (0.5 * plane.x_vector() * scale[0])
-            + (-0.5 * plane.y_vector() * scale[1]),
+            + ( 0.5 * plane.x_vector() * scale.x)
+            + (-0.5 * plane.y_vector() * scale.y),
         plane.origin()
-            + (0.5 * plane.x_vector() * scale[0])
-            + (0.5 * plane.y_vector() * scale[1]),
+            + ( 0.5 * plane.x_vector() * scale.x)
+            + ( 0.5 * plane.y_vector() * scale.y),
         plane.origin()
-            + (-0.5 * plane.x_vector() * scale[0])
-            + (0.5 * plane.y_vector() * scale[1]),
+            + (-0.5 * plane.x_vector() * scale.x)
+            + ( 0.5 * plane.y_vector() * scale.y),
     ];
 
     let vertex_normals = vec![Vector3::new(0.0, 0.0, 1.0)];
@@ -32,21 +32,25 @@ pub fn create_mesh_plane(plane: Plane, scale: [f32; 2]) -> Mesh {
     Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
 }
 
-#[allow(dead_code)]
-pub fn create_box(center: Point3<f32>, scale: [f32; 3]) -> Mesh {
-    #[rustfmt::skip]
+pub fn create_box(center: Point3<f32>, rotate: Rotation3<f32>, scale: Vector3<f32>) -> Mesh {
+    let translation = Matrix4::new_translation(&center.coords);
+    let rotation = Matrix4::from(rotate);
+    let scaling = Matrix4::new_nonuniform_scaling(&scale);
 
+    let t = translation * rotation * scaling;
+
+    #[rustfmt::skip]
     let vertex_positions = vec![
         // back
-        Point3::new(-0.5 * scale[0] + center.x,  0.5 * scale[1] + center.y, -0.5 * scale[2] + center.z),
-        Point3::new(-0.5 * scale[0] + center.x,  0.5 * scale[1] + center.y,  0.5 * scale[2] + center.z),
-        Point3::new( 0.5 * scale[0] + center.x,  0.5 * scale[1] + center.y,  0.5 * scale[2] + center.z),
-        Point3::new( 0.5 * scale[0] + center.x,  0.5 * scale[1] + center.y, -0.5 * scale[2] + center.z),
+        t.transform_point(&Point3::new(-0.5,  0.5, -0.5)),
+        t.transform_point(&Point3::new(-0.5,  0.5,  0.5)),
+        t.transform_point(&Point3::new( 0.5,  0.5,  0.5)),
+        t.transform_point(&Point3::new( 0.5,  0.5, -0.5)),
         // front
-        Point3::new(-0.5 * scale[0] + center.x, -0.5 * scale[1] + center.y, -0.5 * scale[2] + center.z),
-        Point3::new( 0.5 * scale[0] + center.x, -0.5 * scale[1] + center.y, -0.5 * scale[2] + center.z),
-        Point3::new( 0.5 * scale[0] + center.x, -0.5 * scale[1] + center.y,  0.5 * scale[2] + center.z),
-        Point3::new(-0.5 * scale[0] + center.x, -0.5 * scale[1] + center.y,  0.5 * scale[2] + center.z),
+        t.transform_point(&Point3::new(-0.5, -0.5, -0.5)),
+        t.transform_point(&Point3::new( 0.5, -0.5, -0.5)),
+        t.transform_point(&Point3::new( 0.5, -0.5,  0.5)),
+        t.transform_point(&Point3::new(-0.5, -0.5,  0.5)),
     ];
 
     #[rustfmt::skip]
@@ -96,13 +100,20 @@ pub fn create_box(center: Point3<f32>, scale: [f32; 3]) -> Mesh {
 /// Panics if number of parallels is less than 2 or number of
 /// meridians is less than 3.
 pub fn create_uv_sphere(
-    position: [f32; 3],
-    scale: f32,
+    center: Point3<f32>,
+    rotate: Rotation3<f32>,
+    scale: Vector3<f32>,
     n_parallels: u32,
     n_meridians: u32,
 ) -> Mesh {
     assert!(n_parallels >= 2, "Need at least 2 parallels");
     assert!(n_meridians >= 3, "Need at least 3 meridians");
+
+    let translation = Matrix4::new_translation(&center.coords);
+    let rotation = Matrix4::from(rotate);
+    let scaling = Matrix4::new_nonuniform_scaling(&scale);
+
+    let t = translation * rotation * scaling;
 
     // Add the poles
     let lat_line_max = n_parallels + 2;
@@ -127,7 +138,8 @@ pub fn create_uv_sphere(
             let y = (PI * polar_t).sin() * (TWO_PI * azimuthal_t).sin();
             let z = (PI * polar_t).cos();
 
-            vertex_positions.push(v(x, y, z, position, scale));
+            let point = t.transform_point(&Point3::new(x * 0.5, y * 0.5, z * 0.5));
+            vertex_positions.push(point);
         }
     }
 
@@ -155,10 +167,10 @@ pub fn create_uv_sphere(
     // Add vertex data and band-connecting faces for North and South poles
 
     let north_pole = cast_u32(vertex_positions.len());
-    vertex_positions.push(v(0.0, 0.0, 1.0, position, scale));
+    vertex_positions.push(t.transform_point(&Point3::new(0.0, 0.0, 0.5)));
 
     let south_pole = cast_u32(vertex_positions.len());
-    vertex_positions.push(v(0.0, 0.0, -1.0, position, scale));
+    vertex_positions.push(t.transform_point(&Point3::new(0.0, 0.0, -0.5)));
 
     for i in 0..n_meridians {
         let north_p1 = i;
@@ -180,13 +192,5 @@ pub fn create_uv_sphere(
         faces,
         vertex_positions,
         NormalStrategy::Sharp,
-    )
-}
-
-fn v(x: f32, y: f32, z: f32, translation: [f32; 3], scale: f32) -> Point3<f32> {
-    Point3::new(
-        scale * x + translation[0],
-        scale * y + translation[1],
-        scale * z + translation[2],
     )
 }

--- a/src/mesh/smoothing.rs
+++ b/src/mesh/smoothing.rs
@@ -350,7 +350,7 @@ pub fn loop_subdivision(
 mod tests {
     use std::iter::FromIterator;
 
-    use nalgebra;
+    use nalgebra::{Rotation3, Vector3};
 
     use crate::mesh::{analysis, primitive, topology, NormalStrategy, OrientedEdge};
 
@@ -748,7 +748,13 @@ mod tests {
 
     #[test]
     fn test_loop_subdivision_snapshot_uv_sphere() {
-        let mesh = primitive::create_uv_sphere([0.0; 3], 1.0, 2, 3);
+        let mesh = primitive::create_uv_sphere(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(2.0, 2.0, 2.0),
+            2,
+            3,
+        );
         let v2v = topology::compute_vertex_to_vertex_topology(&mesh);
         let f2f = topology::compute_face_to_face_topology(&mesh);
 
@@ -763,7 +769,11 @@ mod tests {
 
     #[test]
     fn test_loop_subdivision_snapshot_box_sharp() {
-        let mesh = primitive::create_box(Point3::origin(), [1.0; 3]);
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(1.0, 1.0, 1.0),
+        );
         let v2v = topology::compute_vertex_to_vertex_topology(&mesh);
         let f2f = topology::compute_face_to_face_topology(&mesh);
 

--- a/src/mesh/tools.rs
+++ b/src/mesh/tools.rs
@@ -369,6 +369,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use nalgebra::{Rotation3, Vector2};
+
     use crate::mesh::{analysis, primitive};
     use crate::plane::Plane;
 
@@ -531,7 +533,7 @@ mod tests {
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
     }
 
-    pub fn open_cube_sharp_mesh(position: [f32; 3], scale: f32) -> Mesh {
+    pub fn open_box_sharp_mesh(position: [f32; 3], scale: f32) -> Mesh {
         let vertex_positions = vec![
             // back
             v(-1.0, 1.0, -1.0, position, scale), //0
@@ -622,7 +624,7 @@ mod tests {
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
     }
 
-    pub fn welded_cube_smooth_mesh(position: [f32; 3], scale: f32) -> Mesh {
+    pub fn welded_box_smooth_mesh(position: [f32; 3], scale: f32) -> Mesh {
         let vertex_positions = vec![
             // back
             v(-1.0, 1.0, -1.0, position, scale),
@@ -685,7 +687,11 @@ mod tests {
 
     #[test]
     fn test_disjoint_mesh_returns_similar_for_box() {
-        let mesh = primitive::create_box(Point3::origin(), [1.0; 3]);
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(1.0, 1.0, 1.0),
+        );
 
         let calculated_meshes = disjoint_mesh(&mesh);
 
@@ -726,7 +732,7 @@ mod tests {
             &Point3::new(0.0, 0.0, 0.0),
             &Vector3::new(0.0, 0.0, 1.0),
         );
-        let plane_mesh = primitive::create_mesh_plane(plane, [2.0; 2]);
+        let plane_mesh = primitive::create_mesh_plane(plane, Vector2::new(2.0, 2.0));
         let plane_reverted = revert_mesh_faces(&plane_mesh);
 
         let expected_reverted_faces = vec![
@@ -739,18 +745,26 @@ mod tests {
 
     #[test]
     fn test_revert_mesh_faces_once_does_not_equal_original() {
-        let cube = primitive::create_box(Point3::origin(), [1.0; 3]);
-        let cube_reverted = revert_mesh_faces(&cube);
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(1.0, 1.0, 1.0),
+        );
+        let mesh_reverted = revert_mesh_faces(&mesh);
 
-        assert_ne!(cube, cube_reverted);
+        assert_ne!(mesh, mesh_reverted);
     }
 
     #[test]
     fn test_revert_mesh_faces_twice_does_equal_original() {
-        let cube = primitive::create_box(Point3::origin(), [1.0; 3]);
-        let cube_twice_reverted = revert_mesh_faces(&revert_mesh_faces(&cube));
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(1.0, 1.0, 1.0),
+        );
+        let mesh_twice_reverted = revert_mesh_faces(&revert_mesh_faces(&mesh));
 
-        assert_eq!(cube, cube_twice_reverted);
+        assert_eq!(mesh, mesh_twice_reverted);
     }
 
     #[test]
@@ -771,7 +785,13 @@ mod tests {
 
     #[test]
     fn test_synchronize_mesh_winding_for_sphere() {
-        let sphere = primitive::create_uv_sphere([0.0, 0.0, 0.0], 1.0, 10, 10);
+        let sphere = primitive::create_uv_sphere(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(1.0, 1.0, 1.0),
+            10,
+            10,
+        );
         let sphere_faces_one_flipped = sphere.faces().iter().enumerate().map(|(i, f)| match f {
             Face::Triangle(t) => {
                 if i == 5 {
@@ -816,9 +836,9 @@ mod tests {
     }
 
     #[test]
-    fn test_weld_cube_sharp_same_len() {
-        let mesh = open_cube_sharp_mesh([0.0, 0.0, 0.0], 1.0);
-        let mesh_after_welding_correct = welded_cube_smooth_mesh([0.0, 0.0, 0.0], 1.0);
+    fn test_weld_box_sharp_same_len() {
+        let mesh = open_box_sharp_mesh([0.0, 0.0, 0.0], 1.0);
+        let mesh_after_welding_correct = welded_box_smooth_mesh([0.0, 0.0, 0.0], 1.0);
 
         let mesh_after_welding = weld(&mesh, 0.1).expect("Welding failed");
 

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -530,24 +530,35 @@ mod tests {
     }
 
     #[test]
-    fn test_pull_point_to_mesh_cube_point_inside_left() {
-        let cube = primitive::create_box(Point3::origin(), [2.0; 3]);
+    fn test_pull_point_to_mesh_box_point_inside_left() {
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(2.0, 2.0, 2.0),
+        );
         let test_point = Point3::new(-0.25, 0.0, 0.0);
-        let unoriented_edges: Vec<_> = cube.unoriented_edges_iter().collect();
+        let unoriented_edges: Vec<_> = mesh.unoriented_edges_iter().collect();
 
         let point_on_mesh_correct = Point3::new(-1.0, 0.0, 0.0);
         let pulled_point_on_mesh_calculated =
-            pull_point_to_mesh(&test_point, &cube, &unoriented_edges);
+            pull_point_to_mesh(&test_point, &mesh, &unoriented_edges);
 
-        assert_eq!(point_on_mesh_correct, pulled_point_on_mesh_calculated.point);
+        assert!(approx::relative_eq!(
+            pulled_point_on_mesh_calculated.point,
+            point_on_mesh_correct,
+        ));
         assert_eq!(0.75, pulled_point_on_mesh_calculated.distance);
     }
 
     #[test]
-    fn test_pull_point_to_mesh_cube_point_inside_top_front_right() {
-        let cube = primitive::create_box(Point3::origin(), [2.0; 3]);
+    fn test_pull_point_to_mesh_box_point_inside_top_front_right() {
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(2.0, 2.0, 2.0),
+        );
         let test_point = Point3::new(0.25, 0.25, 0.25);
-        let unoriented_edges: Vec<_> = cube.unoriented_edges_iter().collect();
+        let unoriented_edges: Vec<_> = mesh.unoriented_edges_iter().collect();
 
         // any of the following points on mesh would be correct
         let points_on_mesh_correct = vec![
@@ -556,7 +567,7 @@ mod tests {
             Point3::new(0.25, 0.25, 1.0),
         ];
         let pulled_point_on_mesh_calculated =
-            pull_point_to_mesh(&test_point, &cube, &unoriented_edges);
+            pull_point_to_mesh(&test_point, &mesh, &unoriented_edges);
 
         assert!(points_on_mesh_correct
             .iter()
@@ -566,15 +577,19 @@ mod tests {
     }
 
     #[test]
-    fn test_pull_point_to_mesh_cube_point_outside_top_front_right() {
-        let cube = primitive::create_box(Point3::origin(), [2.0; 3]);
+    fn test_pull_point_to_mesh_box_point_outside_top_front_right() {
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(2.0, 2.0, 2.0),
+        );
         let test_point = Point3::new(1.25, 1.25, 1.25);
-        let unoriented_edges: Vec<_> = cube.unoriented_edges_iter().collect();
+        let unoriented_edges: Vec<_> = mesh.unoriented_edges_iter().collect();
 
         // corner
         let point_on_mesh_correct = Point3::new(1.0, 1.0, 1.0);
         let pulled_point_on_mesh_calculated =
-            pull_point_to_mesh(&test_point, &cube, &unoriented_edges);
+            pull_point_to_mesh(&test_point, &mesh, &unoriented_edges);
 
         assert_eq!(pulled_point_on_mesh_calculated.point, point_on_mesh_correct);
         assert_eq!(
@@ -584,15 +599,19 @@ mod tests {
     }
 
     #[test]
-    fn test_pull_point_to_mesh_cube_point_outside_front_right() {
-        let cube = primitive::create_box(Point3::origin(), [2.0; 3]);
+    fn test_pull_point_to_mesh_box_point_outside_front_right() {
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(2.0, 2.0, 2.0),
+        );
         let test_point = Point3::new(1.25, 1.25, 0.25);
-        let unoriented_edges: Vec<_> = cube.unoriented_edges_iter().collect();
+        let unoriented_edges: Vec<_> = mesh.unoriented_edges_iter().collect();
 
         // on the edge
         let point_on_mesh_correct = Point3::new(1.0, 1.0, 0.25);
         let pulled_point_on_mesh_calculated =
-            pull_point_to_mesh(&test_point, &cube, &unoriented_edges);
+            pull_point_to_mesh(&test_point, &mesh, &unoriented_edges);
 
         assert_eq!(pulled_point_on_mesh_calculated.point, point_on_mesh_correct);
         assert_eq!(
@@ -602,13 +621,17 @@ mod tests {
     }
 
     #[test]
-    fn test_pull_point_to_mesh_cube_point_on_face() {
-        let cube = primitive::create_box(Point3::origin(), [2.0; 3]);
+    fn test_pull_point_to_mesh_box_point_on_face() {
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(2.0, 2.0, 2.0),
+        );
         let test_point = Point3::new(0.0, 0.0, 1.0);
-        let unoriented_edges: Vec<_> = cube.unoriented_edges_iter().collect();
+        let unoriented_edges: Vec<_> = mesh.unoriented_edges_iter().collect();
 
         let pulled_point_on_mesh_calculated =
-            pull_point_to_mesh(&test_point, &cube, &unoriented_edges);
+            pull_point_to_mesh(&test_point, &mesh, &unoriented_edges);
 
         assert_eq!(pulled_point_on_mesh_calculated.point, test_point);
         assert_eq!(
@@ -618,13 +641,17 @@ mod tests {
     }
 
     #[test]
-    fn test_pull_point_to_mesh_cube_point_on_edge() {
-        let cube = primitive::create_box(Point3::origin(), [2.0; 3]);
+    fn test_pull_point_to_mesh_box_point_on_edge() {
+        let mesh = primitive::create_box(
+            Point3::origin(),
+            Rotation3::identity(),
+            Vector3::new(2.0, 2.0, 2.0),
+        );
         let test_point = Point3::new(1.0, 1.0, 0.0);
-        let unoriented_edges: Vec<_> = cube.unoriented_edges_iter().collect();
+        let unoriented_edges: Vec<_> = mesh.unoriented_edges_iter().collect();
 
         let pulled_point_on_mesh_calculated =
-            pull_point_to_mesh(&test_point, &cube, &unoriented_edges);
+            pull_point_to_mesh(&test_point, &mesh, &unoriented_edges);
 
         assert_eq!(pulled_point_on_mesh_calculated.point, test_point);
         assert_eq!(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -411,6 +411,25 @@ impl<'a> UiFrame<'a> {
                                                 ));
                                             }
                                         }
+                                        ParamRefinement::Float2(param_refinement_float2) => {
+                                            let mut float2_lit =
+                                                arg.unwrap_literal().unwrap_float2();
+
+                                            if ui
+                                                .input_float2(&input_label, &mut float2_lit)
+                                                .read_only(interpreter_busy)
+                                                .build()
+                                            {
+                                                float2_lit = param_refinement_float2.clamp(float2_lit);
+                                                change = Some((
+                                                    stmt_index,
+                                                    arg_index,
+                                                    ast::Expr::Lit(ast::LitExpr::Float2(
+                                                        float2_lit,
+                                                    )),
+                                                ));
+                                            }
+                                        }
                                         ParamRefinement::Float3(param_refinement_float3) => {
                                             let mut float3_lit =
                                                 arg.unwrap_literal().unwrap_float3();
@@ -683,6 +702,12 @@ impl<'a> UiFrame<'a> {
                         ast::Expr::Lit(ast::LitExpr::Float(
                             float_param_refinement.default_value.unwrap_or_default(),
                         ))
+                    }
+                    ParamRefinement::Float2(float2_param_refinement) => {
+                        ast::Expr::Lit(ast::LitExpr::Float2([
+                            float2_param_refinement.default_value_x.unwrap_or_default(),
+                            float2_param_refinement.default_value_y.unwrap_or_default(),
+                        ]))
                     }
                     ParamRefinement::Float3(float3_param_refinement) => {
                         ast::Expr::Lit(ast::LitExpr::Float3([


### PR DESCRIPTION
Now all primitive generating functions take `center`, `rotate`, `scale` and are able to transform the primitives they generate on their own. One exception is plane, whose `Plane` parameter already contains rotation.

All func definitions have been updated to take advantage of this fact.

Also added is the "Create Box" interpreter func.

This is precursor work for returning box as a default value when an error happens and there is no original mesh to return - e.g. when we are importing.