### PR TITLE
Fix weld generating zero vector normals in some cases

### DIFF
--- a/src/importer.rs
+++ b/src/importer.rs
@@ -297,7 +297,9 @@ mod tests {
             vec![Model {
                 name: tobj_model.name,
                 mesh: Mesh::from_triangle_faces_with_vertices_and_normals(
-                    vec![TriangleFace::new(0, 1, 2)],
+                    vec![TriangleFace::new_with_identical_vertex_and_normal_index(
+                        0, 1, 2
+                    )],
                     vec![
                         Point3::new(6.0, 5.0, 4.0),
                         Point3::new(3.0, 2.0, 1.0),
@@ -334,7 +336,9 @@ mod tests {
                 Model {
                     name: tobj_model_1.name,
                     mesh: Mesh::from_triangle_faces_with_vertices_and_normals(
-                        vec![TriangleFace::new(0, 1, 2)],
+                        vec![TriangleFace::new_with_identical_vertex_and_normal_index(
+                            0, 1, 2
+                        )],
                         vec![
                             Point3::new(6.0, 5.0, 4.0),
                             Point3::new(3.0, 2.0, 1.0),
@@ -350,7 +354,9 @@ mod tests {
                 Model {
                     name: tobj_model_2.name,
                     mesh: Mesh::from_triangle_faces_with_vertices_and_normals(
-                        vec![TriangleFace::new(0, 1, 2)],
+                        vec![TriangleFace::new_with_identical_vertex_and_normal_index(
+                            0, 1, 2
+                        )],
                         vec![
                             Point3::new(16.0, 15.0, 14.0),
                             Point3::new(13.0, 12.0, 11.0),
@@ -610,7 +616,9 @@ mod tests {
             static ref MODELS: Vec<Model> = vec![Model {
                 name: "test".to_string(),
                 mesh: Mesh::from_triangle_faces_with_vertices_and_normals(
-                    vec![TriangleFace::new(0, 1, 2)],
+                    vec![TriangleFace::new_with_identical_vertex_and_normal_index(
+                        0, 1, 2
+                    )],
                     vec![
                         Point3::new(6.0, 5.0, 4.0),
                         Point3::new(3.0, 2.0, 1.0),

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -297,9 +297,7 @@ mod tests {
             vec![Model {
                 name: tobj_model.name,
                 mesh: Mesh::from_triangle_faces_with_vertices_and_normals(
-                    vec![TriangleFace::new_with_identical_vertex_and_normal_index(
-                        0, 1, 2
-                    )],
+                    vec![TriangleFace::from_same_vertex_and_normal_index(0, 1, 2)],
                     vec![
                         Point3::new(6.0, 5.0, 4.0),
                         Point3::new(3.0, 2.0, 1.0),
@@ -336,9 +334,7 @@ mod tests {
                 Model {
                     name: tobj_model_1.name,
                     mesh: Mesh::from_triangle_faces_with_vertices_and_normals(
-                        vec![TriangleFace::new_with_identical_vertex_and_normal_index(
-                            0, 1, 2
-                        )],
+                        vec![TriangleFace::from_same_vertex_and_normal_index(0, 1, 2)],
                         vec![
                             Point3::new(6.0, 5.0, 4.0),
                             Point3::new(3.0, 2.0, 1.0),
@@ -354,9 +350,7 @@ mod tests {
                 Model {
                     name: tobj_model_2.name,
                     mesh: Mesh::from_triangle_faces_with_vertices_and_normals(
-                        vec![TriangleFace::new_with_identical_vertex_and_normal_index(
-                            0, 1, 2
-                        )],
+                        vec![TriangleFace::from_same_vertex_and_normal_index(0, 1, 2)],
                         vec![
                             Point3::new(16.0, 15.0, 14.0),
                             Point3::new(13.0, 12.0, 11.0),
@@ -616,9 +610,7 @@ mod tests {
             static ref MODELS: Vec<Model> = vec![Model {
                 name: "test".to_string(),
                 mesh: Mesh::from_triangle_faces_with_vertices_and_normals(
-                    vec![TriangleFace::new_with_identical_vertex_and_normal_index(
-                        0, 1, 2
-                    )],
+                    vec![TriangleFace::from_same_vertex_and_normal_index(0, 1, 2)],
                     vec![
                         Point3::new(6.0, 5.0, 4.0),
                         Point3::new(3.0, 2.0, 1.0),

--- a/src/mesh/analysis.rs
+++ b/src/mesh/analysis.rs
@@ -331,9 +331,11 @@ pub fn triangulated_mesh_genus(vertex_count: usize, edge_count: usize, face_coun
 
 /// Checks if two meshes are similar.
 ///
-/// Two mesh geometries are similar when they are visually similar
-/// (see the definition of `are_visually_similar`), and they have the
-/// same number of vertices and normals.
+/// Two mesh geometries are similar when they are visually similar (see the
+/// definition of `are_visually_similar`), and they have the same number of
+/// vertices and normals. Therefore they are going to be treated the same by all
+/// functions of this software and all their transformations result in similar
+/// mesh geometries.
 #[allow(dead_code)]
 pub fn are_similar(mesh1: &Mesh, mesh2: &Mesh) -> bool {
     mesh1.vertices().len() == mesh2.vertices().len()
@@ -357,10 +359,11 @@ pub fn are_similar(mesh1: &Mesh, mesh2: &Mesh) -> bool {
 /// normals are identical, because one mesh may reuse (share) vertices and
 /// normals in more faces and the other doesn't (applies to all or some faces).
 ///
-/// They mesh geometries are not necessarily identical in memory but they look
+/// The mesh geometries are not necessarily identical in memory but they look
 /// the same. If the number of vertices differs, the mesh geometries don't share
 /// the same qualities (they are not welded in the same places and at least one
-/// of them is not watertight) are not going to be treated the same by some
+/// of them is not watertight). Despite of that, they are considered to be
+/// visually similar but they are not going to be treated the same by some
 /// functions of this software and all their transformations result in different
 /// mesh geometries.
 #[allow(dead_code)]

--- a/src/mesh/analysis.rs
+++ b/src/mesh/analysis.rs
@@ -362,10 +362,9 @@ pub fn are_similar(mesh1: &Mesh, mesh2: &Mesh) -> bool {
 /// The mesh geometries are not necessarily identical in memory but they look
 /// the same. If the number of vertices differs, the mesh geometries don't share
 /// the same qualities (they are not welded in the same places and at least one
-/// of them is not watertight). Despite of that, they are considered to be
-/// visually similar but they are not going to be treated the same by some
-/// functions of this software and all their transformations result in different
-/// mesh geometries.
+/// of them is not watertight). Despite that they are considered visually
+/// similar, they are not going to be treated the same by some functions of this
+/// software and all their transformations result in different mesh geometries.
 #[allow(dead_code)]
 pub fn are_visually_similar(mesh1: &Mesh, mesh2: &Mesh) -> bool {
     struct UnpackedFace {
@@ -474,7 +473,10 @@ mod tests {
             Vector3::new(-1.0,  1.0,  1.0),
         ];
 
-        let faces = vec![TriangleFace::new(0, 1, 2), TriangleFace::new(2, 3, 0)];
+        let faces = vec![
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2),
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 0),
+        ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
     }
@@ -497,8 +499,8 @@ mod tests {
         ];
 
         let faces = vec![
-            TriangleFace::new_separate(0, 1, 2, 1, 2, 3),
-            TriangleFace::new_separate(3, 4, 0, 3, 4, 0),
+            TriangleFace::new(0, 1, 2, 1, 2, 3),
+            TriangleFace::new(3, 4, 0, 3, 4, 0),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
@@ -519,7 +521,10 @@ mod tests {
             Vector3::new(-1.0, 1.0, 1.0),
         ];
 
-        let faces = vec![TriangleFace::new(1, 0, 2), TriangleFace::new(3, 1, 2)];
+        let faces = vec![
+            TriangleFace::new_with_identical_vertex_and_normal_index(1, 0, 2),
+            TriangleFace::new_with_identical_vertex_and_normal_index(3, 1, 2),
+        ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
     }
@@ -539,7 +544,10 @@ mod tests {
             Vector3::new(1.0, 1.0, 1.0),   //2
         ];
 
-        let faces = vec![TriangleFace::new(2, 0, 3), TriangleFace::new(2, 3, 1)];
+        let faces = vec![
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 0, 3),
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 1),
+        ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
     }
@@ -775,23 +783,23 @@ mod tests {
 
         let faces = vec![
             // back
-            TriangleFace::new(2, 1, 0),
-            TriangleFace::new(2, 3, 0),
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 1, 0),
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 0),
             // top
-            TriangleFace::new(2, 1, 5),
-            TriangleFace::new(2, 5, 6),
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 1, 5),
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 5, 6),
             // right
-            TriangleFace::new(2, 6, 7),
-            TriangleFace::new(7, 3, 2),
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 6, 7),
+            TriangleFace::new_with_identical_vertex_and_normal_index(7, 3, 2),
             // bottom
-            TriangleFace::new(3, 7, 4),
-            TriangleFace::new(4, 0, 3),
+            TriangleFace::new_with_identical_vertex_and_normal_index(3, 7, 4),
+            TriangleFace::new_with_identical_vertex_and_normal_index(4, 0, 3),
             // front
-            TriangleFace::new(6, 4, 7),
-            TriangleFace::new(4, 6, 5),
+            TriangleFace::new_with_identical_vertex_and_normal_index(6, 4, 7),
+            TriangleFace::new_with_identical_vertex_and_normal_index(4, 6, 5),
             // left
-            TriangleFace::new(0, 4, 5),
-            TriangleFace::new(5, 1, 0),
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 4, 5),
+            TriangleFace::new_with_identical_vertex_and_normal_index(5, 1, 0),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)

--- a/src/mesh/analysis.rs
+++ b/src/mesh/analysis.rs
@@ -474,8 +474,8 @@ mod tests {
         ];
 
         let faces = vec![
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2),
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 0),
+            TriangleFace::from_same_vertex_and_normal_index(0, 1, 2),
+            TriangleFace::from_same_vertex_and_normal_index(2, 3, 0),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
@@ -522,8 +522,8 @@ mod tests {
         ];
 
         let faces = vec![
-            TriangleFace::new_with_identical_vertex_and_normal_index(1, 0, 2),
-            TriangleFace::new_with_identical_vertex_and_normal_index(3, 1, 2),
+            TriangleFace::from_same_vertex_and_normal_index(1, 0, 2),
+            TriangleFace::from_same_vertex_and_normal_index(3, 1, 2),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
@@ -545,8 +545,8 @@ mod tests {
         ];
 
         let faces = vec![
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 0, 3),
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 1),
+            TriangleFace::from_same_vertex_and_normal_index(2, 0, 3),
+            TriangleFace::from_same_vertex_and_normal_index(2, 3, 1),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
@@ -783,23 +783,23 @@ mod tests {
 
         let faces = vec![
             // back
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 1, 0),
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 0),
+            TriangleFace::from_same_vertex_and_normal_index(2, 1, 0),
+            TriangleFace::from_same_vertex_and_normal_index(2, 3, 0),
             // top
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 1, 5),
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 5, 6),
+            TriangleFace::from_same_vertex_and_normal_index(2, 1, 5),
+            TriangleFace::from_same_vertex_and_normal_index(2, 5, 6),
             // right
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 6, 7),
-            TriangleFace::new_with_identical_vertex_and_normal_index(7, 3, 2),
+            TriangleFace::from_same_vertex_and_normal_index(2, 6, 7),
+            TriangleFace::from_same_vertex_and_normal_index(7, 3, 2),
             // bottom
-            TriangleFace::new_with_identical_vertex_and_normal_index(3, 7, 4),
-            TriangleFace::new_with_identical_vertex_and_normal_index(4, 0, 3),
+            TriangleFace::from_same_vertex_and_normal_index(3, 7, 4),
+            TriangleFace::from_same_vertex_and_normal_index(4, 0, 3),
             // front
-            TriangleFace::new_with_identical_vertex_and_normal_index(6, 4, 7),
-            TriangleFace::new_with_identical_vertex_and_normal_index(4, 6, 5),
+            TriangleFace::from_same_vertex_and_normal_index(6, 4, 7),
+            TriangleFace::from_same_vertex_and_normal_index(4, 6, 5),
             // left
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 4, 5),
-            TriangleFace::new_with_identical_vertex_and_normal_index(5, 1, 0),
+            TriangleFace::from_same_vertex_and_normal_index(0, 4, 5),
+            TriangleFace::from_same_vertex_and_normal_index(5, 1, 0),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -435,10 +435,6 @@ pub struct TriangleFace {
 }
 
 impl TriangleFace {
-    pub fn new_with_identical_vertex_and_normal_index(i1: u32, i2: u32, i3: u32) -> TriangleFace {
-        TriangleFace::new(i1, i2, i3, i1, i2, i3)
-    }
-
     pub fn new(vi1: u32, vi2: u32, vi3: u32, ni1: u32, ni2: u32, ni3: u32) -> TriangleFace {
         assert!(
             vi1 != vi2 && vi1 != vi3 && vi2 != vi3,
@@ -461,6 +457,10 @@ impl TriangleFace {
                 normals: (ni3, ni1, ni2),
             }
         }
+    }
+
+    pub fn from_same_vertex_and_normal_index(i1: u32, i2: u32, i3: u32) -> TriangleFace {
+        TriangleFace::new(i1, i2, i3, i1, i2, i3)
     }
 
     /// Generates 3 oriented edges from the respective triangular face.
@@ -521,7 +521,7 @@ impl TriangleFace {
 
 impl From<(u32, u32, u32)> for TriangleFace {
     fn from((i1, i2, i3): (u32, u32, u32)) -> TriangleFace {
-        TriangleFace::new_with_identical_vertex_and_normal_index(i1, i2, i3)
+        TriangleFace::from_same_vertex_and_normal_index(i1, i2, i3)
     }
 }
 
@@ -803,8 +803,8 @@ mod tests {
         // manually defined faces start their winding from the lowest vertex
         // index. See TriangleFace constructors for more info.
         let faces = vec![
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2),
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 2, 3),
+            TriangleFace::from_same_vertex_and_normal_index(0, 1, 2),
+            TriangleFace::from_same_vertex_and_normal_index(0, 2, 3),
         ];
 
         (faces, vertices, normals)
@@ -933,8 +933,8 @@ mod tests {
         // manually defined faces start their winding from the lowest vertex
         // index. See TriangleFace constructors for more info.
         let faces = vec![
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2),
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 4),
+            TriangleFace::from_same_vertex_and_normal_index(0, 1, 2),
+            TriangleFace::from_same_vertex_and_normal_index(2, 3, 4),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, normals);
@@ -1038,7 +1038,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_to_oriented_edges() {
-        let face = TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2);
+        let face = TriangleFace::from_same_vertex_and_normal_index(0, 1, 2);
 
         let oriented_edges_correct: [OrientedEdge; 3] = [
             OrientedEdge::new(0, 1),
@@ -1055,7 +1055,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_to_unoriented_edges() {
-        let face = TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2);
+        let face = TriangleFace::from_same_vertex_and_normal_index(0, 1, 2);
 
         let unoriented_edges_correct: [UnorientedEdge; 3] = [
             UnorientedEdge(OrientedEdge::new(0, 1)),
@@ -1073,19 +1073,19 @@ mod tests {
     #[test]
     #[should_panic(expected = "One or more face edges consists of the same vertex")]
     fn test_triangle_face_new_with_invalid_vertex_indices_0_1_should_panic() {
-        TriangleFace::new_with_identical_vertex_and_normal_index(0, 0, 2);
+        TriangleFace::from_same_vertex_and_normal_index(0, 0, 2);
     }
 
     #[test]
     #[should_panic(expected = "One or more face edges consists of the same vertex")]
     fn test_triangle_face_new_with_invalid_vertex_indices_1_2_should_panic() {
-        TriangleFace::new_with_identical_vertex_and_normal_index(0, 2, 2);
+        TriangleFace::from_same_vertex_and_normal_index(0, 2, 2);
     }
 
     #[test]
     #[should_panic(expected = "One or more face edges consists of the same vertex")]
     fn test_triangle_face_new_with_invalid_vertex_indices_0_2_should_panic() {
-        TriangleFace::new_with_identical_vertex_and_normal_index(0, 2, 0);
+        TriangleFace::from_same_vertex_and_normal_index(0, 2, 0);
     }
 
     #[test]
@@ -1307,21 +1307,21 @@ mod tests {
 
     #[test]
     fn test_triangle_face_new_lowest_first() {
-        let face = TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2);
+        let face = TriangleFace::from_same_vertex_and_normal_index(0, 1, 2);
         assert_eq!(face.vertices, (0, 1, 2));
         assert_eq!(face.normals, (0, 1, 2));
     }
 
     #[test]
     fn test_triangle_face_new_lowest_second() {
-        let face = TriangleFace::new_with_identical_vertex_and_normal_index(2, 0, 1);
+        let face = TriangleFace::from_same_vertex_and_normal_index(2, 0, 1);
         assert_eq!(face.vertices, (0, 1, 2));
         assert_eq!(face.normals, (0, 1, 2));
     }
 
     #[test]
     fn test_triangle_face_new_lowest_third() {
-        let face = TriangleFace::new_with_identical_vertex_and_normal_index(1, 2, 0);
+        let face = TriangleFace::from_same_vertex_and_normal_index(1, 2, 0);
         assert_eq!(face.vertices, (0, 1, 2));
         assert_eq!(face.normals, (0, 1, 2));
     }

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -68,14 +68,7 @@ impl Mesh {
                     .enumerate()
                     .map(|(i, (i1, i2, i3))| {
                         let normal_index = cast_u32(i);
-                        TriangleFace::new_separate(
-                            i1,
-                            i2,
-                            i3,
-                            normal_index,
-                            normal_index,
-                            normal_index,
-                        )
+                        TriangleFace::new(i1, i2, i3, normal_index, normal_index, normal_index)
                     })
                     .map(Face::from)
                     .collect();
@@ -442,37 +435,11 @@ pub struct TriangleFace {
 }
 
 impl TriangleFace {
-    pub fn new(i1: u32, i2: u32, i3: u32) -> TriangleFace {
-        assert!(
-            i1 != i2 && i1 != i3 && i2 != i3,
-            "One or more face edges consists of the same vertex"
-        );
-        if i1 < i2 && i1 < i3 {
-            TriangleFace {
-                vertices: (i1, i2, i3),
-                normals: (i1, i2, i3),
-            }
-        } else if i2 < i1 && i2 < i3 {
-            TriangleFace {
-                vertices: (i2, i3, i1),
-                normals: (i2, i3, i1),
-            }
-        } else {
-            TriangleFace {
-                vertices: (i3, i1, i2),
-                normals: (i3, i1, i2),
-            }
-        }
+    pub fn new_with_identical_vertex_and_normal_index(i1: u32, i2: u32, i3: u32) -> TriangleFace {
+        TriangleFace::new(i1, i2, i3, i1, i2, i3)
     }
 
-    pub fn new_separate(
-        vi1: u32,
-        vi2: u32,
-        vi3: u32,
-        ni1: u32,
-        ni2: u32,
-        ni3: u32,
-    ) -> TriangleFace {
+    pub fn new(vi1: u32, vi2: u32, vi3: u32, ni1: u32, ni2: u32, ni3: u32) -> TriangleFace {
         assert!(
             vi1 != vi2 && vi1 != vi3 && vi2 != vi3,
             "One or more face edges consists of the same vertex"
@@ -535,7 +502,7 @@ impl TriangleFace {
 
     /// Returns the same face with reverted vertex and normal winding.
     pub fn to_reverted(&self) -> TriangleFace {
-        TriangleFace::new_separate(
+        TriangleFace::new(
             self.vertices.2,
             self.vertices.1,
             self.vertices.0,
@@ -554,7 +521,7 @@ impl TriangleFace {
 
 impl From<(u32, u32, u32)> for TriangleFace {
     fn from((i1, i2, i3): (u32, u32, u32)) -> TriangleFace {
-        TriangleFace::new(i1, i2, i3)
+        TriangleFace::new_with_identical_vertex_and_normal_index(i1, i2, i3)
     }
 }
 
@@ -776,7 +743,7 @@ fn remove_orphan_vertices_and_normals(
                         old_new_normal_map[old_normal_index_2]
                     };
 
-                faces_renumbered.push(Face::Triangle(TriangleFace::new_separate(
+                faces_renumbered.push(Face::Triangle(TriangleFace::new(
                     cast_u32(new_vertex_index_0),
                     cast_u32(new_vertex_index_1),
                     cast_u32(new_vertex_index_2),
@@ -835,7 +802,10 @@ mod tests {
         // When comparing TriangleFaces or Faces from Mesh, make sure the
         // manually defined faces start their winding from the lowest vertex
         // index. See TriangleFace constructors for more info.
-        let faces = vec![TriangleFace::new(0, 1, 2), TriangleFace::new(0, 2, 3)];
+        let faces = vec![
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2),
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 2, 3),
+        ];
 
         (faces, vertices, normals)
     }
@@ -962,7 +932,10 @@ mod tests {
         // When comparing TriangleFaces or Faces from Mesh, make sure the
         // manually defined faces start their winding from the lowest vertex
         // index. See TriangleFace constructors for more info.
-        let faces = vec![TriangleFace::new(0, 1, 2), TriangleFace::new(2, 3, 4)];
+        let faces = vec![
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2),
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 4),
+        ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, normals);
     }
@@ -1065,7 +1038,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_to_oriented_edges() {
-        let face = TriangleFace::new(0, 1, 2);
+        let face = TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2);
 
         let oriented_edges_correct: [OrientedEdge; 3] = [
             OrientedEdge::new(0, 1),
@@ -1082,7 +1055,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_to_unoriented_edges() {
-        let face = TriangleFace::new(0, 1, 2);
+        let face = TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2);
 
         let unoriented_edges_correct: [UnorientedEdge; 3] = [
             UnorientedEdge(OrientedEdge::new(0, 1)),
@@ -1100,37 +1073,37 @@ mod tests {
     #[test]
     #[should_panic(expected = "One or more face edges consists of the same vertex")]
     fn test_triangle_face_new_with_invalid_vertex_indices_0_1_should_panic() {
-        TriangleFace::new(0, 0, 2);
+        TriangleFace::new_with_identical_vertex_and_normal_index(0, 0, 2);
     }
 
     #[test]
     #[should_panic(expected = "One or more face edges consists of the same vertex")]
     fn test_triangle_face_new_with_invalid_vertex_indices_1_2_should_panic() {
-        TriangleFace::new(0, 2, 2);
+        TriangleFace::new_with_identical_vertex_and_normal_index(0, 2, 2);
     }
 
     #[test]
     #[should_panic(expected = "One or more face edges consists of the same vertex")]
     fn test_triangle_face_new_with_invalid_vertex_indices_0_2_should_panic() {
-        TriangleFace::new(0, 2, 0);
+        TriangleFace::new_with_identical_vertex_and_normal_index(0, 2, 0);
     }
 
     #[test]
     #[should_panic(expected = "One or more face edges consists of the same vertex")]
     fn test_triangle_face_new_separate_with_invalid_vertex_indices_0_1_should_panic() {
-        TriangleFace::new_separate(0, 0, 2, 0, 0, 0);
+        TriangleFace::new(0, 0, 2, 0, 0, 0);
     }
 
     #[test]
     #[should_panic(expected = "One or more face edges consists of the same vertex")]
     fn test_triangle_face_new_separate_with_invalid_vertex_indices_1_2_should_panic() {
-        TriangleFace::new_separate(0, 2, 2, 0, 0, 0);
+        TriangleFace::new(0, 2, 2, 0, 0, 0);
     }
 
     #[test]
     #[should_panic(expected = "One or more face edges consists of the same vertex")]
     fn test_triangle_face_new_separate_with_invalid_vertex_indices_0_2_should_panic() {
-        TriangleFace::new_separate(0, 2, 0, 0, 0, 0);
+        TriangleFace::new(0, 2, 0, 0, 0, 0);
     }
 
     #[test]
@@ -1257,7 +1230,7 @@ mod tests {
         let faces_renumbered_to_match_extend_data: Vec<_> = faces
             .iter()
             .map(|f| {
-                TriangleFace::new_separate(
+                TriangleFace::new(
                     f.vertices.0 + 1,
                     f.vertices.1 + 1,
                     f.vertices.2 + 1,
@@ -1312,7 +1285,7 @@ mod tests {
         let faces_renumbered_to_match_extend_vertices_and_normals: Vec<_> = faces
             .iter()
             .map(|f| {
-                TriangleFace::new_separate(
+                TriangleFace::new(
                     f.vertices.0 + 1,
                     f.vertices.1 + 1,
                     f.vertices.2 + 1,
@@ -1334,50 +1307,50 @@ mod tests {
 
     #[test]
     fn test_triangle_face_new_lowest_first() {
-        let face = TriangleFace::new(0, 1, 2);
+        let face = TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2);
         assert_eq!(face.vertices, (0, 1, 2));
         assert_eq!(face.normals, (0, 1, 2));
     }
 
     #[test]
     fn test_triangle_face_new_lowest_second() {
-        let face = TriangleFace::new(2, 0, 1);
+        let face = TriangleFace::new_with_identical_vertex_and_normal_index(2, 0, 1);
         assert_eq!(face.vertices, (0, 1, 2));
         assert_eq!(face.normals, (0, 1, 2));
     }
 
     #[test]
     fn test_triangle_face_new_lowest_third() {
-        let face = TriangleFace::new(1, 2, 0);
+        let face = TriangleFace::new_with_identical_vertex_and_normal_index(1, 2, 0);
         assert_eq!(face.vertices, (0, 1, 2));
         assert_eq!(face.normals, (0, 1, 2));
     }
 
     #[test]
     fn test_triangle_face_new_separate_lowest_first() {
-        let face = TriangleFace::new_separate(0, 1, 2, 3, 4, 5);
+        let face = TriangleFace::new(0, 1, 2, 3, 4, 5);
         assert_eq!(face.vertices, (0, 1, 2));
         assert_eq!(face.normals, (3, 4, 5));
     }
 
     #[test]
     fn test_triangle_face_new_separate_lowest_second() {
-        let face = TriangleFace::new_separate(2, 0, 1, 5, 3, 4);
+        let face = TriangleFace::new(2, 0, 1, 5, 3, 4);
         assert_eq!(face.vertices, (0, 1, 2));
         assert_eq!(face.normals, (3, 4, 5));
     }
 
     #[test]
     fn test_triangle_face_new_separate_lowest_third() {
-        let face = TriangleFace::new_separate(1, 2, 0, 4, 5, 3);
+        let face = TriangleFace::new(1, 2, 0, 4, 5, 3);
         assert_eq!(face.vertices, (0, 1, 2));
         assert_eq!(face.normals, (3, 4, 5));
     }
 
     #[test]
     fn test_triangle_face_to_reverted_comparison_to_reverted() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
-        let face_reverted_correct = TriangleFace::new_separate(3, 2, 1, 6, 5, 4);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
+        let face_reverted_correct = TriangleFace::new(3, 2, 1, 6, 5, 4);
 
         let face_reverted_calculated = face.to_reverted();
         assert_eq!(face_reverted_correct, face_reverted_calculated);
@@ -1385,7 +1358,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_to_reverted_comparison_to_same() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
 
         let face_reverted_calculated = face.to_reverted();
         assert_ne!(face, face_reverted_calculated);
@@ -1393,8 +1366,8 @@ mod tests {
 
     #[test]
     fn test_triangle_face_to_reverted_comparison_to_reverted_and_shifted() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
-        let face_reverted_correct_shifted = TriangleFace::new_separate(2, 1, 3, 5, 4, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
+        let face_reverted_correct_shifted = TriangleFace::new(2, 1, 3, 5, 4, 6);
 
         let face_reverted_calculated = face.to_reverted();
         assert_eq!(face_reverted_correct_shifted, face_reverted_calculated);
@@ -1402,22 +1375,22 @@ mod tests {
 
     #[test]
     fn test_triangle_face_is_reverted_comparison_to_reverted_and_shifted() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
-        let face_reverted_correct_shifted = TriangleFace::new_separate(2, 1, 3, 5, 4, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
+        let face_reverted_correct_shifted = TriangleFace::new(2, 1, 3, 5, 4, 6);
 
         assert!(face_reverted_correct_shifted.is_reverted(&face));
     }
 
     #[test]
     fn test_triangle_face_is_reverted_comparison_to_self() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
 
         assert!(!face.is_reverted(&face));
     }
 
     #[test]
     fn test_triangle_face_contains_oriented_edge_returns_true_because_contains_all() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
         let oriented_edge_1 = OrientedEdge::new(1, 2);
         let oriented_edge_2 = OrientedEdge::new(2, 3);
         let oriented_edge_3 = OrientedEdge::new(3, 1);
@@ -1429,7 +1402,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_contains_oriented_edge_returns_false_because_contains_all_reverted() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
         let oriented_edge_1 = OrientedEdge::new(2, 1);
         let oriented_edge_2 = OrientedEdge::new(3, 2);
         let oriented_edge_3 = OrientedEdge::new(1, 3);
@@ -1441,7 +1414,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_contains_oriented_edge_returns_false_because_different() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
         let oriented_edge = OrientedEdge::new(4, 5);
 
         assert!(!face.contains_oriented_edge(oriented_edge));
@@ -1449,7 +1422,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_contains_unoriented_edge_returns_true_because_contains_all() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
         let unoriented_edge_1 = UnorientedEdge(OrientedEdge::new(1, 2));
         let unoriented_edge_2 = UnorientedEdge(OrientedEdge::new(2, 3));
         let unoriented_edge_3 = UnorientedEdge(OrientedEdge::new(3, 1));
@@ -1461,7 +1434,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_contains_unoriented_edge_returns_true_because_contains_all_reverted() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
         let unoriented_edge_1 = UnorientedEdge(OrientedEdge::new(2, 1));
         let unoriented_edge_2 = UnorientedEdge(OrientedEdge::new(3, 2));
         let unoriented_edge_3 = UnorientedEdge(OrientedEdge::new(1, 3));
@@ -1473,7 +1446,7 @@ mod tests {
 
     #[test]
     fn test_triangle_face_contains_unoriented_edge_returns_false_because_different() {
-        let face = TriangleFace::new_separate(1, 2, 3, 4, 5, 6);
+        let face = TriangleFace::new(1, 2, 3, 4, 5, 6);
         let unoriented_edge = UnorientedEdge(OrientedEdge::new(4, 5));
 
         assert!(!face.contains_unoriented_edge(unoriented_edge));

--- a/src/mesh/primitive.rs
+++ b/src/mesh/primitive.rs
@@ -25,8 +25,8 @@ pub fn create_mesh_plane(plane: Plane, scale: Vector2<f32>) -> Mesh {
     let vertex_normals = vec![Vector3::new(0.0, 0.0, 1.0)];
 
     let faces = vec![
-        TriangleFace::new_separate(0, 1, 2, 0, 0, 0),
-        TriangleFace::new_separate(2, 3, 0, 0, 0, 0),
+        TriangleFace::new(0, 1, 2, 0, 0, 0),
+        TriangleFace::new(2, 3, 0, 0, 0, 0),
     ];
 
     Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
@@ -71,23 +71,23 @@ pub fn create_box(center: Point3<f32>, rotate: Rotation3<f32>, scale: Vector3<f3
 
     let faces = vec![
         // back
-        TriangleFace::new_separate(0, 1, 2, 0, 0, 0),
-        TriangleFace::new_separate(2, 3, 0, 0, 0, 0),
+        TriangleFace::new(0, 1, 2, 0, 0, 0),
+        TriangleFace::new(2, 3, 0, 0, 0, 0),
         // front
-        TriangleFace::new_separate(4, 5, 6, 1, 1, 1),
-        TriangleFace::new_separate(6, 7, 4, 1, 1, 1),
+        TriangleFace::new(4, 5, 6, 1, 1, 1),
+        TriangleFace::new(6, 7, 4, 1, 1, 1),
         // top
-        TriangleFace::new_separate(7, 6, 1, 2, 2, 2),
-        TriangleFace::new_separate(2, 1, 6, 2, 2, 2),
+        TriangleFace::new(7, 6, 1, 2, 2, 2),
+        TriangleFace::new(2, 1, 6, 2, 2, 2),
         // bottom
-        TriangleFace::new_separate(5, 0, 3, 3, 3, 3),
-        TriangleFace::new_separate(0, 5, 4, 3, 3, 3),
+        TriangleFace::new(5, 0, 3, 3, 3, 3),
+        TriangleFace::new(0, 5, 4, 3, 3, 3),
         // right
-        TriangleFace::new_separate(6, 3, 2, 4, 4, 4),
-        TriangleFace::new_separate(3, 6, 5, 4, 4, 4),
+        TriangleFace::new(6, 3, 2, 4, 4, 4),
+        TriangleFace::new(3, 6, 5, 4, 4, 4),
         // left
-        TriangleFace::new_separate(4, 7, 0, 5, 5, 5),
-        TriangleFace::new_separate(1, 0, 7, 5, 5, 5),
+        TriangleFace::new(4, 7, 0, 5, 5, 5),
+        TriangleFace::new(1, 0, 7, 5, 5, 5),
     ];
 
     Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)

--- a/src/mesh/tools.rs
+++ b/src/mesh/tools.rs
@@ -213,11 +213,13 @@ pub fn weld(mesh: &Mesh, tolerance: f32) -> Option<Mesh> {
                 && new_vertex_indices.0 != new_vertex_indices.2
                 && new_vertex_indices.1 != new_vertex_indices.2
             {
-                Some(Face::Triangle(TriangleFace::new(
-                    new_vertex_indices.0,
-                    new_vertex_indices.1,
-                    new_vertex_indices.2,
-                )))
+                Some(Face::Triangle(
+                    TriangleFace::new_with_identical_vertex_and_normal_index(
+                        new_vertex_indices.0,
+                        new_vertex_indices.1,
+                        new_vertex_indices.2,
+                    ),
+                ))
             } else {
                 None
             }
@@ -349,7 +351,7 @@ where
         } else {
             for face in mesh.faces() {
                 match face {
-                    Face::Triangle(f) => faces.push(Face::Triangle(TriangleFace::new_separate(
+                    Face::Triangle(f) => faces.push(Face::Triangle(TriangleFace::new(
                         f.vertices.0 + vertex_offset_u32,
                         f.vertices.1 + vertex_offset_u32,
                         f.vertices.2 + vertex_offset_u32,
@@ -374,18 +376,6 @@ mod tests {
 
     use super::*;
 
-    fn v(x: f32, y: f32, z: f32, translation: [f32; 3], scale: f32) -> Point3<f32> {
-        Point3::new(
-            scale * x + translation[0],
-            scale * y + translation[1],
-            scale * z + translation[2],
-        )
-    }
-
-    fn n(x: f32, y: f32, z: f32) -> Vector3<f32> {
-        Vector3::new(x, y, z)
-    }
-
     fn welded_tessellated_triangle_mesh() -> Mesh {
         let vertices = vec![
             Point3::new(-2.0, -2.0, 0.0),
@@ -397,19 +387,19 @@ mod tests {
         ];
 
         let vertex_normals = vec![
-            n(0.0, 0.0, 1.0),
-            n(0.0, 0.0, 1.0),
-            n(0.0, 0.0, 1.0),
-            n(0.0, 0.0, 1.0),
-            n(0.0, 0.0, 1.0),
-            n(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
         ];
 
         let faces = vec![
-            TriangleFace::new_separate(0, 1, 3, 0, 1, 3),
-            TriangleFace::new_separate(1, 4, 3, 1, 4, 3),
-            TriangleFace::new_separate(1, 2, 4, 1, 2, 4),
-            TriangleFace::new_separate(3, 4, 5, 3, 4, 5),
+            TriangleFace::new(0, 1, 3, 0, 1, 3),
+            TriangleFace::new(1, 4, 3, 1, 4, 3),
+            TriangleFace::new(1, 2, 4, 1, 2, 4),
+            TriangleFace::new(3, 4, 5, 3, 4, 5),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
@@ -431,13 +421,13 @@ mod tests {
             Point3::new(0.0, 2.0, 0.0),   //5, 11
         ];
 
-        let vertex_normals = vec![n(0.0, 0.0, 1.0)];
+        let vertex_normals = vec![Vector3::new(0.0, 0.0, 1.0)];
 
         let faces = vec![
-            TriangleFace::new_separate(0, 1, 2, 0, 0, 0),
-            TriangleFace::new_separate(3, 4, 5, 0, 0, 0),
-            TriangleFace::new_separate(6, 7, 8, 0, 0, 0),
-            TriangleFace::new_separate(9, 10, 11, 0, 0, 0),
+            TriangleFace::new(0, 1, 2, 0, 0, 0),
+            TriangleFace::new(3, 4, 5, 0, 0, 0),
+            TriangleFace::new(6, 7, 8, 0, 0, 0),
+            TriangleFace::new(9, 10, 11, 0, 0, 0),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
@@ -453,13 +443,13 @@ mod tests {
             Point3::new(0.0, 2.0, 0.0),
         ];
 
-        let vertex_normals = vec![n(0.0, 0.0, 1.0)];
+        let vertex_normals = vec![Vector3::new(0.0, 0.0, 1.0)];
 
         let faces = vec![
-            TriangleFace::new_separate(0, 3, 1, 0, 0, 0),
-            TriangleFace::new_separate(1, 3, 4, 0, 0, 0),
-            TriangleFace::new_separate(1, 4, 2, 0, 0, 0),
-            TriangleFace::new_separate(3, 5, 4, 0, 0, 0),
+            TriangleFace::new(0, 3, 1, 0, 0, 0),
+            TriangleFace::new(1, 3, 4, 0, 0, 0),
+            TriangleFace::new(1, 4, 2, 0, 0, 0),
+            TriangleFace::new(3, 5, 4, 0, 0, 0),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
@@ -478,14 +468,14 @@ mod tests {
             Point3::new(0.0, 2.0, 1.0),
         ];
 
-        let vertex_normals = vec![n(0.0, 0.0, 1.0), n(0.0, 0.0, 1.0)];
+        let vertex_normals = vec![Vector3::new(0.0, 0.0, 1.0), Vector3::new(0.0, 0.0, 1.0)];
 
         let faces = vec![
-            TriangleFace::new_separate(0, 3, 1, 0, 0, 0),
-            TriangleFace::new_separate(1, 3, 4, 0, 0, 0),
-            TriangleFace::new_separate(1, 4, 2, 0, 0, 0),
-            TriangleFace::new_separate(3, 5, 4, 0, 0, 0),
-            TriangleFace::new_separate(6, 7, 8, 1, 1, 1),
+            TriangleFace::new(0, 3, 1, 0, 0, 0),
+            TriangleFace::new(1, 3, 4, 0, 0, 0),
+            TriangleFace::new(1, 4, 2, 0, 0, 0),
+            TriangleFace::new(3, 5, 4, 0, 0, 0),
+            TriangleFace::new(6, 7, 8, 1, 1, 1),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
@@ -504,14 +494,14 @@ mod tests {
             Point3::new(0.0, 2.0, 1.0),
         ];
 
-        let vertex_normals = vec![n(0.0, 0.0, 1.0), n(0.0, 0.0, 1.0)];
+        let vertex_normals = vec![Vector3::new(0.0, 0.0, 1.0), Vector3::new(0.0, 0.0, 1.0)];
 
         let faces = vec![
-            TriangleFace::new_separate(0, 3, 1, 0, 0, 0),
-            TriangleFace::new_separate(1, 3, 4, 0, 0, 0),
-            TriangleFace::new_separate(2, 4, 1, 0, 0, 0), // flipped
-            TriangleFace::new_separate(3, 5, 4, 0, 0, 0),
-            TriangleFace::new_separate(6, 7, 8, 1, 1, 1),
+            TriangleFace::new(0, 3, 1, 0, 0, 0),
+            TriangleFace::new(1, 3, 4, 0, 0, 0),
+            TriangleFace::new(2, 4, 1, 0, 0, 0), // flipped
+            TriangleFace::new(3, 5, 4, 0, 0, 0),
+            TriangleFace::new(6, 7, 8, 1, 1, 1),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
@@ -524,9 +514,9 @@ mod tests {
             Point3::new(0.0, 2.0, 1.0),
         ];
 
-        let vertex_normals = vec![n(0.0, 0.0, 1.0)];
+        let vertex_normals = vec![Vector3::new(0.0, 0.0, 1.0)];
 
-        let faces = vec![TriangleFace::new_separate(0, 1, 2, 0, 0, 0)];
+        let faces = vec![TriangleFace::new(0, 1, 2, 0, 0, 0)];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, vertex_normals)
     }
@@ -567,56 +557,56 @@ mod tests {
 
         let vertex_normals = vec![
             // back
-            n(0.0, 1.0, 0.0),
-            n(0.0, 1.0, 0.0),
-            n(0.0, 1.0, 0.0),
-            n(0.0, 1.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
             // front
-            n(0.0, -1.0, 0.0),
-            n(0.0, -1.0, 0.0),
-            n(0.0, -1.0, 0.0),
-            n(0.0, -1.0, 0.0),
+            Vector3::new(0.0, -1.0, 0.0),
+            Vector3::new(0.0, -1.0, 0.0),
+            Vector3::new(0.0, -1.0, 0.0),
+            Vector3::new(0.0, -1.0, 0.0),
             // top
-            n(0.0, 0.0, 1.0),
-            n(0.0, 0.0, 1.0),
-            n(0.0, 0.0, 1.0),
-            n(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
+            Vector3::new(0.0, 0.0, 1.0),
             // bottom
-            n(0.0, 0.0, -1.0),
-            n(0.0, 0.0, -1.0),
-            n(0.0, 0.0, -1.0),
-            n(0.0, 0.0, -1.0),
+            Vector3::new(0.0, 0.0, -1.0),
+            Vector3::new(0.0, 0.0, -1.0),
+            Vector3::new(0.0, 0.0, -1.0),
+            Vector3::new(0.0, 0.0, -1.0),
             // right
-            n(1.0, 0.0, 0.0),
-            n(1.0, 0.0, 0.0),
-            n(1.0, 0.0, 0.0),
-            n(1.0, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
+            Vector3::new(1.0, 0.0, 0.0),
             // left
-            n(-1.0, 0.0, 0.0),
-            n(-1.0, 0.0, 0.0),
-            n(-1.0, 0.0, 0.0),
-            n(-1.0, 0.0, 0.0),
+            Vector3::new(-1.0, 0.0, 0.0),
+            Vector3::new(-1.0, 0.0, 0.0),
+            Vector3::new(-1.0, 0.0, 0.0),
+            Vector3::new(-1.0, 0.0, 0.0),
         ];
 
         let faces = vec![
             // back
-            TriangleFace::new(0, 1, 2),
-            TriangleFace::new(2, 3, 0),
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2),
+            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 0),
             // front
-            TriangleFace::new(4, 5, 6),
-            TriangleFace::new(6, 7, 4),
+            TriangleFace::new_with_identical_vertex_and_normal_index(4, 5, 6),
+            TriangleFace::new_with_identical_vertex_and_normal_index(6, 7, 4),
             // top
-            TriangleFace::new(8, 9, 10),
-            TriangleFace::new(10, 11, 8),
+            TriangleFace::new_with_identical_vertex_and_normal_index(8, 9, 10),
+            TriangleFace::new_with_identical_vertex_and_normal_index(10, 11, 8),
             // bottom
-            TriangleFace::new(12, 13, 14),
-            TriangleFace::new(14, 15, 12),
+            TriangleFace::new_with_identical_vertex_and_normal_index(12, 13, 14),
+            TriangleFace::new_with_identical_vertex_and_normal_index(14, 15, 12),
             // right
-            TriangleFace::new(16, 17, 18),
-            TriangleFace::new(18, 19, 16),
+            TriangleFace::new_with_identical_vertex_and_normal_index(16, 17, 18),
+            TriangleFace::new_with_identical_vertex_and_normal_index(18, 19, 16),
             // left
-            TriangleFace::new(20, 21, 22),
-            TriangleFace::new(22, 23, 20),
+            TriangleFace::new_with_identical_vertex_and_normal_index(20, 21, 22),
+            TriangleFace::new_with_identical_vertex_and_normal_index(22, 23, 20),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
@@ -635,29 +625,29 @@ mod tests {
         ];
 
         let normals = vec![
-            n(0.25, 0.5, 0.25),
-            n(-0.5, -0.25, 0.25),
-            n(-0.25, 0.25, 0.5),
-            n(0.5, 0.25, -0.25),
-            n(-0.33333334, 0.33333334, -0.33333334),
-            n(-0.25, -0.5, -0.25),
-            n(0.33333334, -0.33333334, 0.33333334),
-            n(0.25, -0.25, -0.5),
+            Vector3::new(0.25, 0.5, 0.25),
+            Vector3::new(-0.5, -0.25, 0.25),
+            Vector3::new(-0.25, 0.25, 0.5),
+            Vector3::new(0.5, 0.25, -0.25),
+            Vector3::new(-0.33333334, 0.33333334, -0.33333334),
+            Vector3::new(-0.25, -0.5, -0.25),
+            Vector3::new(0.33333334, -0.33333334, 0.33333334),
+            Vector3::new(0.25, -0.25, -0.5),
         ];
 
         let faces = vec![
-            TriangleFace::new_separate(0, 4, 2, 0, 4, 2),
-            TriangleFace::new_separate(0, 3, 4, 0, 3, 4),
-            TriangleFace::new_separate(5, 7, 6, 5, 7, 6),
-            TriangleFace::new_separate(1, 5, 6, 1, 5, 6),
-            TriangleFace::new_separate(1, 6, 2, 1, 6, 2),
-            TriangleFace::new_separate(0, 2, 6, 0, 2, 6),
-            TriangleFace::new_separate(3, 7, 4, 3, 7, 4),
-            TriangleFace::new_separate(4, 7, 5, 4, 7, 5),
-            TriangleFace::new_separate(0, 6, 3, 0, 6, 3),
-            TriangleFace::new_separate(3, 6, 7, 3, 6, 7),
-            TriangleFace::new_separate(1, 4, 5, 1, 4, 5),
-            TriangleFace::new_separate(1, 2, 4, 1, 2, 4),
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 4, 2),
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 3, 4),
+            TriangleFace::new_with_identical_vertex_and_normal_index(5, 7, 6),
+            TriangleFace::new_with_identical_vertex_and_normal_index(1, 5, 6),
+            TriangleFace::new_with_identical_vertex_and_normal_index(1, 6, 2),
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 2, 6),
+            TriangleFace::new_with_identical_vertex_and_normal_index(3, 7, 4),
+            TriangleFace::new_with_identical_vertex_and_normal_index(4, 7, 5),
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 6, 3),
+            TriangleFace::new_with_identical_vertex_and_normal_index(3, 6, 7),
+            TriangleFace::new_with_identical_vertex_and_normal_index(1, 4, 5),
+            TriangleFace::new_with_identical_vertex_and_normal_index(1, 2, 4),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, normals)
@@ -725,8 +715,8 @@ mod tests {
         let plane_reverted = revert_mesh_faces(&plane_mesh);
 
         let expected_reverted_faces = vec![
-            Face::Triangle(TriangleFace::new_separate(2, 1, 0, 0, 0, 0)),
-            Face::Triangle(TriangleFace::new_separate(0, 3, 2, 0, 0, 0)),
+            Face::Triangle(TriangleFace::new(2, 1, 0, 0, 0, 0)),
+            Face::Triangle(TriangleFace::new(0, 3, 2, 0, 0, 0)),
         ];
 
         assert_eq!(plane_reverted.faces(), expected_reverted_faces.as_slice());

--- a/src/mesh/tools.rs
+++ b/src/mesh/tools.rs
@@ -214,7 +214,7 @@ pub fn weld(mesh: &Mesh, tolerance: f32) -> Option<Mesh> {
                 && new_vertex_indices.1 != new_vertex_indices.2
             {
                 Some(Face::Triangle(
-                    TriangleFace::new_with_identical_vertex_and_normal_index(
+                    TriangleFace::from_same_vertex_and_normal_index(
                         new_vertex_indices.0,
                         new_vertex_indices.1,
                         new_vertex_indices.2,
@@ -590,23 +590,23 @@ mod tests {
 
         let faces = vec![
             // back
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2),
-            TriangleFace::new_with_identical_vertex_and_normal_index(2, 3, 0),
+            TriangleFace::from_same_vertex_and_normal_index(0, 1, 2),
+            TriangleFace::from_same_vertex_and_normal_index(2, 3, 0),
             // front
-            TriangleFace::new_with_identical_vertex_and_normal_index(4, 5, 6),
-            TriangleFace::new_with_identical_vertex_and_normal_index(6, 7, 4),
+            TriangleFace::from_same_vertex_and_normal_index(4, 5, 6),
+            TriangleFace::from_same_vertex_and_normal_index(6, 7, 4),
             // top
-            TriangleFace::new_with_identical_vertex_and_normal_index(8, 9, 10),
-            TriangleFace::new_with_identical_vertex_and_normal_index(10, 11, 8),
+            TriangleFace::from_same_vertex_and_normal_index(8, 9, 10),
+            TriangleFace::from_same_vertex_and_normal_index(10, 11, 8),
             // bottom
-            TriangleFace::new_with_identical_vertex_and_normal_index(12, 13, 14),
-            TriangleFace::new_with_identical_vertex_and_normal_index(14, 15, 12),
+            TriangleFace::from_same_vertex_and_normal_index(12, 13, 14),
+            TriangleFace::from_same_vertex_and_normal_index(14, 15, 12),
             // right
-            TriangleFace::new_with_identical_vertex_and_normal_index(16, 17, 18),
-            TriangleFace::new_with_identical_vertex_and_normal_index(18, 19, 16),
+            TriangleFace::from_same_vertex_and_normal_index(16, 17, 18),
+            TriangleFace::from_same_vertex_and_normal_index(18, 19, 16),
             // left
-            TriangleFace::new_with_identical_vertex_and_normal_index(20, 21, 22),
-            TriangleFace::new_with_identical_vertex_and_normal_index(22, 23, 20),
+            TriangleFace::from_same_vertex_and_normal_index(20, 21, 22),
+            TriangleFace::from_same_vertex_and_normal_index(22, 23, 20),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertex_positions, vertex_normals)
@@ -636,18 +636,18 @@ mod tests {
         ];
 
         let faces = vec![
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 4, 2),
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 3, 4),
-            TriangleFace::new_with_identical_vertex_and_normal_index(5, 7, 6),
-            TriangleFace::new_with_identical_vertex_and_normal_index(1, 5, 6),
-            TriangleFace::new_with_identical_vertex_and_normal_index(1, 6, 2),
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 2, 6),
-            TriangleFace::new_with_identical_vertex_and_normal_index(3, 7, 4),
-            TriangleFace::new_with_identical_vertex_and_normal_index(4, 7, 5),
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 6, 3),
-            TriangleFace::new_with_identical_vertex_and_normal_index(3, 6, 7),
-            TriangleFace::new_with_identical_vertex_and_normal_index(1, 4, 5),
-            TriangleFace::new_with_identical_vertex_and_normal_index(1, 2, 4),
+            TriangleFace::from_same_vertex_and_normal_index(0, 4, 2),
+            TriangleFace::from_same_vertex_and_normal_index(0, 3, 4),
+            TriangleFace::from_same_vertex_and_normal_index(5, 7, 6),
+            TriangleFace::from_same_vertex_and_normal_index(1, 5, 6),
+            TriangleFace::from_same_vertex_and_normal_index(1, 6, 2),
+            TriangleFace::from_same_vertex_and_normal_index(0, 2, 6),
+            TriangleFace::from_same_vertex_and_normal_index(3, 7, 4),
+            TriangleFace::from_same_vertex_and_normal_index(4, 7, 5),
+            TriangleFace::from_same_vertex_and_normal_index(0, 6, 3),
+            TriangleFace::from_same_vertex_and_normal_index(3, 6, 7),
+            TriangleFace::from_same_vertex_and_normal_index(1, 4, 5),
+            TriangleFace::from_same_vertex_and_normal_index(1, 2, 4),
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, vertices, normals)

--- a/src/renderer/scene_renderer.rs
+++ b/src/renderer/scene_renderer.rs
@@ -1041,7 +1041,7 @@ mod tests {
 
         #[rustfmt::skip]
         let faces = vec![
-            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2)
+            TriangleFace::from_same_vertex_and_normal_index(0, 1, 2)
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, positions, normals)

--- a/src/renderer/scene_renderer.rs
+++ b/src/renderer/scene_renderer.rs
@@ -1041,7 +1041,7 @@ mod tests {
 
         #[rustfmt::skip]
         let faces = vec![
-            TriangleFace::new(0, 1, 2)
+            TriangleFace::new_with_identical_vertex_and_normal_index(0, 1, 2)
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, positions, normals)
@@ -1062,7 +1062,7 @@ mod tests {
 
         #[rustfmt::skip]
         let faces = vec![
-            TriangleFace::new_separate(0, 1, 2, 0, 0, 0)
+            TriangleFace::new(0, 1, 2, 0, 0, 0)
         ];
 
         Mesh::from_triangle_faces_with_vertices_and_normals(faces, positions, normals)


### PR DESCRIPTION
The weld function calculates normals as an average of all normals associated to a respective vertex (a vertex can be referenced by multiple faces, each of them may couple it with a different normal). The original weld function deduplicated associated normals, which was not correct. 
Some optimizations were made too and the tests were adjusted to the current algorithm.