### PR TITLE
Extract largest mesh from a group

### DIFF
--- a/src/interpreter_funcs/extract_largest.rs
+++ b/src/interpreter_funcs/extract_largest.rs
@@ -57,7 +57,7 @@ impl Func for FuncExtractLargest {
         let mut mesh = mesh_iter.next().expect("Array must not be empty");
         let mut largest_face_count = mesh.faces().len();
 
-        while let Some(current_mesh) = mesh_iter.next() {
+        for current_mesh in mesh_iter {
             let current_face_count = current_mesh.faces().len();
             if current_face_count > largest_face_count {
                 largest_face_count = current_face_count;

--- a/src/interpreter_funcs/extract_largest.rs
+++ b/src/interpreter_funcs/extract_largest.rs
@@ -53,21 +53,15 @@ impl Func for FuncExtractLargest {
             return Err(FuncError::new(FuncExtractLargestError::Empty));
         }
 
-        let mut largest_face_count = 0;
-        let mut mesh = mesh_array
-            .get_refcounted(0)
-            .expect("Array must not be empty");
+        let mut mesh_iter = mesh_array.iter_refcounted();
+        let mut mesh = mesh_iter.next().expect("Array must not be empty");
+        let mut largest_face_count = mesh.faces().len();
 
-        if mesh_array.len() > 1 {
-            for current_index in 1..mesh_array.len() {
-                let current_mesh = mesh_array
-                    .get_refcounted(current_index)
-                    .expect("Array must not be empty");
-                let current_face_count = current_mesh.faces().len();
-                if current_face_count > largest_face_count {
-                    largest_face_count = current_face_count;
-                    mesh = current_mesh;
-                }
+        while let Some(current_mesh) = mesh_iter.next() {
+            let current_face_count = current_mesh.faces().len();
+            if current_face_count > largest_face_count {
+                largest_face_count = current_face_count;
+                mesh = current_mesh;
             }
         }
 

--- a/src/interpreter_funcs/extract_largest.rs
+++ b/src/interpreter_funcs/extract_largest.rs
@@ -1,0 +1,76 @@
+use std::error;
+use std::fmt;
+
+use crate::interpreter::{
+    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, Value,
+};
+
+#[derive(Debug, PartialEq)]
+pub enum FuncExtractLargestError {
+    Empty,
+}
+
+impl fmt::Display for FuncExtractLargestError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "No mesh geometry contained in group"),
+        }
+    }
+}
+
+impl error::Error for FuncExtractLargestError {}
+
+pub struct FuncExtractLargest;
+
+impl Func for FuncExtractLargest {
+    fn info(&self) -> &FuncInfo {
+        &FuncInfo {
+            name: "Extract Largest",
+            return_value_name: "Extracted Mesh",
+        }
+    }
+
+    fn flags(&self) -> FuncFlags {
+        FuncFlags::PURE
+    }
+
+    fn param_info(&self) -> &[ParamInfo] {
+        &[ParamInfo {
+            name: "Group",
+            refinement: ParamRefinement::MeshArray,
+            optional: false,
+        }]
+    }
+
+    fn return_ty(&self) -> Ty {
+        Ty::Mesh
+    }
+
+    fn call(&mut self, values: &[Value]) -> Result<Value, FuncError> {
+        let mesh_array = values[0].unwrap_mesh_array();
+
+        if mesh_array.is_empty() {
+            return Err(FuncError::new(FuncExtractLargestError::Empty));
+        }
+
+        let mut largest_face_count = 0;
+        let mut mesh = mesh_array
+            .get_refcounted(0)
+            .expect("Array must not be empty");
+
+        if mesh_array.len() > 1 {
+            for current_index in 1..mesh_array.len() {
+                let current_mesh = mesh_array
+                    .get_refcounted(current_index)
+                    .expect("Array must not be empty");
+                let current_face_count = current_mesh.faces().len();
+                if current_face_count > largest_face_count {
+                    largest_face_count = current_face_count;
+                    mesh = current_mesh;
+                }
+            }
+        }
+
+        Ok(Value::Mesh(mesh))
+    }
+}

--- a/src/interpreter_funcs/mod.rs
+++ b/src/interpreter_funcs/mod.rs
@@ -8,6 +8,7 @@ use self::create_plane::FuncCreatePlane;
 use self::create_uv_sphere::FuncCreateUvSphere;
 use self::disjoint_mesh::FuncDisjointMesh;
 use self::extract::FuncExtract;
+use self::extract_largest::FuncExtractLargest;
 use self::import_obj_mesh::FuncImportObjMesh;
 use self::join_group::FuncJoinGroup;
 use self::join_meshes::FuncJoinMeshes;
@@ -25,6 +26,7 @@ mod create_plane;
 mod create_uv_sphere;
 mod disjoint_mesh;
 mod extract;
+mod extract_largest;
 mod import_obj_mesh;
 mod join_group;
 mod join_meshes;
@@ -45,6 +47,7 @@ mod weld;
 // Manipulation funcs
 pub const FUNC_ID_TRANSFORM: FuncIdent = FuncIdent(0);
 pub const FUNC_ID_EXTRACT: FuncIdent = FuncIdent(1);
+pub const FUNC_ID_EXTRACT_LARGEST: FuncIdent = FuncIdent(2);
 
 // Create funcs
 pub const FUNC_ID_CREATE_UV_SPHERE: FuncIdent = FuncIdent(1000);
@@ -80,6 +83,7 @@ pub fn create_function_table() -> BTreeMap<FuncIdent, Box<dyn Func>> {
     // Manipulation funcs
     funcs.insert(FUNC_ID_TRANSFORM, Box::new(FuncTransform));
     funcs.insert(FUNC_ID_EXTRACT, Box::new(FuncExtract));
+    funcs.insert(FUNC_ID_EXTRACT_LARGEST, Box::new(FuncExtractLargest));
 
     // Create funcs
     funcs.insert(FUNC_ID_CREATE_UV_SPHERE, Box::new(FuncCreateUvSphere));


### PR DESCRIPTION
After importing a 3d-scanned mesh this helps to remove mesh crumbs and some erroneous artifacts.

While reviewing also please have a look at this: https://trello.com/c/RYwqyS1P/258-does-import-automatically-join-meshes-because-after-importing-an-obj-with-more-objects-any-extract-returns-the-whole-contents-of