### PR TITLE
Add interpreter log messages

### DIFF
--- a/src/interpreter/func.rs
+++ b/src/interpreter/func.rs
@@ -1,6 +1,6 @@
 use bitflags::bitflags;
 
-use super::{FuncError, Ty, Value};
+use super::{FuncError, LogMessage, Ty, Value};
 
 /// Textual information about the function.
 pub struct FuncInfo {
@@ -22,6 +22,9 @@ bitflags! {
         /// not be re-run by the interpreter, if their inputs did not
         /// change. This flag triggers optimizations. Setting it
         /// incorrectly might produce stale results.
+        ///
+        /// A pure func's log messages are not returned twice, if the
+        /// func's result has been cached and not invalidated.
         const PURE = 0b_0000_0001;
     }
 }
@@ -291,5 +294,6 @@ pub trait Func {
     ///
     /// [`param_info`]: trait.Func.html#tymethod.param_info
     /// [`return_ty`]: trait.Func.html#tymethod.return_ty
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError>;
+    fn call(&mut self, args: &[Value], log: &mut dyn FnMut(LogMessage))
+        -> Result<Value, FuncError>;
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp;
 use std::collections::hash_map::{Entry, HashMap};
 use std::collections::{BTreeMap, HashSet};
@@ -219,12 +220,65 @@ impl From<RuntimeError> for InterpretError {
     }
 }
 
-pub type InterpretResult = Result<ValueSet, InterpretError>;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogMessageLevel {
+    Info,
+    #[allow(dead_code)]
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogMessage {
+    pub level: LogMessageLevel,
+    pub message: Cow<'static, str>,
+}
+
+impl LogMessage {
+    pub fn info<S: Into<Cow<'static, str>>>(message: S) -> Self {
+        Self {
+            level: LogMessageLevel::Info,
+            message: message.into(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn warn<S: Into<Cow<'static, str>>>(message: S) -> Self {
+        Self {
+            level: LogMessageLevel::Warn,
+            message: message.into(),
+        }
+    }
+
+    pub fn error<S: Into<Cow<'static, str>>>(message: S) -> Self {
+        Self {
+            level: LogMessageLevel::Error,
+            message: message.into(),
+        }
+    }
+}
+
+/// The resulting state of the interpreter after interpretting.
+#[derive(Debug, PartialEq)]
+pub struct InterpretOutcome {
+    /// The result of interpretting. Either a value containing the
+    /// state of variables, or the error on which the interpretting
+    /// failed.
+    pub result: Result<InterpretValue, InterpretError>,
+
+    /// The program counter - index of the statement the interpreter
+    /// would execute next.
+    pub pc: usize,
+
+    /// The log messages for each statement. The vector has the same
+    /// length as the interpreted program.
+    pub log_messages: Vec<Vec<LogMessage>>,
+}
 
 /// The state of variable values as captured by interpreting up to a
 /// certain point in a program.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ValueSet {
+pub struct InterpretValue {
     /// The value of the last executed statement. `None` if no
     /// statement was executed.
     pub last_value: Option<Value>,
@@ -258,10 +312,16 @@ struct VarInfo {
 pub struct Interpreter {
     prog: ast::Prog,
     funcs: BTreeMap<FuncIdent, Box<dyn Func>>,
+
+    /// The environment (scope) of the program's memory. Every
+    /// variable's value is looked up here.
     env: HashMap<VarIdent, VarInfo>,
 
-    /// The program counter. Always points to the **next** stmt to execute.
-    pc: usize,
+    /// The log messages output by functions. The outer vector has the
+    /// same length as the program and is indexed by the same
+    /// statement index. Log messages are always cleared before
+    /// interpretting. This is just to keep the vector warm.
+    log_messages: Vec<Vec<LogMessage>>,
 
     /// The number of changes to the program since the interpreter was
     /// created. Incremented with each program modification.
@@ -278,7 +338,7 @@ impl Interpreter {
             prog: ast::Prog::default(),
             funcs,
             env: HashMap::new(),
-            pc: 0,
+            log_messages: Vec::new(),
             epoch: 0,
             last_resolve_epoch: 0,
         }
@@ -290,22 +350,28 @@ impl Interpreter {
     }
 
     pub fn set_prog(&mut self, prog: ast::Prog) {
-        self.env.clear();
-        self.pc = 0;
-        self.epoch += 1;
         self.prog = prog;
+
+        self.env.clear();
+        self.log_messages
+            .resize_with(self.prog.stmts().len(), Vec::new);
+
+        self.epoch += 1;
     }
 
     pub fn clear_prog(&mut self) {
-        self.env.clear();
-        self.pc = 0;
-        self.epoch += 1;
         self.prog = ast::Prog::default();
+
+        self.env.clear();
+        self.log_messages.clear();
+
+        self.epoch += 1;
     }
 
     pub fn push_prog_stmt(&mut self, stmt: ast::Stmt) {
-        self.epoch += 1;
         self.prog.push_stmt(stmt);
+        self.log_messages.push(Vec::new());
+        self.epoch += 1;
     }
 
     pub fn pop_prog_stmt(&mut self) {
@@ -314,15 +380,9 @@ impl Interpreter {
             "Program must not be empty when popping"
         );
 
-        // If we already executed everything we had so far, decrement
-        // the program counter to mark the stmt for re-execution.
-        if self.pc == self.prog.stmts().len() {
-            self.pc -= 1;
-            assert_eq!(self.pc, self.prog.stmts().len() - 1);
-        }
-
-        self.epoch += 1;
         self.prog.pop_stmt();
+        self.log_messages.pop();
+        self.epoch += 1;
     }
 
     #[allow(dead_code)]
@@ -331,14 +391,8 @@ impl Interpreter {
     }
 
     pub fn set_prog_stmt_at(&mut self, index: usize, stmt: ast::Stmt) {
-        // Mark the stmt and everything following it for re-execution,
-        // if we already executed that far
-        if self.pc > index {
-            self.pc = index;
-        }
-
         self.prog.set_stmt_at(index, stmt);
-
+        self.log_messages[index].clear();
         self.epoch += 1;
     }
 
@@ -400,7 +454,7 @@ impl Interpreter {
 
     /// Interprets the whole currently set program and returns the
     /// used/unused values after the last statement.
-    pub fn interpret(&mut self) -> InterpretResult {
+    pub fn interpret(&mut self) -> InterpretOutcome {
         self.interpret_up_until(self.prog.stmts().len().saturating_sub(1))
     }
 
@@ -410,38 +464,61 @@ impl Interpreter {
     ///
     /// If the program does not contain enough statements, interprets
     /// the program up until the end.
-    pub fn interpret_up_until(&mut self, mut index: usize) -> InterpretResult {
+    pub fn interpret_up_until(&mut self, mut index: usize) -> InterpretOutcome {
         if self.prog.stmts().is_empty() {
-            return Ok(ValueSet {
-                last_value: None,
-                used_values: Vec::new(),
-                unused_values: Vec::new(),
-            });
+            return InterpretOutcome {
+                result: Ok(InterpretValue {
+                    last_value: None,
+                    used_values: Vec::new(),
+                    unused_values: Vec::new(),
+                }),
+                pc: 0,
+                log_messages: vec![Vec::new(); self.log_messages.len()],
+            };
         }
 
-        self.resolve()?;
-        self.typecheck()?;
+        if let Err(err) = self.resolve() {
+            return InterpretOutcome {
+                result: Err(InterpretError::from(err)),
+                pc: 0,
+                log_messages: vec![Vec::new(); self.log_messages.len()],
+            };
+        }
+
+        if let Err(err) = self.typecheck() {
+            return InterpretOutcome {
+                result: Err(InterpretError::from(err)),
+                pc: 0,
+                log_messages: vec![Vec::new(); self.log_messages.len()],
+            };
+        }
 
         index = cmp::min(index, self.prog.stmts().len().saturating_sub(1));
 
-        log::debug!("PC before invalidation: {}", self.pc);
         self.invalidate();
-
-        log::debug!("PC before evaluation: {}", self.pc);
-        if self.pc <= index {
-            // Run remaining operations, write results to vars
-            let range_start = self.pc;
-            let range = self.pc..=index;
-
-            for (stmt_index_offset, stmt) in self.prog.stmts()[range].iter().enumerate() {
-                let stmt_index = range_start + stmt_index_offset;
-                eval_stmt(stmt_index, stmt, &mut self.funcs, &mut self.env)?;
-                self.pc += 1;
-            }
-
-            assert_eq!(self.pc, index + 1);
+        for log_messages in &mut self.log_messages {
+            log_messages.clear();
         }
-        log::debug!("PC after evaluation: {}", self.pc);
+
+        log::debug!("Starting program evaluation with PC: 0");
+
+        for (stmt_index, stmt) in self.prog.stmts()[0..=index].iter().enumerate() {
+            if let Err(err) = eval_stmt(
+                stmt_index,
+                stmt,
+                &mut self.funcs,
+                &mut self.env,
+                &mut self.log_messages,
+            ) {
+                return InterpretOutcome {
+                    result: Err(InterpretError::from(err)),
+                    pc: stmt_index + 1,
+                    log_messages: self.log_messages.clone(),
+                };
+            }
+        }
+
+        log::debug!("Ended program evaluation with PC: {}", index + 1);
 
         let unused_vars = self.compute_unused_vars_up_until(index);
         let last_value = match &self.prog.stmts()[index] {
@@ -477,11 +554,15 @@ impl Interpreter {
             }
         }
 
-        Ok(ValueSet {
-            last_value: Some(last_value),
-            used_values,
-            unused_values,
-        })
+        InterpretOutcome {
+            result: Ok(InterpretValue {
+                last_value: Some(last_value),
+                used_values,
+                unused_values,
+            }),
+            pc: index + 1,
+            log_messages: self.log_messages.clone(),
+        }
     }
 
     /// Computes a set of variable identifiers that would be unused,
@@ -513,7 +594,7 @@ impl Interpreter {
         unused_vars
     }
 
-    /// Invalidate variables in the environment.
+    /// Invalidates variables in the environment.
     ///
     /// Verify all variables we have computed already, invalidating
     /// all that could have possibly changed since last execution.
@@ -522,13 +603,6 @@ impl Interpreter {
     /// the fact that any dependency must come before its dependents
     /// in the examined statements due to the serialized nature of the
     /// program.
-    ///
-    /// If we invalidate any variable, we will have to reset our
-    /// program counter to the statement declaring the earliest
-    /// variable we cleared, once again taking advantage of the
-    /// program's serialized form. Cached variables will be skipped
-    /// over during evaluation though, so this does not generate a lot
-    /// of extra work.
     ///
     /// There are 3 types of variable invalidation:
     ///
@@ -539,13 +613,15 @@ impl Interpreter {
     /// 3) Dependency invalidation: variables referenced in the
     ///    parameters have have been invalidated.
     fn invalidate(&mut self) {
+        // FIXME: We'd like to have this return an execution plan so
+        // that we don't necesarily try to execute stmts only to find
+        // that we already have the results in cache.
+
         // FIXME: This is still very pessimistic, we should support an
         // incremental computation model with fact verification a-lá
         // salsa. https://github.com/salsa-rs/salsa
 
-        let mut new_pc = None;
-
-        for (i, stmt) in self.prog.stmts().iter().enumerate() {
+        for stmt in self.prog.stmts() {
             match stmt {
                 ast::Stmt::VarDecl(var_decl) => {
                     let var_ident = var_decl.ident();
@@ -556,11 +632,7 @@ impl Interpreter {
 
                     if !self.funcs[&func_ident].flags().contains(FuncFlags::PURE) {
                         log::debug!("Performing impurity invalidation of {}", var_ident);
-
                         self.env.remove(&var_ident);
-                        if new_pc.is_none() {
-                            new_pc = Some(i);
-                        }
 
                         continue;
                     }
@@ -573,11 +645,7 @@ impl Interpreter {
 
                         if created_call != init_expr {
                             log::debug!("Performing definition invalidation of {}", var_ident);
-
                             occupied.remove_entry();
-                            if new_pc.is_none() {
-                                new_pc = Some(i);
-                            }
 
                             continue;
                         }
@@ -589,28 +657,13 @@ impl Interpreter {
                         if let ast::Expr::Var(var) = expr {
                             if !self.env.contains_key(&var.ident()) {
                                 log::debug!("Performing dependency invalidation of {}", var_ident);
-
                                 self.env.remove(&var_ident);
-                                if new_pc.is_none() {
-                                    new_pc = Some(i);
-                                }
 
                                 break;
                             }
                         }
                     }
                 }
-            }
-        }
-
-        if let Some(pc) = new_pc {
-            if pc < self.pc {
-                log::debug!(
-                    "Resetting PC after invalidation ({} -> {}) to re-compute vars",
-                    self.pc,
-                    pc,
-                );
-                self.pc = pc;
             }
         }
     }
@@ -621,21 +674,45 @@ fn eval_stmt(
     stmt: &ast::Stmt,
     funcs: &mut BTreeMap<FuncIdent, Box<dyn Func>>,
     env: &mut HashMap<VarIdent, VarInfo>,
+    log_messages: &mut [Vec<LogMessage>],
 ) -> Result<(), RuntimeError> {
     let time_start = Instant::now();
     log::debug!("Evaluating stmt {}: {}", stmt_index, stmt);
 
     let result = match stmt {
-        ast::Stmt::VarDecl(var_decl) => eval_var_decl_stmt(stmt_index, var_decl, funcs, env),
+        ast::Stmt::VarDecl(var_decl) => {
+            eval_var_decl_stmt(stmt_index, var_decl, funcs, env, &mut |message| {
+                log_messages[stmt_index].push(message);
+            })
+        }
     };
 
-    log::debug!(
-        "Evaluation of stmt {} took {}ms",
-        stmt_index,
-        time_start.elapsed().as_secs_f32() * 1000.0,
-    );
+    let elapsed_ms = time_start.elapsed().as_secs_f32() * 1000.0;
+    log::debug!("Evaluation of stmt {} took {:.2}ms", stmt_index, elapsed_ms);
 
-    result
+    match result {
+        Ok(cached) => {
+            if cached {
+                log_messages[stmt_index].push(LogMessage::info(format!(
+                    ">>> Taken from cache ({:.2}ms)",
+                    elapsed_ms,
+                )));
+            } else {
+                log_messages[stmt_index]
+                    .push(LogMessage::info(format!(">>> Took {:.2}ms", elapsed_ms)));
+            }
+
+            Ok(())
+        }
+        Err(err) => {
+            log_messages[stmt_index].push(LogMessage::error(format!(
+                ">>> Errored after {:.2}ms",
+                elapsed_ms,
+            )));
+
+            Err(err)
+        }
+    }
 }
 
 fn eval_var_decl_stmt(
@@ -643,7 +720,8 @@ fn eval_var_decl_stmt(
     var_decl: &ast::VarDeclStmt,
     funcs: &mut BTreeMap<FuncIdent, Box<dyn Func>>,
     env: &mut HashMap<VarIdent, VarInfo>,
-) -> Result<(), RuntimeError> {
+    log: &mut dyn FnMut(LogMessage),
+) -> Result<bool, RuntimeError> {
     let var_ident = var_decl.ident();
 
     // This is a false positive. Bad Clippy, bad! Rewriting the code
@@ -660,9 +738,11 @@ fn eval_var_decl_stmt(
 
     #[allow(clippy::map_entry)]
     {
-        if !env.contains_key(&var_ident) {
+        if env.contains_key(&var_ident) {
+            Ok(true)
+        } else {
             let init_expr = var_decl.init_expr();
-            let value = eval_call_expr(stmt_index, init_expr, funcs, env)?;
+            let value = eval_call_expr(stmt_index, init_expr, funcs, env, log)?;
 
             env.insert(
                 var_ident,
@@ -671,10 +751,10 @@ fn eval_var_decl_stmt(
                     value,
                 },
             );
+
+            Ok(false)
         }
     }
-
-    Ok(())
 }
 
 fn eval_expr(
@@ -717,6 +797,7 @@ fn eval_call_expr(
     call: &ast::CallExpr,
     funcs: &mut BTreeMap<FuncIdent, Box<dyn Func>>,
     env: &mut HashMap<VarIdent, VarInfo>,
+    log: &mut dyn FnMut(LogMessage),
 ) -> Result<Value, RuntimeError> {
     // FIXME: @Diagnostics use the func name and the param names in
     // the reported errors
@@ -759,8 +840,7 @@ fn eval_call_expr(
         }
     }
 
-    let result = func.call(&args);
-    match result {
+    match func.call(&args, log) {
         Ok(value) => {
             let return_ty = func.return_ty();
             let value_ty = value.ty();
@@ -773,6 +853,7 @@ fn eval_call_expr(
                     ty_provided: value_ty,
                 });
             }
+
             Ok(value)
         }
         Err(func_error) => Err(RuntimeError::Func {
@@ -849,7 +930,11 @@ mod tests {
             self.return_ty
         }
 
-        fn call(&mut self, values: &[Value]) -> Result<Value, FuncError> {
+        fn call(
+            &mut self,
+            values: &[Value],
+            _log: &mut dyn FnMut(LogMessage),
+        ) -> Result<Value, FuncError> {
             (self.func)(values)
         }
     }
@@ -900,7 +985,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
     }
 
@@ -927,7 +1012,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
     }
 
@@ -954,7 +1039,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
     }
 
@@ -981,7 +1066,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
     }
 
@@ -1027,7 +1112,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
     }
 
@@ -1073,7 +1158,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
     }
 
@@ -1086,16 +1171,19 @@ mod tests {
         let mut interpreter = Interpreter::new(BTreeMap::new());
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let interpret_outcome = interpreter.interpret();
         assert_eq!(
-            value,
-            ValueSet {
-                last_value: None,
-                used_values: Vec::new(),
-                unused_values: Vec::new(),
+            interpret_outcome,
+            InterpretOutcome {
+                result: Ok(InterpretValue {
+                    last_value: None,
+                    used_values: Vec::new(),
+                    unused_values: Vec::new(),
+                }),
+                pc: 0,
+                log_messages: Vec::new(),
             },
         );
-        assert_eq!(interpreter.pc, 0);
     }
 
     #[test]
@@ -1105,16 +1193,19 @@ mod tests {
         let mut interpreter = Interpreter::new(BTreeMap::new());
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret_up_until(0).unwrap();
+        let interpret_outcome = interpreter.interpret_up_until(0);
         assert_eq!(
-            value,
-            ValueSet {
-                last_value: None,
-                used_values: Vec::new(),
-                unused_values: Vec::new(),
+            interpret_outcome,
+            InterpretOutcome {
+                result: Ok(InterpretValue {
+                    last_value: None,
+                    used_values: Vec::new(),
+                    unused_values: Vec::new(),
+                }),
+                pc: 0,
+                log_messages: Vec::new(),
             },
         );
-        assert_eq!(interpreter.pc, 0);
     }
 
     #[test]
@@ -1140,12 +1231,13 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret_up_until(1).unwrap();
+        let interpret_outcome = interpreter.interpret_up_until(1);
+        let value = interpret_outcome.result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
         // The PC must have stayed pointed at 1st stmt, even though it
         // would normally point to 2nd, because we executed less
         // statements than what was requested.
-        assert_eq!(interpreter.pc, 1);
+        assert_eq!(interpret_outcome.pc, 1);
     }
 
     #[test]
@@ -1177,7 +1269,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret_up_until(0).unwrap();
+        let value = interpreter.interpret_up_until(0).result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
     }
 
@@ -1212,10 +1304,10 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
         assert_eq!(n_calls.get(), 1);
     }
@@ -1249,10 +1341,10 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
         assert_eq!(n_calls.get(), 2);
     }
@@ -1301,7 +1393,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
 
         // Change the args but not the func
@@ -1319,7 +1411,7 @@ mod tests {
             )),
         );
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(false)));
         assert_eq!(n_calls.get(), 2);
     }
@@ -1393,7 +1485,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
 
         // Change the func but not the args
@@ -1411,7 +1503,7 @@ mod tests {
             )),
         );
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
 
         assert_eq!(n_calls1.get(), 1);
@@ -1472,10 +1564,10 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Boolean(true)));
 
         assert_eq!(n_calls1.get(), 2);
@@ -1483,43 +1575,6 @@ mod tests {
     }
 
     // FIXME: Prog manipulation tests
-
-    #[test]
-    fn test_interpreter_set_prog_stmt_does_not_advance_pc_to_unexecuted_stmts() {
-        let func_id = FuncIdent(0);
-        let prog = ast::Prog::new(vec![
-            ast::Stmt::VarDecl(ast::VarDeclStmt::new(
-                VarIdent(0),
-                ast::CallExpr::new(func_id, vec![]),
-            )),
-            ast::Stmt::VarDecl(ast::VarDeclStmt::new(
-                VarIdent(1),
-                ast::CallExpr::new(func_id, vec![]),
-            )),
-        ]);
-
-        let mut interpreter = Interpreter::new(BTreeMap::new());
-        interpreter.set_prog(prog);
-        assert_eq!(interpreter.pc, 0);
-
-        interpreter.set_prog_stmt_at(
-            0,
-            ast::Stmt::VarDecl(ast::VarDeclStmt::new(
-                VarIdent(0),
-                ast::CallExpr::new(func_id, vec![]),
-            )),
-        );
-        assert_eq!(interpreter.pc, 0);
-
-        interpreter.set_prog_stmt_at(
-            1,
-            ast::Stmt::VarDecl(ast::VarDeclStmt::new(
-                VarIdent(0),
-                ast::CallExpr::new(func_id, vec![]),
-            )),
-        );
-        assert_eq!(interpreter.pc, 0);
-    }
 
     // Name resolution tests
 
@@ -1552,7 +1607,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
         assert_eq!(
             err,
             InterpretError::from(ResolveError::VarRedefinition {
@@ -1588,7 +1643,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
         assert_eq!(
             err,
             InterpretError::from(ResolveError::UndeclaredVarUse {
@@ -1626,7 +1681,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
         assert_eq!(
             err,
             InterpretError::from(ResolveError::UndeclaredVarUse {
@@ -1670,7 +1725,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
         assert_eq!(
             err,
             InterpretError::from(ResolveError::UndeclaredVarUse {
@@ -1691,7 +1746,7 @@ mod tests {
         let mut interpreter = Interpreter::new(BTreeMap::new());
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
         assert_eq!(
             err,
             InterpretError::from(ResolveError::UndeclaredFuncUse {
@@ -1735,7 +1790,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
         assert_eq!(
             err,
             InterpretError::from(RuntimeError::ArgCountMismatch {
@@ -1771,7 +1826,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
         assert_eq!(
             err,
             InterpretError::from(RuntimeError::ArgTyMismatch {
@@ -1811,7 +1866,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let value = interpreter.interpret().result.unwrap();
         assert_eq!(value.last_value, Some(Value::Float(1.0)));
     }
 
@@ -1842,7 +1897,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
         assert_eq!(
             err,
             InterpretError::from(RuntimeError::ArgTyMismatch {
@@ -1874,7 +1929,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
         assert_eq!(
             err,
             InterpretError::from(RuntimeError::ReturnTyMismatch {
@@ -1923,7 +1978,7 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let err = interpreter.interpret().unwrap_err();
+        let err = interpreter.interpret().result.unwrap_err();
 
         match err {
             InterpretError::Runtime(RuntimeError::Func {
@@ -1944,10 +1999,10 @@ mod tests {
         }
     }
 
-    // ValueSet tests
+    // InterpretOutcome tests
 
     #[test]
-    fn test_interpreter_interpret_value_set() {
+    fn test_interpreter_interpret_outcome() {
         let (func_id, func) = (
             FuncIdent(0),
             TestFunc::new(
@@ -1992,10 +2047,10 @@ mod tests {
         let mut interpreter = Interpreter::new(funcs);
         interpreter.set_prog(prog);
 
-        let value = interpreter.interpret().unwrap();
+        let interpret_outcome = interpreter.interpret();
         assert_eq!(
-            value,
-            ValueSet {
+            interpret_outcome.result,
+            Ok(InterpretValue {
                 last_value: Some(Value::Float(8.0)),
                 used_values: vec![
                     (VarIdent(0), Value::Float(2.0)),
@@ -2005,7 +2060,9 @@ mod tests {
                     (VarIdent(2), Value::Float(8.0)),
                     (VarIdent(3), Value::Float(8.0)),
                 ],
-            }
+            }),
         );
+        assert_eq!(interpret_outcome.pc, 4);
+        assert_eq!(interpret_outcome.log_messages.len(), 4);
     }
 }

--- a/src/interpreter_funcs/create_box.rs
+++ b/src/interpreter_funcs/create_box.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use nalgebra::{Point3, Rotation3, Vector3};
 
 use crate::interpreter::{
-    Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty,
-    Value,
+    Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo,
+    ParamRefinement, Ty, Value,
 };
 use crate::mesh::primitive;
 
@@ -76,7 +76,11 @@ impl Func for FuncCreateBox {
         Ty::Mesh
     }
 
-    fn call(&mut self, values: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        values: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let center = values[0].unwrap_float3();
         let rotate = values[1].unwrap_float3();
         let scale = values[2].unwrap_float3();
@@ -90,6 +94,7 @@ impl Func for FuncCreateBox {
             ),
             Vector3::from(scale),
         );
+
         Ok(Value::Mesh(Arc::new(value)))
     }
 }

--- a/src/interpreter_funcs/create_plane.rs
+++ b/src/interpreter_funcs/create_plane.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use nalgebra::{Point3, Rotation3, Vector2, Vector3};
 
 use crate::interpreter::{
-    Float2ParamRefinement, Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, ParamInfo,
-    ParamRefinement, Ty, Value,
+    Float2ParamRefinement, Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, LogMessage,
+    ParamInfo, ParamRefinement, Ty, Value,
 };
 use crate::mesh::primitive;
 use crate::plane::Plane;
@@ -74,7 +74,11 @@ impl Func for FuncCreatePlane {
         Ty::Mesh
     }
 
-    fn call(&mut self, values: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        values: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let center = values[0].unwrap_float3();
         let rotate = values[1].unwrap_float3();
         let scale = values[2].unwrap_float2();

--- a/src/interpreter_funcs/create_uv_sphere.rs
+++ b/src/interpreter_funcs/create_uv_sphere.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use nalgebra::{Point3, Rotation3, Vector3};
 
 use crate::interpreter::{
-    Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty,
-    UintParamRefinement, Value,
+    Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo,
+    ParamRefinement, Ty, UintParamRefinement, Value,
 };
 use crate::mesh::{primitive, NormalStrategy};
 
@@ -126,7 +126,11 @@ impl Func for FuncCreateUvSphere {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let center = args[0].unwrap_float3();
         let rotate = args[1].unwrap_float3();
         let scale = args[2].unwrap_float3();

--- a/src/interpreter_funcs/disjoint_mesh.rs
+++ b/src/interpreter_funcs/disjoint_mesh.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, MeshArrayValue, ParamInfo, ParamRefinement, Ty, Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, MeshArrayValue, ParamInfo, ParamRefinement,
+    Ty, Value,
 };
 use crate::mesh::tools;
 
@@ -31,7 +32,11 @@ impl Func for FuncDisjointMesh {
         Ty::MeshArray
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh = args[0].unwrap_mesh();
 
         let meshes = tools::disjoint_mesh(&mesh);

--- a/src/interpreter_funcs/extract.rs
+++ b/src/interpreter_funcs/extract.rs
@@ -2,8 +2,8 @@ use std::error;
 use std::fmt;
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, UintParamRefinement,
-    Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty,
+    UintParamRefinement, Value,
 };
 
 #[derive(Debug, PartialEq)]
@@ -58,7 +58,11 @@ impl Func for FuncExtract {
         Ty::Mesh
     }
 
-    fn call(&mut self, values: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        values: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh_array = values[0].unwrap_mesh_array();
         let index = values[1].unwrap_uint();
 

--- a/src/interpreter_funcs/extract_largest.rs
+++ b/src/interpreter_funcs/extract_largest.rs
@@ -2,7 +2,7 @@ use std::error;
 use std::fmt;
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty, Value,
 };
 
 #[derive(Debug, PartialEq)]
@@ -46,7 +46,11 @@ impl Func for FuncExtractLargest {
         Ty::Mesh
     }
 
-    fn call(&mut self, values: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        values: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh_array = values[0].unwrap_mesh_array();
 
         if mesh_array.is_empty() {

--- a/src/interpreter_funcs/import_obj_mesh.rs
+++ b/src/interpreter_funcs/import_obj_mesh.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::importer::{Importer, ImporterError, ObjCache};
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, MeshArrayValue, ParamInfo, ParamRefinement,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, MeshArrayValue, ParamInfo, ParamRefinement,
     StringParamRefinement, Ty, Value,
 };
 
@@ -63,7 +63,11 @@ impl<C: ObjCache> Func for FuncImportObjMesh<C> {
         Ty::MeshArray
     }
 
-    fn call(&mut self, values: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        values: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let path = values[0].unwrap_string();
 
         let result = self.importer.import_obj(path);

--- a/src/interpreter_funcs/join_group.rs
+++ b/src/interpreter_funcs/join_group.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty, Value,
 };
 use crate::mesh::tools;
 
@@ -31,7 +31,11 @@ impl Func for FuncJoinGroup {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh_arc_array = args[0].unwrap_mesh_array();
 
         let meshes = mesh_arc_array.iter();

--- a/src/interpreter_funcs/join_meshes.rs
+++ b/src/interpreter_funcs/join_meshes.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty, Value,
 };
 use crate::mesh::tools;
 
@@ -38,7 +38,11 @@ impl Func for FuncJoinMeshes {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let meshes = args.iter().map(|a| a.unwrap_mesh());
 
         let value = tools::join_multiple_meshes(meshes);

--- a/src/interpreter_funcs/laplacian_smoothing.rs
+++ b/src/interpreter_funcs/laplacian_smoothing.rs
@@ -2,8 +2,8 @@ use std::cmp;
 use std::sync::Arc;
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, UintParamRefinement,
-    Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty,
+    UintParamRefinement, Value,
 };
 use crate::mesh::{smoothing, topology, NormalStrategy};
 
@@ -44,7 +44,11 @@ impl Func for FuncLaplacianSmoothing {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh = args[0].unwrap_mesh();
         let iterations = args[1].unwrap_uint();
 

--- a/src/interpreter_funcs/loop_subdivision.rs
+++ b/src/interpreter_funcs/loop_subdivision.rs
@@ -4,8 +4,8 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, UintParamRefinement,
-    Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty,
+    UintParamRefinement, Value,
 };
 use crate::mesh::{smoothing, topology, NormalStrategy};
 
@@ -68,7 +68,11 @@ impl Func for FuncLoopSubdivision {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh = args[0].unwrap_refcounted_mesh();
         let iterations = cmp::min(args[1].unwrap_uint(), Self::MAX_ITERATIONS);
 

--- a/src/interpreter_funcs/revert_mesh_faces.rs
+++ b/src/interpreter_funcs/revert_mesh_faces.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty, Value,
 };
 use crate::mesh::tools;
 
@@ -31,7 +31,11 @@ impl Func for FuncRevertMeshFaces {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh = args[0].unwrap_mesh();
 
         let value = tools::revert_mesh_faces(mesh);

--- a/src/interpreter_funcs/shrink_wrap.rs
+++ b/src/interpreter_funcs/shrink_wrap.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use nalgebra::{Rotation3, Vector3};
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, UintParamRefinement,
-    Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty,
+    UintParamRefinement, Value,
 };
 use crate::mesh::analysis::BoundingBox;
 use crate::mesh::{analysis, primitive, NormalStrategy};
@@ -47,7 +47,11 @@ impl Func for FuncShrinkWrap {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh = args[0].unwrap_mesh();
         let sphere_density = args[1].unwrap_uint();
 

--- a/src/interpreter_funcs/synchronize_mesh_faces.rs
+++ b/src/interpreter_funcs/synchronize_mesh_faces.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::interpreter::{
-    Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty, Value,
+    Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty, Value,
 };
 use crate::mesh::{analysis, tools, topology};
 
@@ -31,7 +31,11 @@ impl Func for FuncSynchronizeMeshFaces {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh = args[0].unwrap_refcounted_mesh();
 
         let oriented_edges: Vec<_> = mesh.oriented_edges_iter().collect();

--- a/src/interpreter_funcs/transform.rs
+++ b/src/interpreter_funcs/transform.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use nalgebra::{Matrix4, Rotation, Vector3};
 
 use crate::interpreter::{
-    Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty,
-    Value,
+    Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo,
+    ParamRefinement, Ty, Value,
 };
 use crate::mesh::Mesh;
 
@@ -81,7 +81,11 @@ impl Func for FuncTransform {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh = args[0].unwrap_mesh();
 
         let translate = Vector3::from(args[1].unwrap_float3());

--- a/src/interpreter_funcs/voxelize.rs
+++ b/src/interpreter_funcs/voxelize.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use nalgebra::Vector3;
 
 use crate::interpreter::{
-    Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty,
-    UintParamRefinement, Value,
+    Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo,
+    ParamRefinement, Ty, UintParamRefinement, Value,
 };
 use crate::mesh::voxel_cloud::VoxelCloud;
 
@@ -81,7 +81,11 @@ impl Func for FuncVoxelize {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh = args[0].unwrap_mesh();
         let voxel_dimensions = args[1].unwrap_float3();
         let growth_iterations = args[2].unwrap_uint();

--- a/src/interpreter_funcs/weld.rs
+++ b/src/interpreter_funcs/weld.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::interpreter::{
-    FloatParamRefinement, Func, FuncError, FuncFlags, FuncInfo, ParamInfo, ParamRefinement, Ty,
-    Value,
+    FloatParamRefinement, Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo,
+    ParamRefinement, Ty, Value,
 };
 use crate::mesh::tools;
 
@@ -62,7 +62,11 @@ impl Func for FuncWeld {
         Ty::Mesh
     }
 
-    fn call(&mut self, args: &[Value]) -> Result<Value, FuncError> {
+    fn call(
+        &mut self,
+        args: &[Value],
+        _log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
         let mesh = args[0].unwrap_mesh();
         let tolerance = args[1].unwrap_float();
 


### PR DESCRIPTION
Each func run in the interpreter now has the option to log
messages. These messages are returned in the interpreter's response
(`InterpretOutcome`) regardless of whether the interpretting ended
successfully. The UI is updated with autoscrolling consoles that
display the log messages. On the UI, the log messages are always
appended to the console output and the consoles are only cleared when
the operation is removed from the pipeline.

The interpreter appends one log message with the func's run duration
to the func's log after it returns. For cached (and not invalidated)
func results, no new logs are produced, but the interpreter appends a
log message saying that the result was taken from cache. If the func
ends with an error, the interpreter also appends a log message (with
the `Error` level).

Minor refactoring happened in both the interpreter and the UI:

- Interpreter no longer keeps track of the program counter in between
calls to `Interpreter::interpret{_up_until}()` and instead the PC
always begins at 0. This was the simplest solution for producing log
messages for operations we would otherwise skip by not resetting the
PC back to zero after invalidation. This will have a very minor
performance impact (the `env` hash map will be accessed more times)
and a FIXME was left in the code to address the problem in a more
systematic manner later.

- Since there was no way around adding a `RefCell` around UI state for
the consoles, a global string buffer wrapped in a `RefCell` for imgui
components to use is also added to the `Ui` as an
optimization. Rammifications should be minimal, we don't expect to
ever want to `borrow_mut` these `RefCell`s in a reentrant manner. UI
performance should improve slightly.