### PR TITLE
Remove occurrences of I: IntoIterator<> + Clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ struct CameraInterpolation {
 impl CameraInterpolation {
     fn new<'a, I>(camera: &Camera, scene_meshes: I, time: Instant) -> Self
     where
-        I: IntoIterator<Item = &'a Mesh> + Clone,
+        I: Iterator<Item = &'a Mesh>,
     {
         let (source_origin, source_radius) = camera.visible_sphere();
         let bounding_box = BoundingBox::from_meshes(scene_meshes);

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -366,7 +366,7 @@ impl RenderPass<'_> {
     /// renderer.
     pub fn draw_mesh<'a, I>(&mut self, ids: I, mode: DrawMeshMode)
     where
-        I: IntoIterator<Item = &'a GpuMeshId> + Clone,
+        I: Iterator<Item = &'a GpuMeshId> + Clone,
     {
         let mut clear_flags = SceneRendererClearFlags::empty();
         if self.color_needs_clearing {

--- a/src/renderer/scene_renderer.rs
+++ b/src/renderer/scene_renderer.rs
@@ -617,7 +617,7 @@ impl SceneRenderer {
         depth_attachment: &wgpu::TextureView,
         ids: I,
     ) where
-        I: IntoIterator<Item = &'a GpuMeshId> + Clone,
+        I: Iterator<Item = &'a GpuMeshId> + Clone,
     {
         let color_load_op = if clear_flags.contains(ClearFlags::COLOR) {
             wgpu::LoadOp::Clear


### PR DESCRIPTION
Calling `clone()` on `I` could very possibly clone the underlying storage, not
the iterator.

Discovered this while reviewing @janper 's code.