### PR TITLE
Add a note about icons to installer readme

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -18,6 +18,10 @@ To create a distribution follow these steps:
 - Compile `installer/setup.iss` from Inno Setup IDE,
 - Output file will be located at `installer/bin`.
 
+Note that window icon and desktop / Start menu icons differ. Window icon is
+taken from `icons/64x64.ico` and baked into application during compilation.
+Desktop icon is set with `rcedit` and can be an entirely different file.
+
 Installer itself will also contain [Microsoft Visual C++ Redistributable for
 Visual Studio 2015, 2017 and 2019](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
 that is needed to run the application. Code used to install this dependency is


### PR DESCRIPTION
@janper Will this be clear in the future or should I add it somewhere more visible?

Also note that I'm not entirely sure what sizes the different icons should be. There seem to be a lot to take into consideration, from user settings to DPI. I haven't found some unified guidelines regarding this and even Microsoft docs seem to have all kinds of different (outdated) information. Also I'm not entirely sure if just one size of icon is saved as window icon and desktop icon or `winit` / `rcedit` do some resizing. Do you want to spend more time on this or get back to it later if it's a problem?