### PR TITLE
Implement simple align operation

### DIFF
--- a/src/interpreter_funcs/align.rs
+++ b/src/interpreter_funcs/align.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use crate::analytics;
+use crate::interpreter::{
+    BooleanParamRefinement, Func, FuncError, FuncFlags, FuncInfo, LogMessage, ParamInfo,
+    ParamRefinement, Ty, Value,
+};
+use crate::mesh::tools;
+
+pub struct FuncAlign;
+
+impl Func for FuncAlign {
+    fn info(&self) -> &FuncInfo {
+        &FuncInfo {
+            name: "Align",
+            description:
+                "ALIGN MESH TO ANOTHER\n\
+                 \n\
+                 Moves and scales a mesh to match another mesh. 'Mesh to align' will be \
+                 translated so that its center matches the center of 'Align to mesh'. \
+                 'Mesh to align' will be scaled so that the diagonal of its bounding \
+                 box will have the same length as the diagonal of the bounding box \
+                 of 'Align to mesh'.\n\
+                 \n\
+                 Both input meshes will be marked used and thus invisible in the viewport. \
+                 They can still be used in subsequent operations.\n\
+                 \n\
+                 The resulting mesh geometry will be named 'Aligned Mesh'.",
+            return_value_name: "Aligned Mesh",
+        }
+    }
+
+    fn flags(&self) -> FuncFlags {
+        FuncFlags::PURE
+    }
+
+    fn param_info(&self) -> &[ParamInfo] {
+        &[
+            ParamInfo {
+                name: "Mesh to align",
+                description: "Mesh to be transformed to align to another mesh.",
+                refinement: ParamRefinement::Mesh,
+                optional: false,
+            },
+            ParamInfo {
+                name: "Align to mesh",
+                description: "The target mesh, towards which the source mesh should be aligned.",
+                refinement: ParamRefinement::Mesh,
+                optional: false,
+            },
+            ParamInfo {
+                name: "Analyze resulting mesh",
+                description: "Reports detailed analytic information on the created mesh.\n\
+                              The analysis may be slow, therefore it is by default off.",
+                refinement: ParamRefinement::Boolean(BooleanParamRefinement {
+                    default_value: false,
+                }),
+                optional: false,
+            },
+        ]
+    }
+
+    fn return_ty(&self) -> Ty {
+        Ty::Mesh
+    }
+
+    fn call(
+        &mut self,
+        args: &[Value],
+        log: &mut dyn FnMut(LogMessage),
+    ) -> Result<Value, FuncError> {
+        let mesh_to_align = args[0].unwrap_mesh();
+        let align_to_mesh = args[1].unwrap_mesh();
+        let analyze = args[2].unwrap_boolean();
+
+        let value = tools::align_two_meshes(&mesh_to_align, &align_to_mesh);
+
+        if analyze {
+            analytics::report_mesh_analysis(&value, log);
+        }
+
+        Ok(Value::Mesh(Arc::new(value)))
+    }
+}

--- a/src/interpreter_funcs/mod.rs
+++ b/src/interpreter_funcs/mod.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use crate::importer::{EndlessCache, Importer};
 use crate::interpreter::{Func, FuncIdent};
 
+use self::align::FuncAlign;
 use self::create_box::FuncCreateBox;
 use self::create_plane::FuncCreatePlane;
 use self::create_uv_sphere::FuncCreateUvSphere;
@@ -24,6 +25,7 @@ use self::voxel_boolean_union::FuncBooleanUnion;
 use self::voxelize::FuncVoxelize;
 use self::weld::FuncWeld;
 
+mod align;
 mod create_box;
 mod create_plane;
 mod create_uv_sphere;
@@ -55,6 +57,7 @@ pub const FUNC_ID_TRANSFORM: FuncIdent = FuncIdent(0);
 pub const FUNC_ID_EXTRACT: FuncIdent = FuncIdent(1);
 pub const FUNC_ID_EXTRACT_LARGEST: FuncIdent = FuncIdent(2);
 pub const FUNC_ID_SNAP_TO_GROUND: FuncIdent = FuncIdent(3);
+pub const FUNC_ID_ALIGN: FuncIdent = FuncIdent(4);
 
 // Create funcs
 pub const FUNC_ID_CREATE_UV_SPHERE: FuncIdent = FuncIdent(1000);
@@ -95,6 +98,7 @@ pub fn create_function_table() -> BTreeMap<FuncIdent, Box<dyn Func>> {
     funcs.insert(FUNC_ID_EXTRACT, Box::new(FuncExtract));
     funcs.insert(FUNC_ID_EXTRACT_LARGEST, Box::new(FuncExtractLargest));
     funcs.insert(FUNC_ID_SNAP_TO_GROUND, Box::new(FuncSnapToGround));
+    funcs.insert(FUNC_ID_ALIGN, Box::new(FuncAlign));
 
     // Create funcs
     funcs.insert(FUNC_ID_CREATE_UV_SPHERE, Box::new(FuncCreateUvSphere));


### PR DESCRIPTION
Moves and scales a mesh to match another mesh. 'Mesh to align' will be translated so that its center matches the center of 'Align to mesh'.  'Mesh to align' will be scaled so that the diagonal of its bounding box will have the same length as the diagonal of the bounding box of 'Align to mesh'.

This is the first step towards a more sophisticated alignment method using scalar fields.