### PR TITLE
Display used values as transparent

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub use crate::ui::Theme;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::File;
+use std::iter;
 use std::mem;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -22,10 +23,10 @@ use crate::mesh::Mesh;
 use crate::notifications::{NotificationLevel, Notifications};
 use crate::plane::Plane;
 use crate::renderer::{
-    DirectionalLight, DrawMeshMode, GpuMesh, GpuMeshHandle, Options as RendererOptions, Renderer,
+    DirectionalLight, GpuMesh, GpuMeshHandle, Material, Options as RendererOptions, Renderer,
 };
 use crate::session::{PollNotification, Session};
-use crate::ui::{ScreenshotOptions, Ui};
+use crate::ui::{ScreenshotOptions, Ui, ViewportDrawMode};
 
 pub mod geometry;
 pub mod importer;
@@ -218,7 +219,8 @@ pub fn init_and_run(options: Options) -> ! {
 
     #[cfg(not(feature = "dist"))]
     let mut renderer_debug_view = RendererDebugView::Off;
-    let mut renderer_draw_mesh_mode = DrawMeshMode::Shaded;
+    let mut viewport_draw_mode = ViewportDrawMode::ShadedWireframe;
+    let mut viewport_draw_used_values = true;
     let mut renderer = Renderer::new(
         &window,
         initial_window_width,
@@ -234,19 +236,20 @@ pub fn init_and_run(options: Options) -> ! {
             vsync: options.vsync,
             backend: options.gpu_backend,
             power_preference: options.gpu_power_preference,
-            flat_shading_color: [0.0, 0.0, 0.0, 0.1],
+            flat_material_color: [0.0, 0.0, 0.0, 0.1],
+            transparent_matcap_shaded_material_alpha: 0.2,
         },
     );
 
     let mut scene_bounding_box: BoundingBox<f32> = BoundingBox::unit();
-    let mut scene_meshes: HashMap<ValuePath, Arc<Mesh>> = HashMap::new();
-    let mut scene_gpu_mesh_handles: HashMap<ValuePath, GpuMeshHandle> = HashMap::new();
+    let mut scene_meshes: HashMap<ValuePath, (bool, Arc<Mesh>)> = HashMap::new();
+    let mut scene_gpu_mesh_handles: HashMap<ValuePath, (bool, GpuMeshHandle)> = HashMap::new();
 
     let mut ground_plane_mesh = compute_ground_plane_mesh(&scene_bounding_box);
     let mut ground_plane_mesh_bounding_box = ground_plane_mesh.bounding_box();
     let mut ground_plane_gpu_mesh_handle = Some(
         renderer
-            .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh), true)
+            .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh))
             .expect("Failed to add ground plane mesh"),
     );
 
@@ -259,6 +262,7 @@ pub fn init_and_run(options: Options) -> ! {
     let time_start = Instant::now();
     let mut time = time_start;
 
+    #[allow(clippy::cognitive_complexity)]
     event_loop.run(move |event, _, control_flow| {
         *control_flow = winit::event_loop::ControlFlow::Poll;
 
@@ -313,10 +317,35 @@ pub fn init_and_run(options: Options) -> ! {
                 let menu_status = ui_frame.draw_menu_window(
                     time,
                     &mut screenshot_modal_open,
-                    &mut renderer_draw_mesh_mode,
+                    &mut viewport_draw_mode,
+                    &mut viewport_draw_used_values,
                     project_path.as_ref().map(|p| p.as_str()),
                     &mut notifications.borrow_mut(),
                 );
+
+                if menu_status.viewport_draw_used_values_changed {
+                    scene_bounding_box = BoundingBox::union(
+                        scene_meshes
+                            .values()
+                            .filter(|(used, _)| viewport_draw_used_values || !used)
+                            .map(|(_, mesh)| mesh.bounding_box()),
+                    )
+                    .unwrap_or_else(BoundingBox::unit);
+
+                    ground_plane_mesh = compute_ground_plane_mesh(&scene_bounding_box);
+                    ground_plane_mesh_bounding_box = ground_plane_mesh.bounding_box();
+                    renderer.remove_scene_mesh(
+                        ground_plane_gpu_mesh_handle
+                            .take()
+                            .expect("Ground plane must always be present"),
+                    );
+                    ground_plane_gpu_mesh_handle = Some(
+                        renderer
+                            .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh))
+                            .expect("Failed to add ground plane mesh"),
+                    );
+                }
+
                 let reset_viewport =
                     input_state.camera_reset_viewport || menu_status.reset_viewport;
 
@@ -342,13 +371,17 @@ pub fn init_and_run(options: Options) -> ! {
 
                     scene_meshes.clear();
 
-                    for (_, gpu_mesh_handle) in scene_gpu_mesh_handles.drain() {
+                    for (_, (_, gpu_mesh_handle)) in scene_gpu_mesh_handles.drain() {
                         renderer.remove_scene_mesh(gpu_mesh_handle);
                     }
 
-                    scene_bounding_box =
-                        BoundingBox::union(scene_meshes.values().map(|mesh| mesh.bounding_box()))
-                            .unwrap_or_else(BoundingBox::unit);
+                    scene_bounding_box = BoundingBox::union(
+                        scene_meshes
+                            .values()
+                            .filter(|(used, _)| viewport_draw_used_values || !used)
+                            .map(|(_, mesh)| mesh.bounding_box()),
+                    )
+                    .unwrap_or_else(BoundingBox::unit);
 
                     ground_plane_mesh = compute_ground_plane_mesh(&scene_bounding_box);
                     ground_plane_mesh_bounding_box = ground_plane_mesh.bounding_box();
@@ -359,7 +392,7 @@ pub fn init_and_run(options: Options) -> ! {
                     );
                     ground_plane_gpu_mesh_handle = Some(
                         renderer
-                            .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh), true)
+                            .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh))
                             .expect("Failed to add ground plane mesh"),
                     );
 
@@ -442,97 +475,45 @@ pub fn init_and_run(options: Options) -> ! {
                 }
 
                 session.poll(time, |callback_value| match callback_value {
-                    PollNotification::ValueAdded(var_ident, value) => match value {
+                    PollNotification::UsedValueAdded(var_ident, value) => match value {
                         Value::Mesh(mesh) => {
                             let gpu_mesh = GpuMesh::from_mesh(&mesh);
                             let gpu_mesh_id = renderer
-                                .add_scene_mesh(&gpu_mesh, false)
+                                .add_scene_mesh(&gpu_mesh)
                                 .expect("Failed to upload scene mesh");
 
                             let path = ValuePath(var_ident, 0);
 
-                            scene_meshes.insert(path, mesh);
-                            scene_gpu_mesh_handles.insert(path, gpu_mesh_id);
-
-                            scene_bounding_box = BoundingBox::union(
-                                scene_meshes.values().map(|mesh| mesh.bounding_box()),
-                            )
-                            .unwrap_or_else(BoundingBox::unit);
-
-                            ground_plane_mesh = compute_ground_plane_mesh(&scene_bounding_box);
-                            ground_plane_mesh_bounding_box = ground_plane_mesh.bounding_box();
-                            renderer.remove_scene_mesh(
-                                ground_plane_gpu_mesh_handle
-                                    .take()
-                                    .expect("Ground plane must always be present"),
-                            );
-                            ground_plane_gpu_mesh_handle = Some(
-                                renderer
-                                    .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh), true)
-                                    .expect("Failed to add ground plane mesh"),
-                            );
+                            scene_meshes.insert(path, (true, mesh));
+                            scene_gpu_mesh_handles.insert(path, (true, gpu_mesh_id));
                         }
                         Value::MeshArray(mesh_array) => {
                             for (index, mesh) in mesh_array.iter_refcounted().enumerate() {
                                 let gpu_mesh = GpuMesh::from_mesh(&mesh);
                                 let gpu_mesh_id = renderer
-                                    .add_scene_mesh(&gpu_mesh, false)
+                                    .add_scene_mesh(&gpu_mesh)
                                     .expect("Failed to upload scene mesh");
 
                                 let path = ValuePath(var_ident, index);
 
-                                scene_meshes.insert(path, mesh);
-                                scene_gpu_mesh_handles.insert(path, gpu_mesh_id);
+                                scene_meshes.insert(path, (true, mesh));
+                                scene_gpu_mesh_handles.insert(path, (true, gpu_mesh_id));
                             }
-
-                            scene_bounding_box = BoundingBox::union(
-                                scene_meshes.values().map(|mesh| mesh.bounding_box()),
-                            )
-                            .unwrap_or_else(BoundingBox::unit);
-
-                            ground_plane_mesh = compute_ground_plane_mesh(&scene_bounding_box);
-                            ground_plane_mesh_bounding_box = ground_plane_mesh.bounding_box();
-                            renderer.remove_scene_mesh(
-                                ground_plane_gpu_mesh_handle
-                                    .take()
-                                    .expect("Ground plane must always be present"),
-                            );
-                            ground_plane_gpu_mesh_handle = Some(
-                                renderer
-                                    .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh), true)
-                                    .expect("Failed to add ground plane mesh"),
-                            );
                         }
                         _ => (/* Ignore other values, we don't display them in the viewport */),
                     },
-                    PollNotification::ValueRemoved(var_ident, value) => match value {
+
+                    PollNotification::UsedValueRemoved(var_ident, value) => match value {
                         Value::Mesh(_) => {
                             let path = ValuePath(var_ident, 0);
 
                             scene_meshes.remove(&path);
                             let gpu_mesh_id = scene_gpu_mesh_handles
                                 .remove(&path)
-                                .expect("Gpu mesh ID was not tracked");
+                                .expect("Gpu mesh ID was not tracked")
+                                .1;
 
                             renderer.remove_scene_mesh(gpu_mesh_id);
-
-                            scene_bounding_box = BoundingBox::union(
-                                scene_meshes.values().map(|mesh| mesh.bounding_box()),
-                            )
-                            .unwrap_or_else(BoundingBox::unit);
-
-                            ground_plane_mesh = compute_ground_plane_mesh(&scene_bounding_box);
-                            ground_plane_mesh_bounding_box = ground_plane_mesh.bounding_box();
-                            renderer.remove_scene_mesh(
-                                ground_plane_gpu_mesh_handle
-                                    .take()
-                                    .expect("Ground plane must always be present"),
-                            );
-                            ground_plane_gpu_mesh_handle = Some(
-                                renderer
-                                    .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh), true)
-                                    .expect("Failed to add ground plane mesh"),
-                            );
                         }
                         Value::MeshArray(mesh_array) => {
                             for index in 0..mesh_array.len() {
@@ -541,38 +522,100 @@ pub fn init_and_run(options: Options) -> ! {
                                 scene_meshes.remove(&path);
                                 let gpu_mesh_id = scene_gpu_mesh_handles
                                     .remove(&path)
-                                    .expect("Gpu mesh ID was not tracked");
+                                    .expect("Gpu mesh ID was not tracked")
+                                    .1;
 
                                 renderer.remove_scene_mesh(gpu_mesh_id);
                             }
-
-                            scene_bounding_box = BoundingBox::union(
-                                scene_meshes.values().map(|mesh| mesh.bounding_box()),
-                            )
-                            .unwrap_or_else(BoundingBox::unit);
-
-                            ground_plane_mesh = compute_ground_plane_mesh(&scene_bounding_box);
-                            ground_plane_mesh_bounding_box = ground_plane_mesh.bounding_box();
-                            renderer.remove_scene_mesh(
-                                ground_plane_gpu_mesh_handle
-                                    .take()
-                                    .expect("Ground plane must always be present"),
-                            );
-                            ground_plane_gpu_mesh_handle = Some(
-                                renderer
-                                    .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh), true)
-                                    .expect("Failed to add ground plane mesh"),
-                            );
                         }
                         _ => (/* Ignore other values, we don't display them in the viewport */),
                     },
+
+                    PollNotification::UnusedValueAdded(var_ident, value) => match value {
+                        Value::Mesh(mesh) => {
+                            let gpu_mesh = GpuMesh::from_mesh(&mesh);
+                            let gpu_mesh_id = renderer
+                                .add_scene_mesh(&gpu_mesh)
+                                .expect("Failed to upload scene mesh");
+
+                            let path = ValuePath(var_ident, 0);
+
+                            scene_meshes.insert(path, (false, mesh));
+                            scene_gpu_mesh_handles.insert(path, (false, gpu_mesh_id));
+                        }
+                        Value::MeshArray(mesh_array) => {
+                            for (index, mesh) in mesh_array.iter_refcounted().enumerate() {
+                                let gpu_mesh = GpuMesh::from_mesh(&mesh);
+                                let gpu_mesh_id = renderer
+                                    .add_scene_mesh(&gpu_mesh)
+                                    .expect("Failed to upload scene mesh");
+
+                                let path = ValuePath(var_ident, index);
+
+                                scene_meshes.insert(path, (false, mesh));
+                                scene_gpu_mesh_handles.insert(path, (false, gpu_mesh_id));
+                            }
+                        }
+                        _ => (/* Ignore other values, we don't display them in the viewport */),
+                    },
+
+                    PollNotification::UnusedValueRemoved(var_ident, value) => match value {
+                        Value::Mesh(_) => {
+                            let path = ValuePath(var_ident, 0);
+
+                            scene_meshes.remove(&path);
+                            let gpu_mesh_id = scene_gpu_mesh_handles
+                                .remove(&path)
+                                .expect("Gpu mesh ID was not tracked")
+                                .1;
+
+                            renderer.remove_scene_mesh(gpu_mesh_id);
+                        }
+                        Value::MeshArray(mesh_array) => {
+                            for index in 0..mesh_array.len() {
+                                let path = ValuePath(var_ident, cast_usize(index));
+
+                                scene_meshes.remove(&path);
+                                let gpu_mesh_id = scene_gpu_mesh_handles
+                                    .remove(&path)
+                                    .expect("Gpu mesh ID was not tracked")
+                                    .1;
+
+                                renderer.remove_scene_mesh(gpu_mesh_id);
+                            }
+                        }
+                        _ => (/* Ignore other values, we don't display them in the viewport */),
+                    },
+
                     PollNotification::FinishedSuccessfully => {
+                        scene_bounding_box = BoundingBox::union(
+                            scene_meshes
+                                .values()
+                                .filter(|(used, _)| viewport_draw_used_values || !used)
+                                .map(|(_, mesh)| mesh.bounding_box()),
+                        )
+                        .unwrap_or_else(BoundingBox::unit);
+
+                        ground_plane_mesh = compute_ground_plane_mesh(&scene_bounding_box);
+                        ground_plane_mesh_bounding_box = ground_plane_mesh.bounding_box();
+                        renderer.remove_scene_mesh(
+                            ground_plane_gpu_mesh_handle
+                                .take()
+                                .expect("Ground plane must always be present"),
+                        );
+                        ground_plane_gpu_mesh_handle = Some(
+                            renderer
+                                .add_scene_mesh(&GpuMesh::from_mesh(&ground_plane_mesh))
+                                .expect("Failed to add ground plane mesh"),
+                        );
+
                         notifications.borrow_mut().push(
                             time,
                             NotificationLevel::Info,
                             "Execution of the Sequence of operations finished successfully.",
                         );
                     }
+
                     PollNotification::FinishedWithError(error_message) => {
                         notifications.borrow_mut().push(
                             time,
@@ -608,15 +651,76 @@ pub fn init_and_run(options: Options) -> ! {
                 window_command_buffer
                     .set_camera_matrices(&camera.projection_matrix(), &camera.view_matrix());
 
+                match viewport_draw_mode {
+                    ViewportDrawMode::Wireframe => {
+                        window_command_buffer.draw_meshes_to_primary_render_target(
+                            true,
+                            scene_gpu_mesh_handles
+                                .values()
+                                .filter(|(used, _)| viewport_draw_used_values || !used)
+                                .map(|(_, handle)| (handle, Material::Edges)),
+                        );
+                    }
+                    ViewportDrawMode::Shaded => {
+                        window_command_buffer.draw_meshes_to_primary_render_target(
+                            true,
+                            scene_gpu_mesh_handles
+                                .values()
+                                .filter(|(used, _)| viewport_draw_used_values || !used)
+                                .map(|(used, handle)| {
+                                    if *used {
+                                        (handle, Material::TransparentMatcapShaded)
+                                    } else {
+                                        (handle, Material::MatcapShaded)
+                                    }
+                                }),
+                        );
+                    }
+                    ViewportDrawMode::ShadedWireframe => {
+                        window_command_buffer.draw_meshes_to_primary_render_target(
+                            true,
+                            scene_gpu_mesh_handles
+                                .values()
+                                .filter(|(used, _)| viewport_draw_used_values || !used)
+                                .map(|(used, handle)| {
+                                    if *used {
+                                        (handle, Material::TransparentMatcapShadedEdges)
+                                    } else {
+                                        (handle, Material::MatcapShadedEdges)
+                                    }
+                                }),
+                        );
+                    }
+                    ViewportDrawMode::ShadedWireframeXray => {
+                        window_command_buffer.draw_meshes_to_primary_render_target(
+                            true,
+                            scene_gpu_mesh_handles
+                                .values()
+                                .filter(|(used, _)| viewport_draw_used_values || !used)
+                                .map(|(used, handle)| {
+                                    if *used {
+                                        (handle, Material::TransparentMatcapShaded)
+                                    } else {
+                                        (handle, Material::MatcapShaded)
+                                    }
+                                }),
+                        );
+
+                        window_command_buffer.draw_meshes_to_primary_render_target(
+                            false,
+                            scene_gpu_mesh_handles
+                                .values()
+                                .filter(|(used, _)| viewport_draw_used_values || !used)
+                                .map(|(_, handle)| (handle, Material::EdgesXray)),
+                        );
+                    }
+                }
+
                 window_command_buffer.draw_meshes_to_primary_render_target(
-                    scene_gpu_mesh_handles.values(),
-                    renderer_draw_mesh_mode,
-                    true,
-                );
-                window_command_buffer.draw_meshes_to_primary_render_target(
-                    ground_plane_gpu_mesh_handle.iter(),
-                    DrawMeshMode::FlatWithShadows,
                     false,
+                    ground_plane_gpu_mesh_handle
+                        .iter()
+                        .zip(iter::repeat(Material::FlatWithShadows)),
                 );
 
                 #[cfg(not(feature = "dist"))]
@@ -669,12 +773,75 @@ pub fn init_and_run(options: Options) -> ! {
 
                     // For screenshots, we don't need to cast shadows, and we
                     // don't render the ground on purpose.
-                    screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
-                        &screenshot_render_target,
-                        scene_gpu_mesh_handles.values(),
-                        renderer_draw_mesh_mode,
-                        false,
-                    );
+                    match viewport_draw_mode {
+                        ViewportDrawMode::Wireframe => {
+                            screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
+                                &screenshot_render_target,
+                                true,
+                                scene_gpu_mesh_handles
+                                    .values()
+                                    .filter(|(used, _)| viewport_draw_used_values || !used)
+                                    .map(|(_, handle)| (handle, Material::Edges)),
+                            );
+                        }
+                        ViewportDrawMode::Shaded => {
+                            screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
+                                &screenshot_render_target,
+                                true,
+                                scene_gpu_mesh_handles
+                                    .values()
+                                    .filter(|(used, _)| viewport_draw_used_values || !used)
+                                    .map(|(used, handle)| {
+                                        if *used {
+                                            (handle, Material::TransparentMatcapShaded)
+                                        } else {
+                                            (handle, Material::MatcapShaded)
+                                        }
+                                    }),
+                            );
+                        }
+                        ViewportDrawMode::ShadedWireframe => {
+                            screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
+                                &screenshot_render_target,
+                                true,
+                                scene_gpu_mesh_handles
+                                    .values()
+                                    .filter(|(used, _)| viewport_draw_used_values || !used)
+                                    .map(|(used, handle)| {
+                                        if *used {
+                                            (handle, Material::TransparentMatcapShadedEdges)
+                                        } else {
+                                            (handle, Material::MatcapShadedEdges)
+                                        }
+                                    }),
+                            );
+                        }
+                        ViewportDrawMode::ShadedWireframeXray => {
+                            screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
+                                &screenshot_render_target,
+                                true,
+                                scene_gpu_mesh_handles
+                                    .values()
+                                    .filter(|(used, _)| viewport_draw_used_values || !used)
+                                    .map(|(used, handle)| {
+                                        if *used {
+                                            (handle, Material::TransparentMatcapShaded)
+                                        } else {
+                                            (handle, Material::MatcapShaded)
+                                        }
+                                    }),
+                            );
+
+                            screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
+                                &screenshot_render_target,
+                                false,
+                                scene_gpu_mesh_handles
+                                    .values()
+                                    .filter(|(used, _)| viewport_draw_used_values || !used)
+                                    .map(|(_, handle)| (handle, Material::EdgesXray)),
+                            );
+                        }
+                    }
 
                     screenshot_command_buffer.submit();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ pub use crate::ui::Theme;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs::File;
-use std::iter;
 use std::mem;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -659,79 +658,73 @@ pub fn init_and_run(options: Options) -> ! {
                 match viewport_draw_mode {
                     ViewportDrawMode::Wireframe => {
                         window_command_buffer.draw_meshes_to_primary_render_target(
-                            true,
                             scene_gpu_mesh_handles
                                 .values()
                                 .filter(|(used, _)| viewport_draw_used_values || !used)
                                 .map(|(used, handle)| {
                                     if *used {
-                                        (handle, Material::TransparentMatcapShaded)
+                                        (handle, Material::TransparentMatcapShaded, false)
                                     } else {
-                                        (handle, Material::Edges)
+                                        (handle, Material::Edges, true)
                                     }
                                 }),
                         );
                     }
                     ViewportDrawMode::Shaded => {
                         window_command_buffer.draw_meshes_to_primary_render_target(
-                            true,
                             scene_gpu_mesh_handles
                                 .values()
                                 .filter(|(used, _)| viewport_draw_used_values || !used)
                                 .map(|(used, handle)| {
                                     if *used {
-                                        (handle, Material::TransparentMatcapShaded)
+                                        (handle, Material::TransparentMatcapShaded, false)
                                     } else {
-                                        (handle, Material::MatcapShaded)
+                                        (handle, Material::MatcapShaded, true)
                                     }
                                 }),
                         );
                     }
                     ViewportDrawMode::ShadedWireframe => {
                         window_command_buffer.draw_meshes_to_primary_render_target(
-                            true,
                             scene_gpu_mesh_handles
                                 .values()
                                 .filter(|(used, _)| viewport_draw_used_values || !used)
                                 .map(|(used, handle)| {
                                     if *used {
-                                        (handle, Material::TransparentMatcapShaded)
+                                        (handle, Material::TransparentMatcapShaded, false)
                                     } else {
-                                        (handle, Material::MatcapShadedEdges)
+                                        (handle, Material::MatcapShadedEdges, true)
                                     }
                                 }),
                         );
                     }
                     ViewportDrawMode::ShadedWireframeXray => {
                         window_command_buffer.draw_meshes_to_primary_render_target(
-                            true,
                             scene_gpu_mesh_handles
                                 .values()
                                 .filter(|(used, _)| viewport_draw_used_values || !used)
                                 .map(|(used, handle)| {
                                     if *used {
-                                        (handle, Material::TransparentMatcapShaded)
+                                        (handle, Material::TransparentMatcapShaded, false)
                                     } else {
-                                        (handle, Material::MatcapShaded)
+                                        (handle, Material::MatcapShaded, true)
                                     }
                                 }),
                         );
 
                         window_command_buffer.draw_meshes_to_primary_render_target(
-                            false,
                             scene_gpu_mesh_handles
                                 .values()
                                 .filter(|(used, _)| !used)
-                                .map(|(_, handle)| (handle, Material::EdgesXray)),
+                                .map(|(_, handle)| (handle, Material::EdgesXray, false)),
                         );
                     }
                 }
 
                 window_command_buffer.draw_meshes_to_primary_render_target(
-                    false,
                     ground_plane_gpu_mesh_handle
                         .iter()
-                        .zip(iter::repeat(Material::FlatWithShadows)),
+                        .map(|handle| (handle, Material::FlatWithShadows, false)),
                 );
 
                 #[cfg(not(feature = "dist"))]
@@ -788,15 +781,14 @@ pub fn init_and_run(options: Options) -> ! {
                         ViewportDrawMode::Wireframe => {
                             screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
                                 &screenshot_render_target,
-                                true,
                                 scene_gpu_mesh_handles
                                     .values()
                                     .filter(|(used, _)| viewport_draw_used_values || !used)
                                     .map(|(used, handle)| {
                                         if *used {
-                                            (handle, Material::TransparentMatcapShaded)
+                                            (handle, Material::TransparentMatcapShaded, false)
                                         } else {
-                                            (handle, Material::Edges)
+                                            (handle, Material::Edges, true)
                                         }
                                     }),
                             );
@@ -804,15 +796,14 @@ pub fn init_and_run(options: Options) -> ! {
                         ViewportDrawMode::Shaded => {
                             screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
                                 &screenshot_render_target,
-                                true,
                                 scene_gpu_mesh_handles
                                     .values()
                                     .filter(|(used, _)| viewport_draw_used_values || !used)
                                     .map(|(used, handle)| {
                                         if *used {
-                                            (handle, Material::TransparentMatcapShaded)
+                                            (handle, Material::TransparentMatcapShaded, false)
                                         } else {
-                                            (handle, Material::MatcapShaded)
+                                            (handle, Material::MatcapShaded, true)
                                         }
                                     }),
                             );
@@ -820,15 +811,14 @@ pub fn init_and_run(options: Options) -> ! {
                         ViewportDrawMode::ShadedWireframe => {
                             screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
                                 &screenshot_render_target,
-                                true,
                                 scene_gpu_mesh_handles
                                     .values()
                                     .filter(|(used, _)| viewport_draw_used_values || !used)
                                     .map(|(used, handle)| {
                                         if *used {
-                                            (handle, Material::TransparentMatcapShaded)
+                                            (handle, Material::TransparentMatcapShaded, false)
                                         } else {
-                                            (handle, Material::MatcapShadedEdges)
+                                            (handle, Material::MatcapShadedEdges, true)
                                         }
                                     }),
                             );
@@ -836,26 +826,24 @@ pub fn init_and_run(options: Options) -> ! {
                         ViewportDrawMode::ShadedWireframeXray => {
                             screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
                                 &screenshot_render_target,
-                                true,
                                 scene_gpu_mesh_handles
                                     .values()
                                     .filter(|(used, _)| viewport_draw_used_values || !used)
                                     .map(|(used, handle)| {
                                         if *used {
-                                            (handle, Material::TransparentMatcapShaded)
+                                            (handle, Material::TransparentMatcapShaded, false)
                                         } else {
-                                            (handle, Material::MatcapShaded)
+                                            (handle, Material::MatcapShaded, true)
                                         }
                                     }),
                             );
 
                             screenshot_command_buffer.draw_meshes_to_offscreen_render_target(
                                 &screenshot_render_target,
-                                false,
                                 scene_gpu_mesh_handles
                                     .values()
                                     .filter(|(used, _)| !used)
-                                    .map(|(_, handle)| (handle, Material::EdgesXray)),
+                                    .map(|(_, handle)| (handle, Material::EdgesXray, false)),
                             );
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,12 @@ pub fn init_and_run(options: Options) -> ! {
             backend: options.gpu_backend,
             power_preference: options.gpu_power_preference,
             flat_material_color: [0.0, 0.0, 0.0, 0.1],
-            transparent_matcap_shaded_material_alpha: 0.2,
+            // FIXME: These different alphas are to workaround a blending bug in
+            // the renderer. Fix the blending bug.
+            transparent_matcap_shaded_material_alpha: match options.theme {
+                Theme::Dark => 0.5,
+                Theme::Funky => 0.15,
+            },
         },
     );
 
@@ -658,7 +663,13 @@ pub fn init_and_run(options: Options) -> ! {
                             scene_gpu_mesh_handles
                                 .values()
                                 .filter(|(used, _)| viewport_draw_used_values || !used)
-                                .map(|(_, handle)| (handle, Material::Edges)),
+                                .map(|(used, handle)| {
+                                    if *used {
+                                        (handle, Material::TransparentMatcapShaded)
+                                    } else {
+                                        (handle, Material::Edges)
+                                    }
+                                }),
                         );
                     }
                     ViewportDrawMode::Shaded => {
@@ -684,7 +695,7 @@ pub fn init_and_run(options: Options) -> ! {
                                 .filter(|(used, _)| viewport_draw_used_values || !used)
                                 .map(|(used, handle)| {
                                     if *used {
-                                        (handle, Material::TransparentMatcapShadedEdges)
+                                        (handle, Material::TransparentMatcapShaded)
                                     } else {
                                         (handle, Material::MatcapShadedEdges)
                                     }
@@ -710,7 +721,7 @@ pub fn init_and_run(options: Options) -> ! {
                             false,
                             scene_gpu_mesh_handles
                                 .values()
-                                .filter(|(used, _)| viewport_draw_used_values || !used)
+                                .filter(|(used, _)| !used)
                                 .map(|(_, handle)| (handle, Material::EdgesXray)),
                         );
                     }
@@ -781,7 +792,13 @@ pub fn init_and_run(options: Options) -> ! {
                                 scene_gpu_mesh_handles
                                     .values()
                                     .filter(|(used, _)| viewport_draw_used_values || !used)
-                                    .map(|(_, handle)| (handle, Material::Edges)),
+                                    .map(|(used, handle)| {
+                                        if *used {
+                                            (handle, Material::TransparentMatcapShaded)
+                                        } else {
+                                            (handle, Material::Edges)
+                                        }
+                                    }),
                             );
                         }
                         ViewportDrawMode::Shaded => {
@@ -809,7 +826,7 @@ pub fn init_and_run(options: Options) -> ! {
                                     .filter(|(used, _)| viewport_draw_used_values || !used)
                                     .map(|(used, handle)| {
                                         if *used {
-                                            (handle, Material::TransparentMatcapShadedEdges)
+                                            (handle, Material::TransparentMatcapShaded)
                                         } else {
                                             (handle, Material::MatcapShadedEdges)
                                         }
@@ -837,7 +854,7 @@ pub fn init_and_run(options: Options) -> ! {
                                 false,
                                 scene_gpu_mesh_handles
                                     .values()
-                                    .filter(|(used, _)| viewport_draw_used_values || !used)
+                                    .filter(|(used, _)| !used)
                                     .map(|(_, handle)| (handle, Material::EdgesXray)),
                             );
                         }

--- a/src/renderer/common.rs
+++ b/src/renderer/common.rs
@@ -32,7 +32,7 @@ pub fn upload_texture_rgba8_unorm(
     let byte_count = cast_u32(data.len());
     let pixel_size = byte_count / width / height;
 
-    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
     encoder.copy_buffer_to_texture(
         wgpu::BufferCopyView {
             buffer: &buffer,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,6 +1,4 @@
-pub use self::scene_renderer::{
-    AddMeshError, DirectionalLight, DrawMeshMode, GpuMesh, GpuMeshHandle,
-};
+pub use self::scene_renderer::{AddMeshError, DirectionalLight, GpuMesh, GpuMeshHandle, Material};
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -47,8 +45,10 @@ pub struct Options {
     /// Whether to select an explicit power preference profile for the renderer
     /// to use when choosing a GPU.
     pub power_preference: Option<GpuPowerPreference>,
-    /// The color with which to render surfaces in `DrawMeshMode::FlatWithShadows`.
-    pub flat_shading_color: [f64; 4],
+    /// The color with which to render surfaces in `Material::FlatWithShadows`.
+    pub flat_material_color: [f64; 4],
+    /// The transparency value of transparent matcap materials.
+    pub transparent_matcap_shaded_material_alpha: f64,
 }
 
 /// Multi-sampling setting. Can be either disabled (1 sample per
@@ -243,7 +243,9 @@ impl Renderer {
                 sample_count: options.msaa.sample_count(),
                 output_color_attachment_format: TEXTURE_FORMAT_COLOR,
                 output_depth_attachment_format: TEXTURE_FORMAT_DEPTH,
-                flat_shading_color: options.flat_shading_color,
+                flat_material_color: options.flat_material_color,
+                transparent_matcap_shaded_material_alpha: options
+                    .transparent_matcap_shaded_material_alpha,
             },
         );
 
@@ -526,13 +528,8 @@ impl Renderer {
     ///
     /// The mesh will be available for drawing in subsequent render
     /// passes.
-    pub fn add_scene_mesh(
-        &mut self,
-        mesh: &GpuMesh,
-        transparent: bool,
-    ) -> Result<GpuMeshHandle, AddMeshError> {
-        self.scene_renderer
-            .add_mesh(&self.device, mesh, transparent)
+    pub fn add_scene_mesh(&mut self, mesh: &GpuMesh) -> Result<GpuMeshHandle, AddMeshError> {
+        self.scene_renderer.add_mesh(&self.device, mesh)
     }
 
     /// Removes mesh from the GPU.
@@ -581,7 +578,7 @@ impl Renderer {
         let frame = self.swap_chain.get_next_texture();
         let encoder = self
             .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
 
         CommandBuffer {
             backbuffer_needs_clearing: true,
@@ -670,16 +667,14 @@ impl CommandBuffer<'_> {
     /// objects rendered in subsequent calls (in addition to casting shadows on
     /// objects rendered within the same call), but the shadows won't be present
     /// on objects rendered in prior calls.
-    pub fn draw_meshes_to_primary_render_target<'a, H>(
+    pub fn draw_meshes_to_primary_render_target<'a, P>(
         &mut self,
-        mesh_handles: H,
-        mode: DrawMeshMode,
         cast_shadows: bool,
+        mesh_handle_material_pairs: P,
     ) where
-        H: Iterator<Item = &'a GpuMeshHandle> + Clone,
+        P: Iterator<Item = (&'a GpuMeshHandle, Material)> + Clone,
     {
         self.scene_renderer.draw_meshes(
-            mode,
             cast_shadows,
             self.primary_render_target_needs_clearing,
             self.clear_color,
@@ -689,7 +684,7 @@ impl CommandBuffer<'_> {
             self.msaa_texture_view.as_ref(),
             &self.color_texture_view,
             &self.depth_texture_view,
-            mesh_handles,
+            mesh_handle_material_pairs,
         );
 
         self.primary_render_target_needs_clearing = false;
@@ -710,14 +705,13 @@ impl CommandBuffer<'_> {
     /// objects rendered in subsequent calls (in addition to casting shadows on
     /// objects rendered within the same call), but the shadows won't be present
     /// on objects rendered in prior calls.
-    pub fn draw_meshes_to_offscreen_render_target<'a, H>(
+    pub fn draw_meshes_to_offscreen_render_target<'a, P>(
         &mut self,
         render_target_handle: &OffscreenRenderTargetHandle,
-        mesh_handles: H,
-        mode: DrawMeshMode,
         cast_shadows: bool,
+        mesh_handle_material_pairs: P,
     ) where
-        H: Iterator<Item = &'a GpuMeshHandle> + Clone,
+        P: Iterator<Item = (&'a GpuMeshHandle, Material)> + Clone,
     {
         let offscreen_render_target = &self.offscreen_render_targets[&render_target_handle.0];
         let offscreen_render_target_needs_clearing = self
@@ -730,7 +724,6 @@ impl CommandBuffer<'_> {
             .expect("Need encoder to record drawing");
 
         self.scene_renderer.draw_meshes(
-            mode,
             cast_shadows,
             offscreen_render_target_needs_clearing,
             self.clear_color,
@@ -738,7 +731,7 @@ impl CommandBuffer<'_> {
             offscreen_render_target.msaa_texture_view.as_ref(),
             &offscreen_render_target.color_texture_view,
             &offscreen_render_target.depth_texture_view,
-            mesh_handles,
+            mesh_handle_material_pairs,
         );
 
         encoder.copy_texture_to_buffer(

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::time::{Duration, Instant};
 
 use crate::interpreter::ast::{FuncIdent, Prog, Stmt, VarIdent};
-use crate::interpreter::{Func, InterpretError, LogMessage, Ty, Value};
+use crate::interpreter::{Func, InterpretError, InterpretValue, LogMessage, Ty, Value};
 use crate::interpreter_funcs;
 use crate::interpreter_server::{
     InterpreterRequest, InterpreterResponse, InterpreterServer, PollResponseError, RequestId,
@@ -14,11 +14,25 @@ use crate::interpreter_server::{
 /// about what values have been added since the last poll, and what
 /// values have been removed are no longer required.
 pub enum PollNotification {
-    ValueAdded(VarIdent, Value),
-    ValueRemoved(VarIdent, Value),
+    UsedValueAdded(VarIdent, Value),
+    UsedValueRemoved(VarIdent, Value),
+    UnusedValueAdded(VarIdent, Value),
+    UnusedValueRemoved(VarIdent, Value),
     FinishedSuccessfully,
     // FIXME: Replace String with InterpretError
     FinishedWithError(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum DiffEvent {
+    AddUsed(VarIdent, Value),
+    RemoveUsed(VarIdent),
+    VerifyUsed(VarIdent, Value),
+    TransitionUsedToUnused(VarIdent, Value),
+    AddUnused(VarIdent, Value),
+    RemoveUnused(VarIdent),
+    VerifyUnused(VarIdent, Value),
+    TransitionUnusedToUsed(VarIdent, Value),
 }
 
 /// An editing session.
@@ -42,7 +56,12 @@ pub struct Session {
     log_messages: Vec<Vec<LogMessage>>,
     error: Option<InterpretError>,
 
+    used_values: HashMap<VarIdent, Value>,
     unused_values: HashMap<VarIdent, Value>,
+
+    // Working memory for diffing interpreter responses
+    diff_events: Vec<DiffEvent>,
+    diff_processed_idents: HashSet<VarIdent>,
 
     // Auxiliary side-arrays for prog. Determine mesh and mesh-array
     // vars visible from a stmt. The value is read by producing a
@@ -66,10 +85,14 @@ impl Session {
             interpreter_interpret_request_in_flight: None,
             interpreter_edit_prog_requests_in_flight: HashSet::new(),
 
+            diff_events: Vec::with_capacity(64),
+            diff_processed_idents: HashSet::with_capacity(64),
+
             prog: Prog::new(Vec::new()),
             log_messages: Vec::new(),
             error: None,
 
+            used_values: HashMap::new(),
             unused_values: HashMap::new(),
 
             var_visibility_mesh: Vec::new(),
@@ -362,87 +385,7 @@ impl Session {
 
                             match interpret_outcome.result {
                                 Ok(interpret_value) => {
-                                    // Now we track whether the usage of any value changed. Adding
-                                    // an operation to the pipeline can:
-                                    // - create a new unused_value
-                                    // - create a new used_value
-                                    // - change an existing unused_value to used_value
-                                    //
-                                    // Removing an operation from the pipeline can:
-                                    // - remove an existing unused_value
-                                    // - remove an existing used_value
-                                    // - change an existing used_value to unused_value
-                                    //
-                                    // We diff the old and new sets and perform the following
-                                    // operations:
-                                    // - Detect which values should be removed and `Remove` them
-                                    // - Detect which values should be retained, but they
-                                    //   changed, we both `Remove` and `Add` them to notify
-                                    //   the outside of the change
-                                    // - Detect which values should be added and `Add` them
-
-                                    // FIXME: Currently, we only call the add/remove
-                                    // handlers with when a value enters or leaves the
-                                    // unused_values set. This can be easily copy-paste
-                                    // extended to handle used_values the same way.
-
-                                    let mut to_remove =
-                                        Vec::with_capacity(self.unused_values.len());
-                                    let mut to_reinsert =
-                                        Vec::with_capacity(self.unused_values.len());
-                                    for (current_var_ident, current_value) in &self.unused_values {
-                                        if let Some((var_ident, value)) = interpret_value
-                                            .unused_values
-                                            .iter()
-                                            .find(|(var_ident, _)| var_ident == current_var_ident)
-                                        {
-                                            // The value is present under the same
-                                            // identifier in both new and old value set,
-                                            // but it could have changed! If it did, we
-                                            // both remove the old value and add the new.
-                                            if value != current_value {
-                                                to_remove.push(*var_ident);
-                                                to_reinsert.push((*var_ident, value.clone()));
-                                            }
-                                        } else {
-                                            // The value is no longer present in the new
-                                            // value set, let's remove it!
-                                            to_remove.push(*current_var_ident);
-                                        }
-                                    }
-
-                                    // Process values to remove and values to reinsert
-                                    for var_ident in to_remove {
-                                        let value = self.unused_values.remove(&var_ident).expect(
-                                            "Value must be present if we want to remove it",
-                                        );
-                                        callback(PollNotification::ValueRemoved(var_ident, value));
-                                    }
-                                    for (var_ident, value) in to_reinsert {
-                                        let inserted = self
-                                            .unused_values
-                                            .insert(var_ident, value.clone())
-                                            .is_none();
-                                        assert!(
-                                            inserted,
-                                            "Value must have been removed previously for reinsertion",
-                                        );
-                                        callback(PollNotification::ValueAdded(var_ident, value))
-                                    }
-
-                                    for (var_ident, value) in interpret_value.unused_values {
-                                        // Only add and emit events for values that we
-                                        // didn't have before. We handled re-insertions
-                                        // earlier by comparing the values.
-                                        if let Entry::Vacant(vacant) =
-                                            self.unused_values.entry(var_ident)
-                                        {
-                                            vacant.insert(value.clone());
-                                            callback(PollNotification::ValueAdded(
-                                                var_ident, value,
-                                            ));
-                                        }
-                                    }
+                                    self.process_interpret_value(interpret_value, &mut callback);
 
                                     // Impure funcs (think import) can sometimes succeed
                                     // with the same parameters for which they previously
@@ -456,12 +399,12 @@ impl Session {
                                         "Interpreter failed with error: {}",
                                         interpret_error,
                                     );
-                                    callback(PollNotification::FinishedWithError(format!(
-                                        "{}",
-                                        interpret_error
-                                    )));
+
+                                    let error_message = format!("{}", interpret_error);
 
                                     self.error = Some(interpret_error);
+
+                                    callback(PollNotification::FinishedWithError(error_message));
                                 }
                             }
 
@@ -483,6 +426,179 @@ impl Session {
                 Err(PollResponseError::Pending) => {
                     // No more responses, break out of the loop
                     break;
+                }
+            }
+        }
+    }
+
+    /// Tracks whether the usage of any value changed and calls callback with
+    /// corresponding notification.
+    ///
+    /// Executing a program with new added statements can:
+    ///
+    /// - Create a new unused value
+    /// - Create a new used value
+    /// - Transition an existing unused value to used value
+    ///
+    /// Executing a program with statements removed can:
+    ///
+    /// - Remove an existing unused value
+    /// - Remove an existing used value
+    /// - Transition an existing used value to unused value
+    ///
+    /// We diff the old and new sets and perform the following operations:
+    ///
+    /// - Detect which values should be added and add them (for both used and unused sets),
+    /// - Detect which values should be removed and remove them (for both used
+    ///   and unused sets),
+    /// - Detect which values should be retained, but they changed, we both
+    ///   remove and add them to notify the outside of the change (for both used
+    ///   and unused sets),
+    /// - Detect which values should be transitioned from the used set to unused
+    ///   and miami vice versa.
+    fn process_interpret_value<C>(&mut self, interpret_value: InterpretValue, mut callback: C)
+    where
+        C: FnMut(PollNotification),
+    {
+        // To correctly diff new state against old, we need to keep a copy of
+        // the old state around. Therefore, we perform changes in 2 stages:
+        //
+        // 1) Generate a list of diff events by comparing new and old sets,
+        // 2) Interpret the list of diff events and modify the old set and fire
+        //    callbacks with corresponding notifications.
+
+        let InterpretValue {
+            used_values,
+            unused_values,
+            ..
+        } = interpret_value;
+
+        let events = &mut self.diff_events;
+        let processed_idents = &mut self.diff_processed_idents;
+
+        // Look at new used values to detect addition, verification and transition events.
+        for (var_ident, value) in used_values {
+            let contained_in_used = self.used_values.contains_key(&var_ident);
+            let contained_in_unused = self.unused_values.contains_key(&var_ident);
+
+            match (contained_in_used, contained_in_unused) {
+                (true, true) => panic!("Value can't be both used and unused"),
+                (true, false) => events.push(DiffEvent::VerifyUsed(var_ident, value)),
+                (false, true) => events.push(DiffEvent::TransitionUnusedToUsed(var_ident, value)),
+                (false, false) => events.push(DiffEvent::AddUsed(var_ident, value)),
+            }
+
+            processed_idents.insert(var_ident);
+        }
+
+        // Look at new unused values to detect addition, verification, and transition events.
+        for (var_ident, value) in unused_values {
+            let contained_in_used = self.used_values.contains_key(&var_ident);
+            let contained_in_unused = self.unused_values.contains_key(&var_ident);
+
+            match (contained_in_used, contained_in_unused) {
+                (true, true) => panic!("Value can't be both used and unused"),
+                (true, false) => events.push(DiffEvent::TransitionUsedToUnused(var_ident, value)),
+                (false, true) => events.push(DiffEvent::VerifyUnused(var_ident, value)),
+                (false, false) => events.push(DiffEvent::AddUnused(var_ident, value)),
+            }
+
+            processed_idents.insert(var_ident);
+        }
+
+        // See if there is a value in the old used set we haven't seen yet. If
+        // so, it has to be a removal event.
+        for var_ident in self.used_values.keys() {
+            if !processed_idents.contains(var_ident) {
+                events.push(DiffEvent::RemoveUsed(*var_ident));
+            }
+        }
+
+        // See if there is a value in the old unused set we haven't seen yet. If
+        // so, it has to be a removal event.
+        for var_ident in self.unused_values.keys() {
+            if !processed_idents.contains(var_ident) {
+                events.push(DiffEvent::RemoveUnused(*var_ident));
+            }
+        }
+
+        // Process all the events, update internal state, call callback with
+        // change notifications. Make sure working memory is cleared for next
+        // iteration.
+        processed_idents.clear();
+        for event in events.drain(..) {
+            match event {
+                DiffEvent::AddUsed(var_ident, value) => {
+                    self.used_values.insert(var_ident, value.clone());
+                    callback(PollNotification::UsedValueAdded(var_ident, value));
+                }
+                DiffEvent::RemoveUsed(var_ident) => {
+                    let value = self
+                        .used_values
+                        .remove(&var_ident)
+                        .expect("Values scheduled for removal must be present");
+                    callback(PollNotification::UsedValueRemoved(var_ident, value));
+                }
+                DiffEvent::VerifyUsed(var_ident, value) => {
+                    match self.used_values.entry(var_ident) {
+                        Entry::Occupied(mut occupied) => {
+                            if occupied.get() != &value {
+                                let old_value = occupied.get().clone();
+                                occupied.insert(value.clone());
+
+                                callback(PollNotification::UsedValueRemoved(var_ident, old_value));
+                                callback(PollNotification::UsedValueAdded(var_ident, value));
+                            }
+                        }
+                        _ => panic!("Values scheduled for verification must be present"),
+                    }
+                }
+                DiffEvent::TransitionUsedToUnused(var_ident, value) => {
+                    let old_value = self
+                        .used_values
+                        .remove(&var_ident)
+                        .expect("Values scheduled for transition must be present");
+                    self.unused_values.insert(var_ident, value.clone());
+
+                    callback(PollNotification::UsedValueRemoved(var_ident, old_value));
+                    callback(PollNotification::UnusedValueAdded(var_ident, value));
+                }
+                DiffEvent::AddUnused(var_ident, value) => {
+                    self.unused_values.insert(var_ident, value.clone());
+                    callback(PollNotification::UnusedValueAdded(var_ident, value));
+                }
+                DiffEvent::RemoveUnused(var_ident) => {
+                    let value = self
+                        .unused_values
+                        .remove(&var_ident)
+                        .expect("Values scheduled for removal must be present");
+                    callback(PollNotification::UnusedValueRemoved(var_ident, value));
+                }
+                DiffEvent::VerifyUnused(var_ident, value) => {
+                    match self.unused_values.entry(var_ident) {
+                        Entry::Occupied(mut occupied) => {
+                            if occupied.get() != &value {
+                                let old_value = occupied.get().clone();
+                                occupied.insert(value.clone());
+
+                                callback(PollNotification::UnusedValueRemoved(
+                                    var_ident, old_value,
+                                ));
+                                callback(PollNotification::UnusedValueAdded(var_ident, value));
+                            }
+                        }
+                        _ => panic!("Values scheduled for verification must be present"),
+                    }
+                }
+                DiffEvent::TransitionUnusedToUsed(var_ident, value) => {
+                    let old_value = self
+                        .unused_values
+                        .remove(&var_ident)
+                        .expect("Values scheduled for transition must be present");
+                    self.used_values.insert(var_ident, value.clone());
+
+                    callback(PollNotification::UnusedValueRemoved(var_ident, old_value));
+                    callback(PollNotification::UsedValueAdded(var_ident, value));
                 }
             }
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -455,7 +455,7 @@ impl Session {
     ///   remove and add them to notify the outside of the change (for both used
     ///   and unused sets),
     /// - Detect which values should be transitioned from the used set to unused
-    ///   and miami vice versa.
+    ///   and vice versa.
     fn process_interpret_value<C>(&mut self, interpret_value: InterpretValue, mut callback: C)
     where
         C: FnMut(PollNotification),

--- a/src/shaders/scene_color_pass.frag
+++ b/src/shaders/scene_color_pass.frag
@@ -8,6 +8,7 @@ layout(set = 3, binding = 0) uniform texture2D u_shadow_map_texture;
 layout(set = 4, binding = 0, std140) uniform ColorPass {
     vec4 u_shading_mode_flat_color;
     vec3 u_shading_mode_edges_color;
+    float u_shading_mode_shaded_alpha;
     uint u_shading_mode;
 };
 
@@ -47,7 +48,9 @@ void main() {
 
     // -- Sample matcap color --
 
-    vec4 matcap_color = texture(sampler2D(u_matcap_texture, u_sampler), v_matcap_tex_coords);
+    vec4 matcap_color = vec4(texture(sampler2D(u_matcap_texture, u_sampler),
+                                     v_matcap_tex_coords).rgb,
+                             u_shading_mode_shaded_alpha);
 
     // -- Compute shadow --
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -41,7 +41,7 @@ pub enum Theme {
 
 /// The draw mode applied to a group of objects in the viewport. Not always a
 /// 1:1 mapping with renderer materials.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ViewportDrawMode {
     Wireframe,
     Shaded,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -640,7 +640,7 @@ impl<'a> UiFrame<'a> {
                         if *viewport_draw_used_values {
                             "Viewport now draws used geometry."
                         } else {
-                            "Viewport now doesn't draw used geomery."
+                            "Viewport now doesn't draw used geometry."
                         }
                     );
                 }
@@ -649,9 +649,11 @@ impl<'a> UiFrame<'a> {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
                         ui.text("DRAW USED GEOMETRY IN VIEWPORT\n\
                         \n\
+                        When enabled, used geometry will be drawn with \
+                        a transparent material.\n
+                        \n
                         Used geometry is geometry that has been referenced as a parameter \
-                        in an operation. When enabled, used geometry will be drawn with \
-                        a transparent material.");
+                        in an operation.");
                         wrap_token.pop(ui);
                     });
                 }


### PR DESCRIPTION
The feature is published as a check box in the main menu. Enabled by default,
now all used values/geometries are visible in the viewport, rendered with a
transparent(er) version of the currently selected viewport draw mode.

The renderer is refactored to divorce the concepts of a material and a viewport
draw mode. A viewport draw mode is what the application knows about and maps to
renderer materials. The renderer is now able to render each object within a
batch with a different material. Internally, a material is represented as a set
of values contained in a uniform buffer. Depending on a material's transparency
behavior (opaque/transparent/xray), the renderer automatically selects a correct
render pipeline to draw with - some pipelines read-write depth, some only read
depth, and some always pass the depth test without writing - and sorts the
objects in the three transparency category render lists (opaque, transparent,
xray) based on the object's centroid z value after projection with the camera
view matrix.

The session now notifies the caller with changes to used values. Internal value
diffing algorithm has been simplified, optimized and expanded to support
transitioning values between used and unused value sets.

The "Center viewport" feature now takes into consideration, whether used values
are visible, and always centers only around visible values.

Please test extensively. A lot of untested code has been changed and refactored.