### PR TITLE
Adjust texts to match printed manual, add styling to new elements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,7 +714,7 @@ pub fn init_and_run(options: Options) -> ! {
                         notifications.borrow_mut().push(
                             time,
                             NotificationLevel::Info,
-                            "Execution of the Sequence of operations finished successfully.",
+                            "Execution of the Operation pipeline finished successfully.",
                         );
                     }
                     PollNotification::FinishedWithError(error_message) => {
@@ -722,7 +722,7 @@ pub fn init_and_run(options: Options) -> ! {
                             time,
                             NotificationLevel::Error,
                             format!(
-                                "Execution of the Sequence of operations finished with error: {}",
+                                "Execution of the Operation pipeline finished with error: {}",
                                 error_message
                             ),
                         );

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -744,7 +744,7 @@ impl<'a> UiFrame<'a> {
                 if ui.is_item_hovered() {
                     ui.tooltip(|| {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
-                        ui.text_colored(self.colors.tooltip_text, "SAVE PROJECT INTO THE CURENT A .hurban FILE\n\
+                        ui.text_colored(self.colors.tooltip_text, "SAVE PROJECT INTO THE CURRENT A .hurban FILE\n\
                         \n\
                         Saves the current project into a .hurban file. \
                         When used for the first time, opens a system dialog to specify save file location.\n\

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -683,7 +683,7 @@ impl<'a> UiFrame<'a> {
                 if ui.is_item_hovered() {
                     ui.tooltip(|| {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
-                        ui.text_colored(self.colors.tooltip_text, "TAKE SCREENSHOT\n\
+                        ui.text_colored(self.colors.tooltip_text, "SAVE SCREENSHOT\n\
                         \n\
                         Opens the dialog for saving the current viewport into a PNG file.");
                         wrap_token.pop(ui);
@@ -711,6 +711,18 @@ impl<'a> UiFrame<'a> {
                     project_status.new_requested = false;
                 }
 
+                if ui.is_item_hovered() {
+                    ui.tooltip(|| {
+                        let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
+                        ui.text_colored(self.colors.tooltip_text, "RESET THE PIPELINE\n\
+                        \n\
+                        Closes the current project and starts a new one. \n\
+                        \n\
+                        The new project is not saved by default and has to be saved manually.");
+                        wrap_token.pop(ui);
+                    });
+                }
+
                 if ui.button(imgui::im_str!("Save"), [-f32::MIN_POSITIVE, 0.0]) {
                     match &project_status.path {
                         Some(project_path_str) => {
@@ -732,12 +744,12 @@ impl<'a> UiFrame<'a> {
                 if ui.is_item_hovered() {
                     ui.tooltip(|| {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
-                        ui.text_colored(self.colors.tooltip_text, "SAVE PROJECT INTO A .hurban FILE\n\
+                        ui.text_colored(self.colors.tooltip_text, "SAVE PROJECT INTO THE CURENT A .hurban FILE\n\
                         \n\
                         Saves the current project into a .hurban file. \
                         When used for the first time, opens a system dialog to specify save file location.\n\
                         \n\
-                        The .hurban project file contains only the operation sequence. It does not contain any \
+                        The .hurban project file contains only the operation pipeline. It does not contain any \
                         actual geometry, but rather just the sequence of operations that generates the geometry \
                         and references to the external files to import. \
                         It is advised to keep the files to import next to the .hurban project file \
@@ -755,6 +767,23 @@ impl<'a> UiFrame<'a> {
                     ) {
                         status.save_path = Some(path);
                     }
+                }
+
+                if ui.is_item_hovered() {
+                    ui.tooltip(|| {
+                        let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
+                        ui.text_colored(self.colors.tooltip_text, "SAVE PROJECT INTO A NEW .hurban FILE\n\
+                        \n\
+                        Saves the current project into a .hurban file. \
+                        Opens a system dialog to specify save file location.\n\
+                        \n\
+                        The .hurban project file contains only the operation pipeline. It does not contain any \
+                        actual geometry, but rather just the sequence of operations that generates the geometry \
+                        and references to the external files to import. \
+                        It is advised to keep the files to import next to the .hurban project file \
+                        and distribute them together.");
+                        wrap_token.pop(ui);
+                    });
                 }
 
                 if ui.button(imgui::im_str!("Open"), [-f32::MIN_POSITIVE, 0.0])
@@ -781,10 +810,9 @@ impl<'a> UiFrame<'a> {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
                         ui.text_colored(self.colors.tooltip_text, "OPEN PROJECT FROM A .hurban FILE\n\
                         \n\
-                        Opens the sequence of operations saved in a .hurban file. \
-                        The current unsaved project will be lost.\n\
+                        Opens the sequence of operations saved in a .hurban file.\n\
                         \n\
-                        The .hurban project file contains only the operation sequence. It does not contain any \
+                        The .hurban project file contains only the operation pipeline. It does not contain any \
                         actual geometry, but rather just the sequence of operations that generates the geometry \
                         and references to the external files to import. \
                         It is advised to keep the files to import next to the .hurban project file \
@@ -828,35 +856,42 @@ impl<'a> UiFrame<'a> {
     pub fn draw_prevent_overwrite_modal(&self) -> SaveModalResult {
         let ui = &self.imgui_ui;
         let mut save_modal_result = SaveModalResult::Nothing;
-
+        let window_color_token = ui.push_style_color(
+            imgui::StyleColor::PopupBg,
+            self.colors.popup_window_background,
+        );
         ui.open_popup(imgui::im_str!("Unsaved changes"));
         ui.popup_modal(imgui::im_str!("Unsaved changes"))
             .resizable(false)
             .build(|| {
-                ui.text("Your changes will be lost if you don't save them.");
+                ui.text("To preserve unsaved changes in the pipeline please save the project.");
 
-                if ui.button(imgui::im_str!("Save"), [0.0, 0.0]) {
+                let width_unit = ui.window_size()[0] / 11.0;
+
+                if ui.button(imgui::im_str!("Save"), [width_unit * 3.0, 0.0]) {
                     save_modal_result = SaveModalResult::Save;
 
                     ui.close_current_popup();
                 }
 
-                ui.same_line(0.0);
+                ui.same_line(width_unit * 4.0);
 
-                if ui.button(imgui::im_str!("Discard changes"), [0.0, 0.0]) {
+                if ui.button(imgui::im_str!("Discard changes"), [width_unit * 3.0, 0.0]) {
                     save_modal_result = SaveModalResult::DontSave;
 
                     ui.close_current_popup();
                 }
 
-                ui.same_line(0.0);
+                ui.same_line(width_unit * 8.0);
 
-                if ui.button(imgui::im_str!("Cancel"), [0.0, 0.0]) {
+                if ui.button(imgui::im_str!("Cancel"), [width_unit * 3.0, 0.0]) {
                     save_modal_result = SaveModalResult::Cancel;
 
                     ui.close_current_popup();
                 }
             });
+
+        window_color_token.pop(ui);
 
         save_modal_result
     }
@@ -894,7 +929,7 @@ impl<'a> UiFrame<'a> {
         let mut change = None;
 
         let bold_font_token = ui.push_font(self.font_ids.bold);
-        imgui::Window::new(imgui::im_str!("Sequence of operations"))
+        imgui::Window::new(imgui::im_str!("Operation pipeline"))
             .movable(false)
             .resizable(false)
             .collapsible(false)
@@ -906,23 +941,23 @@ impl<'a> UiFrame<'a> {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
                         let regular_font_token = ui.push_font(self.font_ids.regular);
                         ui.text_colored(self.colors.tooltip_text,
-                            "SEQUENCE OF OPERATIONS\n\
+                            "OPERATION PIPELINE\n\
                             \n\
-                            An ordered list of operations that generate the viewport geometry. \
-                            When the sequence is run, the operations are being executed one after \
+                            An ordered sequence of operations that generate the viewport geometry. \
+                            When the pipeline is run, the operations are being executed one after \
                             another from top down. Each operation can be customized by setting the \
                             input parameter values or specifying the input data (mesh geometry, \
                             mesh group, path to file).\n\
                             \n\
-                            Each operation in the sequence generates data: either a mesh geometry or \
+                            Each operation in the pipeline generates data: either a mesh geometry or \
                             a mesh group which can be later used in a subsequent operation. Only unused \
                             (freshly generated) geometry (mesh or group) is rendered in the viewport, \
                             however even the geometry, which has been already used, can be reused in \
                             subsequent operations. Operations can take as an input only that geometry, \
-                            which has been generated in the preceding operations in the sequence.\n\
+                            which has been generated in the preceding operations in the pipeline.\n\
                             \n\
                             It is possible to change any input parameters of any operation at any time, \
-                            not only after the operation has been added to the sequence. \
+                            not only after the operation has been added to the pipeline. \
                             This is useful when some parameters need to be adjusted only after the results \
                             of subsequent operations can be visually evaluated. This approach is a gateway \
                             to full-fledged parametric modeling paradigm.\n\
@@ -1422,7 +1457,8 @@ impl<'a> UiFrame<'a> {
                         let regular_font_token = ui.push_font(self.font_ids.regular);
                         ui.text_colored(self.colors.tooltip_text, "AVAILABLE OPERATIONS\n\
                         \n\
-                        A list of available operations to be stacked into a sequence of operations.");
+                        A list of available operations to be stacked into the sequence of operations \
+                        in the Operation pipeline.");
                         regular_font_token.pop(ui);
                         wrap_token.pop(ui);
                     });
@@ -1464,10 +1500,10 @@ impl<'a> UiFrame<'a> {
                 if ui.is_item_hovered() {
                     ui.tooltip(|| {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
-                        ui.text_colored(self.colors.tooltip_text, "RUN RECOMPUTATION OF THE SEQUENCE OF OPERATIONS\n\
+                        ui.text_colored(self.colors.tooltip_text, "RUN RECOMPUTATION OF THE OPERATION PIPELINE\n\
                         \n\
-                        Executes the list of operations stacked in the Sequence of operations one \
-                        after another from top down. The Sequence of operations editing is disabled \
+                        Executes the list of operations stacked in the Operation pipeline one \
+                        after another from top down. The Operation pipeline editing is disabled \
                         during the computation. If any operation fails due to invalid input parameters, \
                         the computation stops and the error will be reported in the console log of the \
                         respective operation.");
@@ -1494,7 +1530,7 @@ impl<'a> UiFrame<'a> {
                     notifications.push(
                         current_time,
                         NotificationLevel::Warn,
-                        "Removed last operation from the Sequence.",
+                        "Removed last operation from the Operation pipeline.",
                     );
                 }
                 if let Some((color_token, style_token)) = popping_tokens {
@@ -1505,10 +1541,17 @@ impl<'a> UiFrame<'a> {
                 if ui.is_item_hovered() {
                     ui.tooltip(|| {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
-                        ui.text_colored(self.colors.tooltip_text, "REMOVE LAST OPERATION FROM THE SEQUENCE\n\
+                        ui.text_colored(self.colors.tooltip_text, "REMOVE LAST OPERATION FROM THE OPERATION PIPELINE\n\
                         \n\
-                        Only the last operation in the sequence of operations can be removed. \
+                        Only the last operation in the sequence of operations stacked into \
+                        the Operation pipeline can be removed.");
+                        let text_color_token = ui.push_style_color(
+                            imgui::StyleColor::Text,
+                            self.colors.log_message_warn,
+                        );
+                        ui.text("\n\
                         The removal cannot be undone!");
+                        text_color_token.pop(ui);
                         wrap_token.pop(ui);
                     });
                 }
@@ -1520,7 +1563,7 @@ impl<'a> UiFrame<'a> {
                     if ui.is_item_hovered() {
                         ui.tooltip(|| {
                             let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
-                            ui.text_colored(self.colors.tooltip_text, "RUN RECOMPUTATION OF THE SEQUENCE OF OPERATIONS AUTOMATICALLY\n\
+                            ui.text_colored(self.colors.tooltip_text, "RUN RECOMPUTATION OF THE OPERATION PIPELINE AUTOMATICALLY\n\
                             \n\
                             Executes the list of operations stacked in the Sequence of \
                             operations one after another from top down automatically whenever a \
@@ -1563,7 +1606,7 @@ impl<'a> UiFrame<'a> {
                         notifications.push(
                             current_time,
                             NotificationLevel::Info,
-                            format!("Added new operation to the Sequence: {}.", func.info().name),
+                            format!("Added new operation to the Operation pipeline: {}.", func.info().name),
                         );
                     }
 
@@ -1677,7 +1720,7 @@ impl<'a> UiFrame<'a> {
             notifications.push(
                 current_time,
                 NotificationLevel::Info,
-                "Execution of the Sequence of operations has started...",
+                "Execution of the Operation pipeline has started...",
             );
             session.interpret();
         }


### PR DESCRIPTION
Some texts are now returned to their former version, some parts are a compromise between old and new versions (mainly words "sequence" and "pipeline").
The official name of the pipeline is now "Operation pipeline" with a subtitle "sequence of operations".

This is mainly due to a printed manual, that hasn't been updated and still uses the name "Operation pipeline". This compromise can remain in the master.