### PR TITLE
Add project extension if it's missing while saving

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,11 +401,14 @@ pub fn init_and_run(options: Options) -> ! {
                     let project = project::Project { version: 1, stmts };
 
                     match project::save(&save_path, project) {
-                        Ok(_) => {
+                        Ok(save_path) => {
+                            let save_path = save_path
+                                .as_os_str()
+                                .to_str()
+                                .expect("Failed to convert save path to str.");
+
                             project_status.save(&save_path);
-
                             change_window_title(&window, &project_status);
-
                             notifications.borrow_mut().push(
                                 time,
                                 NotificationLevel::Info,
@@ -548,15 +551,25 @@ pub fn init_and_run(options: Options) -> ! {
                                 let project = project::Project { version: 1, stmts };
 
                                 match project::save(&save_path, project) {
-                                    Ok(_) => match prevent_overwrite_status {
+                                    Ok(save_path) => match prevent_overwrite_status {
                                         project::NextAction::Exit => {
                                             *control_flow = winit::event_loop::ControlFlow::Exit
                                         }
                                         project::NextAction::NewProject => {
+                                            let save_path = save_path
+                                                .as_os_str()
+                                                .to_str()
+                                                .expect("Failed to convert save path to str.");
+
                                             project_status.save(&save_path);
                                             project_status.new_requested = true;
                                         }
                                         project::NextAction::OpenProject => {
+                                            let save_path = save_path
+                                                .as_os_str()
+                                                .to_str()
+                                                .expect("Failed to convert save path to str.");
+
                                             project_status.save(&save_path);
                                             project_status.open_requested = true
                                         }

--- a/src/project.rs
+++ b/src/project.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{self, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use ron;
 use serde::Serialize;
@@ -97,17 +97,28 @@ pub struct Project {
     pub stmts: Vec<ast::Stmt>,
 }
 
-pub fn save<P: AsRef<Path>>(path: P, project: Project) -> Result<(), ProjectError> {
+/// Saves project to given path. If this path does not contain valid project
+/// extension, it is automatically added.
+///
+/// Returns `PathBuf` which can be different than original path if the project
+/// extension was added.
+pub fn save<P: AsRef<Path>>(path: P, project: Project) -> Result<PathBuf, ProjectError> {
     let pretty_config = ron::ser::PrettyConfig::default();
     let mut serializer = ron::ser::Serializer::new(Some(pretty_config), true);
     project.serialize(&mut serializer)?;
 
+    let mut path_buf = path.as_ref().to_path_buf();
+
+    if path_buf.extension().is_none() {
+        path_buf.set_extension(PROJECT_EXTENSION);
+    }
+
     let contents = serializer.into_output_string();
-    let mut file = File::create(path)?;
+    let mut file = File::create(path_buf.as_path())?;
 
     file.write_all(contents.as_bytes())?;
 
-    Ok(())
+    Ok(path_buf)
 }
 
 pub fn open<P: AsRef<Path>>(path: P) -> Result<Project, ProjectError> {

--- a/src/project.rs
+++ b/src/project.rs
@@ -109,8 +109,17 @@ pub fn save<P: AsRef<Path>>(path: P, project: Project) -> Result<PathBuf, Projec
 
     let mut path_buf = path.as_ref().to_path_buf();
 
-    if path_buf.extension().is_none() {
-        path_buf.set_extension(PROJECT_EXTENSION);
+    match path_buf.extension() {
+        Some(extension) => {
+            let extension = extension.to_string_lossy().into_owned();
+
+            if extension != PROJECT_EXTENSION {
+                path_buf.set_extension(format!("{}.{}", extension, PROJECT_EXTENSION));
+            }
+        }
+        None => {
+            path_buf.set_extension(PROJECT_EXTENSION);
+        }
     }
 
     let contents = serializer.into_output_string();


### PR DESCRIPTION
While Windows can filter by file type in save dialog, it doesn't automatically handle adding of this file type's extension to saved file. This patch fixes it and adds extension to files that don't contain it.