### PR TITLE
EULA as a separate file and in the About section

### DIFF
--- a/eula.md
+++ b/eula.md
@@ -1,43 +1,86 @@
 # End-User License Agreement (EULA) of H.U.R.B.A.N. selector
 
-This End-User License Agreement ("EULA") is a legal agreement between you and Slovak Design Center and Subdigital s.r.o.
+This End-User License Agreement ("EULA") is a legal agreement between you and
+Slovak Design Center and Subdigital s.r.o.
 
-This EULA agreement governs your acquisition and use of our H.U.R.B.A.N. selector software ("Software") directly from Slovak Design Center and Subdigital s.r.o. or indirectly through a Slovak Design Center and Subdigital s.r.o. authorized reseller or distributor (a "Reseller").
+This EULA agreement governs your acquisition and use of our H.U.R.B.A.N.
+selector software ("Software") directly from Slovak Design Center and Subdigital
+s.r.o. or indirectly through a Slovak Design Center and Subdigital s.r.o.
+authorized reseller or distributor (a "Reseller").
 
-Please read this EULA agreement carefully before completing the installation process and using the H.U.R.B.A.N. selector software. It provides a license to use the H.U.R.B.A.N. selector software and contains warranty information and liability disclaimers.
+Please read this EULA agreement carefully before completing the installation
+process and using the H.U.R.B.A.N. selector software. It provides a license to
+use the H.U.R.B.A.N. selector software and contains warranty information and
+liability disclaimers.
 
-If you register for a free trial of the H.U.R.B.A.N. selector software, this EULA agreement will also govern that trial. By clicking "accept" or installing and/or using the H.U.R.B.A.N. selector software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.
+If you register for a free trial of the H.U.R.B.A.N. selector software, this
+EULA agreement will also govern that trial. By clicking "accept" or installing
+and/or using the H.U.R.B.A.N. selector software, you are confirming your
+acceptance of the Software and agreeing to become bound by the terms of this
+EULA agreement.
 
-If you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.
+If you are entering into this EULA agreement on behalf of a company or other
+legal entity, you represent that you have the authority to bind such entity and
+its affiliates to these terms and conditions. If you do not have such authority
+or if you do not agree with the terms and conditions of this EULA agreement, do
+not install or use the Software, and you must not accept this EULA agreement.
 
-This EULA agreement shall apply only to the Software supplied by Slovak Design Center and Subdigital s.r.o. herewith regardless of whether other software is referred to or described herein. The terms also apply to any Slovak Design Center and Subdigital s.r.o. updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply. This EULA was created by EULA Template for H.U.R.B.A.N. selector.
+This EULA agreement shall apply only to the Software supplied by Slovak Design
+Center and Subdigital s.r.o. herewith regardless of whether other software is
+referred to or described herein. The terms also apply to any Slovak Design
+Center and Subdigital s.r.o. updates, supplements, Internet-based services, and
+support services for the Software, unless other terms accompany those items on
+delivery. If so, those terms apply. This EULA was created by EULA Template for
+H.U.R.B.A.N. selector.
 
 ## License Grant
 
-Slovak Design Center and Subdigital s.r.o. hereby grants you a personal, non-transferable, non-exclusive licence to use the H.U.R.B.A.N. selector software on your devices in accordance with the terms of this EULA agreement.
+Slovak Design Center and Subdigital s.r.o. hereby grants you a personal,
+non-transferable, non-exclusive licence to use the H.U.R.B.A.N. selector
+software on your devices in accordance with the terms of this EULA agreement.
 
-You are permitted to load the H.U.R.B.A.N. selector software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum requirements of the H.U.R.B.A.N. selector software.
+You are permitted to load the H.U.R.B.A.N. selector software (for example a PC,
+laptop, mobile or tablet) under your control. You are responsible for ensuring
+your device meets the minimum requirements of the H.U.R.B.A.N. selector
+software.
 
 You are not permitted to:
 
-* Edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things
-* Reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose
-* Allow any third party to use the Software on behalf of or for the benefit of any third party
-* Use the Software in any way which breaches any applicable local, national or international law
-* Use the Software for any purpose that Slovak Design Center and Subdigital s.r.o. considers is a breach of this EULA agreement
+* Reproduce, copy, distribute, resell or otherwise use the Software for any
+  commercial purpose
+* Allow any third party to use the Software on behalf of or for the benefit of
+  any third party
+* Use the Software in any way which breaches any applicable local, national or
+  international law
+* Use the Software for any purpose that Slovak Design Center and Subdigital
+  s.r.o. considers is a breach of this EULA agreement
 
 ## Intellectual Property and Ownership
 
-Slovak Design Center and Subdigital s.r.o. shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of Slovak Design Center and Subdigital s.r.o..
+Slovak Design Center and Subdigital s.r.o. shall at all times retain ownership
+of the Software as originally downloaded by you and all subsequent downloads of
+the Software by you. The Software (and the copyright, and other intellectual
+property rights of whatever nature in the Software, including any modifications
+made thereto) are and shall remain the property of Slovak Design Center and
+Subdigital s.r.o..
 
-Slovak Design Center and Subdigital s.r.o. reserves the right to grant licences to use the Software to third parties.
+Slovak Design Center and Subdigital s.r.o. reserves the right to grant licences
+to use the Software to third parties.
 
 ## Termination
 
-This EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to Slovak Design Center and Subdigital s.r.o..
+This EULA agreement is effective from the date you first use the Software and
+shall continue until terminated. You may terminate it at any time upon written
+notice to Slovak Design Center and Subdigital s.r.o..
 
-It will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.
+It will also terminate immediately if you fail to comply with any term of this
+EULA agreement. Upon such termination, the licenses granted by this EULA
+agreement will immediately terminate and you agree to stop all access and use of
+the Software. The provisions that by their nature continue and survive will
+survive any termination of this EULA agreement.
 
 ## Governing Law
 
-This EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Slovak republic.
+This EULA agreement, and any dispute arising out of or in connection with this
+EULA agreement, shall be governed by and construed in accordance with the laws
+of Slovak republic.

--- a/eula.md
+++ b/eula.md
@@ -1,0 +1,43 @@
+# End-User License Agreement (EULA) of H.U.R.B.A.N. selector
+
+This End-User License Agreement ("EULA") is a legal agreement between you and Slovak Design Center and Subdigital s.r.o.
+
+This EULA agreement governs your acquisition and use of our H.U.R.B.A.N. selector software ("Software") directly from Slovak Design Center and Subdigital s.r.o. or indirectly through a Slovak Design Center and Subdigital s.r.o. authorized reseller or distributor (a "Reseller").
+
+Please read this EULA agreement carefully before completing the installation process and using the H.U.R.B.A.N. selector software. It provides a license to use the H.U.R.B.A.N. selector software and contains warranty information and liability disclaimers.
+
+If you register for a free trial of the H.U.R.B.A.N. selector software, this EULA agreement will also govern that trial. By clicking "accept" or installing and/or using the H.U.R.B.A.N. selector software, you are confirming your acceptance of the Software and agreeing to become bound by the terms of this EULA agreement.
+
+If you are entering into this EULA agreement on behalf of a company or other legal entity, you represent that you have the authority to bind such entity and its affiliates to these terms and conditions. If you do not have such authority or if you do not agree with the terms and conditions of this EULA agreement, do not install or use the Software, and you must not accept this EULA agreement.
+
+This EULA agreement shall apply only to the Software supplied by Slovak Design Center and Subdigital s.r.o. herewith regardless of whether other software is referred to or described herein. The terms also apply to any Slovak Design Center and Subdigital s.r.o. updates, supplements, Internet-based services, and support services for the Software, unless other terms accompany those items on delivery. If so, those terms apply. This EULA was created by EULA Template for H.U.R.B.A.N. selector.
+
+## License Grant
+
+Slovak Design Center and Subdigital s.r.o. hereby grants you a personal, non-transferable, non-exclusive licence to use the H.U.R.B.A.N. selector software on your devices in accordance with the terms of this EULA agreement.
+
+You are permitted to load the H.U.R.B.A.N. selector software (for example a PC, laptop, mobile or tablet) under your control. You are responsible for ensuring your device meets the minimum requirements of the H.U.R.B.A.N. selector software.
+
+You are not permitted to:
+
+* Edit, alter, modify, adapt, translate or otherwise change the whole or any part of the Software nor permit the whole or any part of the Software to be combined with or become incorporated in any other software, nor decompile, disassemble or reverse engineer the Software or attempt to do any such things
+* Reproduce, copy, distribute, resell or otherwise use the Software for any commercial purpose
+* Allow any third party to use the Software on behalf of or for the benefit of any third party
+* Use the Software in any way which breaches any applicable local, national or international law
+* Use the Software for any purpose that Slovak Design Center and Subdigital s.r.o. considers is a breach of this EULA agreement
+
+## Intellectual Property and Ownership
+
+Slovak Design Center and Subdigital s.r.o. shall at all times retain ownership of the Software as originally downloaded by you and all subsequent downloads of the Software by you. The Software (and the copyright, and other intellectual property rights of whatever nature in the Software, including any modifications made thereto) are and shall remain the property of Slovak Design Center and Subdigital s.r.o..
+
+Slovak Design Center and Subdigital s.r.o. reserves the right to grant licences to use the Software to third parties.
+
+## Termination
+
+This EULA agreement is effective from the date you first use the Software and shall continue until terminated. You may terminate it at any time upon written notice to Slovak Design Center and Subdigital s.r.o..
+
+It will also terminate immediately if you fail to comply with any term of this EULA agreement. Upon such termination, the licenses granted by this EULA agreement will immediately terminate and you agree to stop all access and use of the Software. The provisions that by their nature continue and survive will survive any termination of this EULA agreement.
+
+## Governing Law
+
+This EULA agreement, and any dispute arising out of or in connection with this EULA agreement, shall be governed by and construed in accordance with the laws of Slovak republic.

--- a/eula.txt
+++ b/eula.txt
@@ -5,7 +5,7 @@ Slovak Design Center.
 
 This EULA agreement governs your acquisition and use of our H.U.R.B.A.N.
 selector software ("Software") directly from Slovak Design Center or indirectly
-through a Slovak Design Center. authorized reseller or distributor (a
+through a Slovak Design Center authorized reseller or distributor (a
 "Reseller").
 
 Please read this EULA agreement carefully before completing the installation
@@ -26,8 +26,8 @@ or if you do not agree with the terms and conditions of this EULA agreement, do
 not install or use the Software, and you must not accept this EULA agreement.
 
 This EULA agreement shall apply only to the Software supplied by Slovak Design
-Center. herewith regardless of whether other software is referred to or
-described herein. The terms also apply to any Slovak Design Center. updates,
+Center herewith regardless of whether other software is referred to or
+described herein. The terms also apply to any Slovak Design Center updates,
 supplements, Internet-based services, and support services for the Software,
 unless other terms accompany those items on delivery. If so, those terms apply.
 This EULA was created by EULA Template for H.U.R.B.A.N. selector.
@@ -63,7 +63,7 @@ property rights of whatever nature in the Software, including any modifications
 made thereto) are and shall remain the property of Slovak Design Center and
 Subdigital s.r.o..
 
-Slovak Design Center. reserves the right to grant licences to use the Software
+Slovak Design Center reserves the right to grant licences to use the Software
 to third parties.
 
 TERMINATION

--- a/eula.txt
+++ b/eula.txt
@@ -1,5 +1,4 @@
-End-User License Agreement (EULA) of H.U.R.B.A.N. selector
-==========================================================
+END-USER LICENSE AGREEMENT (EULA) OF H.U.R.B.A.N. SELECTOR
 
 This End-User License Agreement ("EULA") is a legal agreement between you and
 Slovak Design Center.
@@ -33,8 +32,7 @@ supplements, Internet-based services, and support services for the Software,
 unless other terms accompany those items on delivery. If so, those terms apply.
 This EULA was created by EULA Template for H.U.R.B.A.N. selector.
 
-License Grant
--------------
+LICENSE GRANT
 
 Slovak Design Center. hereby grants you a personal, non-transferable,
 non-exclusive licence to use the H.U.R.B.A.N. selector software on your devices
@@ -56,8 +54,7 @@ You are not permitted to:
 * Use the Software for any purpose that Slovak Design Center considers is a
   breach of this EULA agreement
 
-Intellectual Property and Ownership
------------------------------------
+INTELLECTUAL PROPERTY AND OWNERSHIP
 
 Slovak Design Center and Subdigital s.r.o. shall at all times retain ownership
 of the Software as originally downloaded by you and all subsequent downloads of
@@ -69,8 +66,7 @@ Subdigital s.r.o..
 Slovak Design Center. reserves the right to grant licences to use the Software
 to third parties.
 
-Termination
------------
+TERMINATION
 
 This EULA agreement is effective from the date you first use the Software and
 shall continue until terminated. You may terminate it at any time upon written
@@ -82,8 +78,7 @@ agreement will immediately terminate and you agree to stop all access and use of
 the Software. The provisions that by their nature continue and survive will
 survive any termination of this EULA agreement.
 
-Governing Law
--------------
+GOVERNING LAW
 
 This EULA agreement, and any dispute arising out of or in connection with this
 EULA agreement, shall be governed by and construed in accordance with the laws

--- a/eula.txt
+++ b/eula.txt
@@ -34,7 +34,7 @@ This EULA was created by EULA Template for H.U.R.B.A.N. selector.
 
 LICENSE GRANT
 
-Slovak Design Center. hereby grants you a personal, non-transferable,
+Slovak Design Center hereby grants you a personal, non-transferable,
 non-exclusive licence to use the H.U.R.B.A.N. selector software on your devices
 in accordance with the terms of this EULA agreement.
 

--- a/eula.txt
+++ b/eula.txt
@@ -1,12 +1,13 @@
-# End-User License Agreement (EULA) of H.U.R.B.A.N. selector
+End-User License Agreement (EULA) of H.U.R.B.A.N. selector
+==========================================================
 
 This End-User License Agreement ("EULA") is a legal agreement between you and
-Slovak Design Center and Subdigital s.r.o.
+Slovak Design Center.
 
 This EULA agreement governs your acquisition and use of our H.U.R.B.A.N.
-selector software ("Software") directly from Slovak Design Center and Subdigital
-s.r.o. or indirectly through a Slovak Design Center and Subdigital s.r.o.
-authorized reseller or distributor (a "Reseller").
+selector software ("Software") directly from Slovak Design Center or indirectly
+through a Slovak Design Center. authorized reseller or distributor (a
+"Reseller").
 
 Please read this EULA agreement carefully before completing the installation
 process and using the H.U.R.B.A.N. selector software. It provides a license to
@@ -26,18 +27,18 @@ or if you do not agree with the terms and conditions of this EULA agreement, do
 not install or use the Software, and you must not accept this EULA agreement.
 
 This EULA agreement shall apply only to the Software supplied by Slovak Design
-Center and Subdigital s.r.o. herewith regardless of whether other software is
-referred to or described herein. The terms also apply to any Slovak Design
-Center and Subdigital s.r.o. updates, supplements, Internet-based services, and
-support services for the Software, unless other terms accompany those items on
-delivery. If so, those terms apply. This EULA was created by EULA Template for
-H.U.R.B.A.N. selector.
+Center. herewith regardless of whether other software is referred to or
+described herein. The terms also apply to any Slovak Design Center. updates,
+supplements, Internet-based services, and support services for the Software,
+unless other terms accompany those items on delivery. If so, those terms apply.
+This EULA was created by EULA Template for H.U.R.B.A.N. selector.
 
-## License Grant
+License Grant
+-------------
 
-Slovak Design Center and Subdigital s.r.o. hereby grants you a personal,
-non-transferable, non-exclusive licence to use the H.U.R.B.A.N. selector
-software on your devices in accordance with the terms of this EULA agreement.
+Slovak Design Center. hereby grants you a personal, non-transferable,
+non-exclusive licence to use the H.U.R.B.A.N. selector software on your devices
+in accordance with the terms of this EULA agreement.
 
 You are permitted to load the H.U.R.B.A.N. selector software (for example a PC,
 laptop, mobile or tablet) under your control. You are responsible for ensuring
@@ -52,10 +53,11 @@ You are not permitted to:
   any third party
 * Use the Software in any way which breaches any applicable local, national or
   international law
-* Use the Software for any purpose that Slovak Design Center and Subdigital
-  s.r.o. considers is a breach of this EULA agreement
+* Use the Software for any purpose that Slovak Design Center considers is a
+  breach of this EULA agreement
 
-## Intellectual Property and Ownership
+Intellectual Property and Ownership
+-----------------------------------
 
 Slovak Design Center and Subdigital s.r.o. shall at all times retain ownership
 of the Software as originally downloaded by you and all subsequent downloads of
@@ -64,14 +66,15 @@ property rights of whatever nature in the Software, including any modifications
 made thereto) are and shall remain the property of Slovak Design Center and
 Subdigital s.r.o..
 
-Slovak Design Center and Subdigital s.r.o. reserves the right to grant licences
-to use the Software to third parties.
+Slovak Design Center. reserves the right to grant licences to use the Software
+to third parties.
 
-## Termination
+Termination
+-----------
 
 This EULA agreement is effective from the date you first use the Software and
 shall continue until terminated. You may terminate it at any time upon written
-notice to Slovak Design Center and Subdigital s.r.o..
+notice to Slovak Design Center.
 
 It will also terminate immediately if you fail to comply with any term of this
 EULA agreement. Upon such termination, the licenses granted by this EULA
@@ -79,7 +82,8 @@ agreement will immediately terminate and you agree to stop all access and use of
 the Software. The provisions that by their nature continue and survive will
 survive any termination of this EULA agreement.
 
-## Governing Law
+Governing Law
+-------------
 
 This EULA agreement, and any dispute arising out of or in connection with this
 EULA agreement, shall be governed by and construed in accordance with the laws

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -14,6 +14,7 @@ DefaultDirName={autopf}\{#AppSetupName}
 DefaultGroupName={#AppSetupName}
 OutputBaseFilename={#AppSetupName}-{#AppVersion}
 OutputDir=bin
+LicenseFile=..\eula.txt
 
 PrivilegesRequired=admin
 ArchitecturesAllowed=x64
@@ -27,6 +28,7 @@ DisableReadyMemo=no
 
 [Files]
 Source: "..\target\release\{#AppExeName}"; DestDir: "{app}"; Check: IsX64
+Source: "..\eula.txt"; DestDir: "{app}"
 
 [Icons]
 Name: "{userdesktop}\{#AppSetupName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -564,8 +564,8 @@ impl<'a> UiFrame<'a> {
                     [window_width * 0.95, window_width * 0.95 / width_logos as f32 * height_logos as f32],
                 ).build(ui);
                 ui.new_line();
-
-                ui.text(imgui::im_str!("LICENSE"));
+                
+                ui.text(imgui::im_str!("SOURCE CODE LICENSE"));
                 regular_font_token = ui.push_font(self.font_ids.regular);
                 ui.text_wrapped(imgui::im_str!(
                     "The editor source code is provided under the GNU GENERAL PUBLIC \
@@ -577,7 +577,105 @@ impl<'a> UiFrame<'a> {
                     The source code of H.U.R.B.A.N. selector written in Rust can be found on \
                     GitHub (https://github.com/subdgtl/HURBAN-Selector)."));
                     ui.new_line();
+                    regular_font_token.pop(ui);
+                ui.new_line();
+                ui.separator();
+                ui.new_line();
+                ui.text(imgui::im_str!("END-USER LICENSE AGREEMENT of H.U.R.B.A.N. selector"));
+                ui.new_line();
+                regular_font_token = ui.push_font(self.font_ids.regular);
+                ui.text_wrapped(imgui::im_str!("\
+                    This End-User License Agreement ('EULA') is a legal agreement between you \
+                    and Slovak Design Center and Subdigital s.r.o.\n\
+                    \n\
+                    This EULA agreement governs your acquisition and use of our H.U.R.B.A.N. \
+                    selector software ('Software') directly from Slovak Design Center and Subdigital \
+                    s.r.o. or indirectly through a Slovak Design Center and Subdigital s.r.o. \
+                    authorized reseller or distributor (a 'Reseller').\n\
+                    \n\
+                    Please read this EULA agreement carefully before completing the installation \
+                    process and using the H.U.R.B.A.N. selector software. It provides a license to \
+                    use the H.U.R.B.A.N. selector software and contains warranty information and \
+                    liability disclaimers.\n\
+                    \n\
+                    If you register for a free trial of the H.U.R.B.A.N. selector software, this EULA \
+                    agreement will also govern that trial. By clicking 'accept' or installing and/or \
+                    using the H.U.R.B.A.N. selector software, you are confirming your acceptance of \
+                    the Software and agreeing to become bound by the terms of this EULA agreement.\n\
+                    \n\
+                    If you are entering into this EULA agreement on behalf of a company or other legal \
+                    entity, you represent that you have the authority to bind such entity and its \
+                    affiliates to these terms and conditions. If you do not have such authority or if \
+                    you do not agree with the terms and conditions of this EULA agreement, do not \
+                    install or use the Software, and you must not accept this EULA agreement.\n\
+                    \n\
+                    This EULA agreement shall apply only to the Software supplied by Slovak Design \
+                    Center and Subdigital s.r.o. herewith regardless of whether other software is \
+                    referred to or described herein. The terms also apply to any Slovak Design Center \
+                    and Subdigital s.r.o. updates, supplements, Internet-based services, and support \
+                    services for the Software, unless other terms accompany those items on delivery. \
+                    If so, those terms apply. This EULA was created by EULA Template for H.U.R.B.A.N. \
+                    selector."));
+                ui.new_line();
+                ui.text(imgui::im_str!("LICENSE AGREEMENT"));
+                ui.new_line();
+                ui.text_wrapped(imgui::im_str!("\
+                    Slovak Design Center and Subdigital s.r.o. hereby grants you a personal, \
+                    non-transferable, non-exclusive licence to use the H.U.R.B.A.N. selector software \
+                    on your devices in accordance with the terms of this EULA agreement.\n\
+                    \n\
+                    You are permitted to load the H.U.R.B.A.N. selector software (for example a PC, \
+                    laptop, mobile or tablet) under your control. You are responsible for ensuring \
+                    your device meets the minimum requirements of the H.U.R.B.A.N. selector software.\n\
+                    \n\
+                    You are not permitted to:\n\
+                    * Edit, alter, modify, adapt, translate or otherwise change the whole or any part of \
+                    the Software nor permit the whole or any part of the Software to be combined with or \
+                    become incorporated in any other software, nor decompile, disassemble or reverse \
+                    engineer the Software or attempt to do any such things\n\
+                    * Reproduce, copy, distribute, resell or otherwise use the Software for any \
+                    commercial purpose\n\
+                    * Allow any third party to use the Software on behalf of or for the benefit of \
+                    any third party\n\
+                    * Use the Software in any way which breaches any applicable local, national or \
+                    international law\n\
+                    * Use the Software for any purpose that Slovak Design Center and Subdigital s.r.o. \
+                    considers is a breach of this EULA agreement"));
+                ui.new_line();
+                ui.text(imgui::im_str!("INTELLECTUAL PROPERTY AND OWNERSHIP"));
+                ui.new_line();
+                ui.text_wrapped(imgui::im_str!("\
+                    Slovak Design Center and Subdigital s.r.o. shall at all times retain ownership of \
+                    the Software as originally downloaded by you and all subsequent downloads of the \
+                    Software by you. The Software (and the copyright, and other intellectual property \
+                    rights of whatever nature in the Software, including any modifications made thereto) \
+                    are and shall remain the property of Slovak Design Center and Subdigital s.r.o..\n\
+                    \n\
+                    Slovak Design Center and Subdigital s.r.o. reserves the right to grant licences to \
+                    use the Software to third parties."));
+                ui.new_line();
+                ui.text(imgui::im_str!("TERMINATION"));
+                ui.new_line();
+                ui.text_wrapped(imgui::im_str!("\
+                    This EULA agreement is effective from the date you first use the Software and shall \
+                    continue until terminated. You may terminate it at any time upon written notice to \
+                    Slovak Design Center and Subdigital s.r.o..\n\
+                    \n\
+                    It will also terminate immediately if you fail to comply with any term of this EULA \
+                    agreement. Upon such termination, the licenses granted by this EULA agreement will \
+                    immediately terminate and you agree to stop all access and use of the Software. \
+                    The provisions that by their nature continue and survive will survive any termination \
+                    of this EULA agreement."));
+                ui.new_line();
+                ui.text(imgui::im_str!("GOVERNING LAW"));
+                ui.new_line();
+                ui.text_wrapped(imgui::im_str!("\
+                    This EULA agreement, and any dispute arising out of or in connection with this EULA \
+                    agreement, shall be governed by and construed in accordance with the laws of \
+                    Slovak republic."));
                 regular_font_token.pop(ui);
+
+
                 wrap_token.pop(ui);
             });
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -564,7 +564,7 @@ impl<'a> UiFrame<'a> {
                     [window_width * 0.95, window_width * 0.95 / width_logos as f32 * height_logos as f32],
                 ).build(ui);
                 ui.new_line();
-                
+
                 ui.text(imgui::im_str!("SOURCE CODE LICENSE"));
                 regular_font_token = ui.push_font(self.font_ids.regular);
                 ui.text_wrapped(imgui::im_str!(
@@ -576,8 +576,8 @@ impl<'a> UiFrame<'a> {
                     \n\
                     The source code of H.U.R.B.A.N. selector written in Rust can be found on \
                     GitHub (https://github.com/subdgtl/HURBAN-Selector)."));
-                    ui.new_line();
-                    regular_font_token.pop(ui);
+                ui.new_line();
+                regular_font_token.pop(ui);
                 ui.new_line();
                 ui.separator();
                 ui.new_line();
@@ -674,8 +674,6 @@ impl<'a> UiFrame<'a> {
                     agreement, shall be governed by and construed in accordance with the laws of \
                     Slovak republic."));
                 regular_font_token.pop(ui);
-
-
                 wrap_token.pop(ui);
             });
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -586,11 +586,11 @@ impl<'a> UiFrame<'a> {
                 regular_font_token = ui.push_font(self.font_ids.regular);
                 ui.text_wrapped(imgui::im_str!("\
                     This End-User License Agreement ('EULA') is a legal agreement between you \
-                    and Slovak Design Center and Subdigital s.r.o.\n\
+                    and Slovak Design Center\n\
                     \n\
                     This EULA agreement governs your acquisition and use of our H.U.R.B.A.N. \
-                    selector software ('Software') directly from Slovak Design Center and Subdigital \
-                    s.r.o. or indirectly through a Slovak Design Center and Subdigital s.r.o. \
+                    selector software ('Software') directly from Slovak Design Center \
+                    or indirectly through a Slovak Design Center \
                     authorized reseller or distributor (a 'Reseller').\n\
                     \n\
                     Please read this EULA agreement carefully before completing the installation \
@@ -610,9 +610,9 @@ impl<'a> UiFrame<'a> {
                     install or use the Software, and you must not accept this EULA agreement.\n\
                     \n\
                     This EULA agreement shall apply only to the Software supplied by Slovak Design \
-                    Center and Subdigital s.r.o. herewith regardless of whether other software is \
+                    Center herewith regardless of whether other software is \
                     referred to or described herein. The terms also apply to any Slovak Design Center \
-                    and Subdigital s.r.o. updates, supplements, Internet-based services, and support \
+                    updates, supplements, Internet-based services, and support \
                     services for the Software, unless other terms accompany those items on delivery. \
                     If so, those terms apply. This EULA was created by EULA Template for H.U.R.B.A.N. \
                     selector."));
@@ -620,7 +620,7 @@ impl<'a> UiFrame<'a> {
                 ui.text(imgui::im_str!("LICENSE AGREEMENT"));
                 ui.new_line();
                 ui.text_wrapped(imgui::im_str!("\
-                    Slovak Design Center and Subdigital s.r.o. hereby grants you a personal, \
+                    Slovak Design Center hereby grants you a personal, \
                     non-transferable, non-exclusive licence to use the H.U.R.B.A.N. selector software \
                     on your devices in accordance with the terms of this EULA agreement.\n\
                     \n\
@@ -635,7 +635,7 @@ impl<'a> UiFrame<'a> {
                     any third party\n\
                     * Use the Software in any way which breaches any applicable local, national or \
                     international law\n\
-                    * Use the Software for any purpose that Slovak Design Center and Subdigital s.r.o. \
+                    * Use the Software for any purpose that Slovak Design Center \
                     considers is a breach of this EULA agreement"));
                 ui.new_line();
                 ui.text(imgui::im_str!("INTELLECTUAL PROPERTY AND OWNERSHIP"));
@@ -647,7 +647,7 @@ impl<'a> UiFrame<'a> {
                     rights of whatever nature in the Software, including any modifications made thereto) \
                     are and shall remain the property of Slovak Design Center and Subdigital s.r.o..\n\
                     \n\
-                    Slovak Design Center and Subdigital s.r.o. reserves the right to grant licences to \
+                    Slovak Design Center reserves the right to grant licences to \
                     use the Software to third parties."));
                 ui.new_line();
                 ui.text(imgui::im_str!("TERMINATION"));
@@ -655,7 +655,7 @@ impl<'a> UiFrame<'a> {
                 ui.text_wrapped(imgui::im_str!("\
                     This EULA agreement is effective from the date you first use the Software and shall \
                     continue until terminated. You may terminate it at any time upon written notice to \
-                    Slovak Design Center and Subdigital s.r.o..\n\
+                    Slovak Design Center.\n\
                     \n\
                     It will also terminate immediately if you fail to comply with any term of this EULA \
                     agreement. Upon such termination, the licenses granted by this EULA agreement will \

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -629,10 +629,6 @@ impl<'a> UiFrame<'a> {
                     your device meets the minimum requirements of the H.U.R.B.A.N. selector software.\n\
                     \n\
                     You are not permitted to:\n\
-                    * Edit, alter, modify, adapt, translate or otherwise change the whole or any part of \
-                    the Software nor permit the whole or any part of the Software to be combined with or \
-                    become incorporated in any other software, nor decompile, disassemble or reverse \
-                    engineer the Software or attempt to do any such things\n\
                     * Reproduce, copy, distribute, resell or otherwise use the Software for any \
                     commercial purpose\n\
                     * Allow any third party to use the Software on behalf of or for the benefit of \


### PR DESCRIPTION
I've found a template for an EULA. Please, have a look and give your feedback.

The EULA is now in two places - as a part of the **About** window inside the software and as a **separate file** ~`license.md`~ `eula.md`. I'm not sure if the `.md` format is usual an suitable. We should investigate a bit to find the most suitable option for distributing the license agreement.

My findings from free software so far:

- **Blender**: a `copyright.txt` file in the Blender root folder. It seems to be a derivative of a GNU GPL license. There are also many other `.txt` files with licenses for partial things, such as libraries and fonts
- **FileZilla**: a `GPL.html` file in the program's root folder
- **Firefox**: no apparent license file in program's root and subfolders
- **Adobe Reader DC**: a `ReadMe.htm` file in program's root - it's a combination of readme and a brief license (single page, no scrolling needed)
- **VLC**: a `COPYING.txt` file in program's root folder with GNU GPL inside. Many other files, such as `AUTHORS.txt` or `THANKS.txt`

Aside from polishing the license itself (or simply choosing GNU GPL just like anybody else), I would like us (and by "us" I mean @ondrowan ) to implement this:

- [x] Display the license agreement during the installation process
- [x] Save the license file next to the executable binary during the installation