### PR TITLE
Implement streaming obj serialization

### DIFF
--- a/src/exporter.rs
+++ b/src/exporter.rs
@@ -1,0 +1,184 @@
+use std::borrow::Borrow;
+use std::convert::TryFrom;
+use std::io::{self, Write};
+
+use crate::convert::cast_u32;
+use crate::mesh::{Face, Mesh};
+
+// FIXME: Mesh arrays are currently exported as objects (o). Export them as
+// groups (g).
+
+/// Write mesh models serialized in OBJ format to provided output writer.
+///
+/// Flushes `writer` at least once - after all data has been written. Formats
+/// each floating point number `decimal_precision` digits.
+pub fn export_obj<'a, I, N, W>(
+    writer: &mut W,
+    models: I,
+    decimal_precision: u32,
+) -> Result<(), io::Error>
+where
+    I: IntoIterator<Item = (N, &'a Mesh)>,
+    N: Borrow<str>,
+    W: Write,
+{
+    // usize to u32 conversion can fail on 16-bit systems, in which case we'll
+    // use the max value of usize. This probably won't ever happen.
+    let decimal_precision = usize::try_from(decimal_precision).unwrap_or(usize::max_value());
+
+    // OBJ indices are global, meaning a face from object "o2" can reference a
+    // vertex from "o1". We maintain proper namespacing between the exported
+    // objects by tracking the index offsets for data we export (vertices and
+    // normals). Offsets start with 1, because OBJ indices do.
+    let mut vertex_index_offset = 1;
+    let mut normal_index_offset = 1;
+
+    writeln!(writer, "# Exported by H.U.R.B.A.N selector")?;
+    writeln!(writer)?;
+
+    for (name, mesh) in models {
+        writeln!(writer, "o {}", name.borrow())?;
+        writeln!(writer)?;
+
+        for vertex in mesh.vertices() {
+            writeln!(
+                writer,
+                "v {1:.0$} {2:.0$} {3:.0$}",
+                decimal_precision, vertex.x, vertex.y, vertex.z,
+            )?;
+        }
+        writeln!(writer)?;
+
+        for normal in mesh.normals() {
+            writeln!(
+                writer,
+                "vn {1:.0$} {2:.0$} {3:.0$}",
+                decimal_precision, normal.x, normal.y, normal.z,
+            )?;
+        }
+        writeln!(writer)?;
+
+        for face in mesh.faces() {
+            let Face::Triangle(triangle_face) = face;
+            let vertices = triangle_face.vertices;
+            let normals = triangle_face.normals;
+
+            writeln!(
+                writer,
+                "f {1:.0$}//{4:.0$} {2:.0$}//{5:.0$} {3:.0$}//{6:.0$}",
+                decimal_precision,
+                vertices.0 + vertex_index_offset,
+                vertices.1 + vertex_index_offset,
+                vertices.2 + vertex_index_offset,
+                normals.0 + normal_index_offset,
+                normals.1 + normal_index_offset,
+                normals.2 + normal_index_offset,
+            )?;
+        }
+        writeln!(writer)?;
+
+        vertex_index_offset += cast_u32(mesh.vertices().len());
+        normal_index_offset += cast_u32(mesh.normals().len());
+    }
+
+    writer.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use nalgebra::{Point3, Vector3};
+
+    use crate::mesh::TriangleFace;
+
+    use super::*;
+
+    #[test]
+    fn test_export_obj_simple() {
+        let name = "Our Test-model__";
+        let mesh = Mesh::from_triangle_faces_with_vertices_and_normals(
+            [TriangleFace::new(0, 1, 2, 0, 0, 0)].iter().copied(),
+            [
+                Point3::new(-0.3, -0.3, 0.0),
+                Point3::new(0.3, -0.3, 0.0),
+                Point3::new(0.0, 0.4, 0.0),
+            ]
+            .iter()
+            .copied(),
+            [Vector3::new(0.0, 0.0, 1.0)].iter().copied(),
+        );
+
+        let expected_output: &[u8] = b"\
+            # Exported by H.U.R.B.A.N selector\n\
+            \n\
+            o Our Test-model__\n\
+            \n\
+            v -0.30000 -0.30000 0.00000\n\
+            v 0.30000 -0.30000 0.00000\n\
+            v 0.00000 0.40000 0.00000\n\
+            \n\
+            vn 0.00000 0.00000 1.00000\n\
+            \n\
+            f 1//1 2//1 3//1\n\
+            \n";
+
+        let mut output = Vec::new();
+        export_obj(&mut output, iter::once((name, &mesh)), 5).unwrap();
+
+        assert_eq!(output, Vec::from(expected_output));
+    }
+
+    #[test]
+    fn test_export_obj_index_namespacing() {
+        let name1 = "Our Test-model__";
+        let mesh1 = Mesh::from_triangle_faces_with_vertices_and_normals(
+            [TriangleFace::new(0, 1, 2, 0, 0, 0)].iter().copied(),
+            [
+                Point3::new(-0.3, -0.3, 0.0),
+                Point3::new(0.3, -0.3, 0.0),
+                Point3::new(0.0, 0.4, 0.0),
+            ]
+            .iter()
+            .copied(),
+            [Vector3::new(0.0, 0.0, 1.0)].iter().copied(),
+        );
+
+        let name2 = "Another model";
+        let mesh2 = mesh1.clone();
+
+        let expected_output: &[u8] = b"\
+            # Exported by H.U.R.B.A.N selector\n\
+            \n\
+            o Our Test-model__\n\
+            \n\
+            v -0.30000 -0.30000 0.00000\n\
+            v 0.30000 -0.30000 0.00000\n\
+            v 0.00000 0.40000 0.00000\n\
+            \n\
+            vn 0.00000 0.00000 1.00000\n\
+            \n\
+            f 1//1 2//1 3//1\n\
+            \n\
+            o Another model\n\
+            \n\
+            v -0.30000 -0.30000 0.00000\n\
+            v 0.30000 -0.30000 0.00000\n\
+            v 0.00000 0.40000 0.00000\n\
+            \n\
+            vn 0.00000 0.00000 1.00000\n\
+            \n\
+            f 4//2 5//2 6//2\n\
+            \n";
+
+        let mut output = Vec::new();
+        export_obj(
+            &mut output,
+            [(name1, &mesh1), (name2, &mesh2)].iter().copied(),
+            5,
+        )
+        .unwrap();
+
+        assert_eq!(output, Vec::from(expected_output));
+    }
+}

--- a/src/interpreter/ast.rs
+++ b/src/interpreter/ast.rs
@@ -1,9 +1,16 @@
 use std::fmt;
 
+// Note that by deriving serde::Serialize and serde::Deserialize on FuncIdent
+// and VarIdent, we accidentally stabilized their internal representation even
+// if it is `pub(crate)`. We therefore document that no assumptions must be made
+// about those 64 bits, so that we can change the way we generate those
+// identifiers later.
+
 /// A unique function identifier.
 ///
-/// Has to stay stable for the lifetime of the interpreter and program
-/// using it.
+/// Has to stay stable for the lifetime of the interpreter and program using
+/// it. Internally has 64-bits of precision, but no assumptions must be made
+/// about the meaning of those bits.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
@@ -17,8 +24,9 @@ impl fmt::Display for FuncIdent {
 
 /// A unique variable identifier.
 ///
-/// Has to stay stable for the lifetime of the interpreter and program
-/// using it.
+/// Has to stay stable for the lifetime of the interpreter and program using
+/// it. Internally has 64-bits of precision, but no assumptions must be made
+/// about the meaning of those bits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct VarIdent(pub(crate) u64);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,7 @@ pub fn init_and_run(options: Options) -> ! {
                     &mut viewport_draw_mode,
                     &mut viewport_draw_used_values,
                     &mut project_status,
+                    &mut session,
                     &mut notifications.borrow_mut(),
                 );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -601,7 +601,7 @@ pub fn init_and_run(options: Options) -> ! {
 
                 if menu_status.export_obj {
                     if let Some(path) = tinyfiledialogs::save_file_dialog_with_filter(
-                        "Save",
+                        "Export OBJ",
                         "export.obj",
                         &["*.obj"],
                         "Wavefront (.obj)",

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -352,10 +352,6 @@ impl Mesh {
         &self.vertices
     }
 
-    pub fn vertices_mut(&mut self) -> &mut [Point3<f32>] {
-        &mut self.vertices
-    }
-
     pub fn normals(&self) -> &[Vector3<f32>] {
         &self.normals
     }

--- a/src/project.rs
+++ b/src/project.rs
@@ -25,7 +25,7 @@ pub enum NextAction {
 
 #[derive(Debug, Default)]
 pub struct ProjectStatus {
-    pub path: Option<String>,
+    pub path: Option<PathBuf>,
     pub error: Option<ProjectError>,
     pub new_requested: bool,
     pub open_requested: bool,
@@ -34,8 +34,8 @@ pub struct ProjectStatus {
 }
 
 impl ProjectStatus {
-    pub fn save(&mut self, path: &str) {
-        self.path = Some(path.to_string());
+    pub fn save<P: AsRef<Path>>(&mut self, path: P) {
+        self.path = Some(path.as_ref().to_path_buf());
         self.changed_since_last_save = false;
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -12,6 +12,7 @@ use crate::interpreter::ast;
 
 pub const DEFAULT_NEW_FILENAME: &str = "new_project.hurban";
 
+pub const EXTENSION: &str = "hurban";
 pub const EXTENSION_DESCRIPTION: &str = "HURBAN selector project (.hurban)";
 pub const EXTENSION_FILTER: &[&str] = &["*.hurban"];
 
@@ -116,12 +117,12 @@ pub fn save<P: AsRef<Path>>(path: P, project: Project) -> Result<PathBuf, Projec
         Some(extension) => {
             let extension = extension.to_string_lossy().into_owned();
 
-            if extension != PROJECT_EXTENSION {
-                path_buf.set_extension(format!("{}.{}", extension, PROJECT_EXTENSION));
+            if extension != EXTENSION {
+                path_buf.set_extension(format!("{}.{}", extension, EXTENSION));
             }
         }
         None => {
-            path_buf.set_extension(PROJECT_EXTENSION);
+            path_buf.set_extension(EXTENSION);
         }
     }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -10,7 +10,10 @@ use serde::Serialize;
 
 use crate::interpreter::ast;
 
-pub const PROJECT_EXTENSION: &str = "hurban";
+pub const DEFAULT_NEW_FILENAME: &str = "new_project.hurban";
+
+pub const EXTENSION_DESCRIPTION: &str = "HURBAN selector project (.hurban)";
+pub const EXTENSION_FILTER: &[&str] = &["*.hurban"];
 
 #[derive(Debug, Clone, Copy)]
 pub enum NextAction {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1061,8 +1061,10 @@ impl<'a> UiFrame<'a> {
                     });
                 }
 
-                let export_obj_disabled = !session.synced();
-                let export_obj_button_tokens = if export_obj_disabled {
+                let export_obj_disabled_unsynced = !session.synced();
+                let export_obj_disabled_empty = session.stmts().is_empty();
+                let export_obj_disabled = export_obj_disabled_unsynced || export_obj_disabled_empty;
+                let export_obj_button_tokens = if export_obj_disabled  {
                     Some(push_disabled_style(ui))
                 } else {
                     None
@@ -1081,10 +1083,17 @@ impl<'a> UiFrame<'a> {
                         ui.text_colored(self.colors.tooltip_text, "EXPORT OBJ\n\
                         \n\
                         Opens a system dialog for exporting all unused geometry into an OBJ file.");
-                        if export_obj_disabled {
+                        if export_obj_disabled_unsynced {
                             ui.text_colored(
                                 self.colors.log_message_warn,
                                 "WARNING: All operations must be executed before exporting.",
+                            );
+                        }
+                        if export_obj_disabled_empty {
+                            ui.text_colored(
+                                self.colors.log_message_warn,
+                                "WARNING: Can not export empty scene.\n\
+                                 Try adding operations to the pipeline and executing first.",
                             );
                         }
                         wrap_token.pop(ui);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -27,7 +27,7 @@ const PIPELINE_WINDOW_HEIGHT_MULT: f32 = 1.0 - OPERATIONS_WINDOW_HEIGHT_MULT;
 const PIPELINE_OPERATION_CONSOLE_HEIGHT: f32 = 40.0;
 
 const MENU_WINDOW_WIDTH: f32 = 160.0;
-const MENU_WINDOW_HEIGHT: f32 = 298.0;
+const MENU_WINDOW_HEIGHT: f32 = 321.0;
 
 const NOTIFICATIONS_WINDOW_WIDTH: f32 = 600.0;
 const NOTIFICATIONS_WINDOW_HEIGHT_MULT: f32 = 0.1;
@@ -893,7 +893,7 @@ impl<'a> UiFrame<'a> {
                 }
 
                 status.reset_viewport =
-                    ui.button(imgui::im_str!("Reset Viewport"), [-f32::MIN_POSITIVE, 0.0]);
+                    ui.button(imgui::im_str!("Reset viewport"), [-f32::MIN_POSITIVE, 0.0]);
                 if status.reset_viewport {
                     notifications.push(
                         current_time,
@@ -907,33 +907,6 @@ impl<'a> UiFrame<'a> {
                         ui.text_colored(self.colors.tooltip_text, "RESET VIEWPORT CAMERA\n\
                         \n\
                         Set the viewport camera to look at all visible geometry in the scene.");
-                        wrap_token.pop(ui);
-                    });
-                }
-
-                if ui.button(imgui::im_str!("Save Screenshot"), [-f32::MIN_POSITIVE, 0.0]) {
-                    *screenshot_modal_open = true;
-                }
-                if ui.is_item_hovered() {
-                    ui.tooltip(|| {
-                        let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
-                        ui.text_colored(self.colors.tooltip_text, "SAVE SCREENSHOT\n\
-                        \n\
-                        Opens a system dialog for saving the current viewport into a PNG file.");
-                        wrap_token.pop(ui);
-                    });
-                }
-
-                status.export_obj = ui.button(
-                    imgui::im_str!("Export OBJ"),
-                    [-f32::MIN_POSITIVE, 0.0],
-                );
-                if ui.is_item_hovered() {
-                    ui.tooltip(|| {
-                        let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
-                        ui.text_colored(self.colors.tooltip_text, "EXPORT OBJ\n\
-                        \n\
-                        Opens a system dialog for exporting all unused geometry into an OBJ file.");
                         wrap_token.pop(ui);
                     });
                 }
@@ -966,6 +939,45 @@ impl<'a> UiFrame<'a> {
                         wrap_token.pop(ui);
                     });
                 }
+
+                                if ui.button(imgui::im_str!("Open"), [-f32::MIN_POSITIVE, 0.0])
+                    || project_status.open_requested
+                {
+                    // FIXME: @Refactoring Factor out this use of
+                    // tinyfiledialogs from this module
+                    if project_status.changed_since_last_save
+                        && project_status.prevent_overwrite_status.is_none()
+                    {
+                        status.prevent_overwrite_modal = Some(OverwriteModalTrigger::OpenProject);
+                    } else if let Some(path) = tinyfiledialogs::open_file_dialog(
+                        "Open",
+                        "",
+                        Some((project::EXTENSION_FILTER, project::EXTENSION_DESCRIPTION)),
+                    ) {
+                        status.open_path = Some(path);
+                    }
+
+                    project_status.prevent_overwrite_status = None;
+                    project_status.open_requested = false;
+                }
+
+                if ui.is_item_hovered() {
+                    ui.tooltip(|| {
+                        let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
+                        ui.text_colored(self.colors.tooltip_text, "OPEN PROJECT FROM A .hurban FILE\n\
+                        \n\
+                        Opens the sequence of operations saved in a .hurban file.\n\
+                        \n\
+                        The .hurban project file contains only the operation pipeline. It does not contain any \
+                        actual geometry, but rather just the sequence of operations that generates the geometry \
+                        and references to the external files to import. \
+                        It is advised to keep the files to import next to the .hurban project file \
+                        and distribute them together.");
+                        wrap_token.pop(ui);
+                    });
+                }
+
+                ui.separator();
 
                 if ui.button(imgui::im_str!("Save"), [-f32::MIN_POSITIVE, 0.0]) {
                     match &project_status.path {
@@ -1034,39 +1046,29 @@ impl<'a> UiFrame<'a> {
                     });
                 }
 
-                if ui.button(imgui::im_str!("Open"), [-f32::MIN_POSITIVE, 0.0])
-                    || project_status.open_requested
-                {
-                    // FIXME: @Refactoring Factor out this use of
-                    // tinyfiledialogs from this module
-                    if project_status.changed_since_last_save
-                        && project_status.prevent_overwrite_status.is_none()
-                    {
-                        status.prevent_overwrite_modal = Some(OverwriteModalTrigger::OpenProject);
-                    } else if let Some(path) = tinyfiledialogs::open_file_dialog(
-                        "Open",
-                        "",
-                        Some((project::EXTENSION_FILTER, project::EXTENSION_DESCRIPTION)),
-                    ) {
-                        status.open_path = Some(path);
-                    }
-
-                    project_status.prevent_overwrite_status = None;
-                    project_status.open_requested = false;
+                if ui.button(imgui::im_str!("Save screenshot..."), [-f32::MIN_POSITIVE, 0.0]) {
+                    *screenshot_modal_open = true;
                 }
-
                 if ui.is_item_hovered() {
                     ui.tooltip(|| {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
-                        ui.text_colored(self.colors.tooltip_text, "OPEN PROJECT FROM A .hurban FILE\n\
+                        ui.text_colored(self.colors.tooltip_text, "SAVE SCREENSHOT\n\
                         \n\
-                        Opens the sequence of operations saved in a .hurban file.\n\
+                        Opens a system dialog for saving the current viewport into a PNG file.");
+                        wrap_token.pop(ui);
+                    });
+                }
+
+                status.export_obj = ui.button(
+                    imgui::im_str!("Export OBJ..."),
+                    [-f32::MIN_POSITIVE, 0.0],
+                );
+                if ui.is_item_hovered() {
+                    ui.tooltip(|| {
+                        let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
+                        ui.text_colored(self.colors.tooltip_text, "EXPORT OBJ\n\
                         \n\
-                        The .hurban project file contains only the operation pipeline. It does not contain any \
-                        actual geometry, but rather just the sequence of operations that generates the geometry \
-                        and references to the external files to import. \
-                        It is advised to keep the files to import next to the .hurban project file \
-                        and distribute them together.");
+                        Opens a system dialog for exporting all unused geometry into an OBJ file.");
                         wrap_token.pop(ui);
                     });
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -724,6 +724,7 @@ impl<'a> UiFrame<'a> {
         viewport_draw_mode: &mut ViewportDrawMode,
         viewport_draw_used_values: &mut bool,
         project_status: &mut project::ProjectStatus,
+        session: &mut Session,
         notifications: &mut Notifications,
     ) -> MenuStatus {
         let ui = &self.imgui_ui;
@@ -1060,16 +1061,32 @@ impl<'a> UiFrame<'a> {
                     });
                 }
 
+                let export_obj_disabled = !session.synced();
+                let export_obj_button_tokens = if export_obj_disabled {
+                    Some(push_disabled_style(ui))
+                } else {
+                    None
+                };
                 status.export_obj = ui.button(
                     imgui::im_str!("Export OBJ..."),
                     [-f32::MIN_POSITIVE, 0.0],
                 );
+                if let Some((color_token, style_token)) = export_obj_button_tokens {
+                    color_token.pop(ui);
+                    style_token.pop(ui);
+                }
                 if ui.is_item_hovered() {
                     ui.tooltip(|| {
                         let wrap_token = ui.push_text_wrap_pos(WRAP_POS_TOOLTIP_TEXT_PIXELS);
                         ui.text_colored(self.colors.tooltip_text, "EXPORT OBJ\n\
                         \n\
                         Opens a system dialog for exporting all unused geometry into an OBJ file.");
+                        if export_obj_disabled {
+                            ui.text_colored(
+                                self.colors.log_message_warn,
+                                "WARNING: All operations must be executed before exporting.",
+                            );
+                        }
                         wrap_token.pop(ui);
                     });
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1069,7 +1069,7 @@ impl<'a> UiFrame<'a> {
                 } else {
                     None
                 };
-                status.export_obj = ui.button(
+                let export_obj = ui.button(
                     imgui::im_str!("Export OBJ..."),
                     [-f32::MIN_POSITIVE, 0.0],
                 );
@@ -1099,6 +1099,8 @@ impl<'a> UiFrame<'a> {
                         wrap_token.pop(ui);
                     });
                 }
+
+                status.export_obj = !export_obj_disabled && export_obj;
 
                 ui.separator();
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::f32;
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use crate::convert::{
@@ -112,8 +113,8 @@ pub struct MenuStatus {
     pub reset_viewport: bool,
     pub export_obj: bool,
     pub new_project: bool,
-    pub save_path: Option<String>,
-    pub open_path: Option<String>,
+    pub save_path: Option<PathBuf>,
+    pub open_path: Option<PathBuf>,
     pub prevent_overwrite_modal: Option<OverwriteModalTrigger>,
 }
 
@@ -954,7 +955,7 @@ impl<'a> UiFrame<'a> {
                         "",
                         Some((project::EXTENSION_FILTER, project::EXTENSION_DESCRIPTION)),
                     ) {
-                        status.open_path = Some(path);
+                        status.open_path = Some(PathBuf::from(path));
                     }
 
                     project_status.prevent_overwrite_status = None;
@@ -981,8 +982,8 @@ impl<'a> UiFrame<'a> {
 
                 if ui.button(imgui::im_str!("Save"), [-f32::MIN_POSITIVE, 0.0]) {
                     match &project_status.path {
-                        Some(project_path_str) => {
-                            status.save_path = Some(project_path_str.to_string())
+                        Some(project_path) => {
+                            status.save_path = Some(project_path.clone())
                         }
                         None => {
                             // FIXME: @Refactoring Factor out this use of
@@ -993,7 +994,7 @@ impl<'a> UiFrame<'a> {
                                 project::EXTENSION_FILTER,
                                 project::EXTENSION_DESCRIPTION,
                             ) {
-                                status.save_path = Some(path);
+                                status.save_path = Some(PathBuf::from(path));
                             }
                         }
                     }
@@ -1025,7 +1026,7 @@ impl<'a> UiFrame<'a> {
                         project::EXTENSION_FILTER,
                         project::EXTENSION_DESCRIPTION,
                     ) {
-                        status.save_path = Some(path);
+                        status.save_path = Some(PathBuf::from(path));
                     }
                 }
 


### PR DESCRIPTION
This implements streaming OBJ serialization into a
`std::io::Writer`. Functionality is triggered by a main menu "Export OBJ"
button. Only unused geometries are exported. For each mesh or element of
mesh-array, a new "o" tag is created in the resulting OBJ file. The object name
is the same as the `return_value_name` that would be displayed in the pipeline
window in most cases. For some edge cases however, only the raw stringified var
ident is outputted. If the exported mesh is a mesh-array element and it's index
is not zero, it is part of the name written after the "o" tag.

The commit also does a bit of minor cleanup elsewhere:

- Ensures the session never generates the same variable identifier
  twice (related to being confident that if a var name is present in the
  session, it does not reference a previously removed variable declaration),
- Removes some per-frame uses of the format! macro from `ui.rs`,
- Inlines one simple call to tinyfiledialogs from `ui.rs` to `lib.rs`.