### PR TITLE
Review analysis performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "imgui 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ crc32fast = "1.2.0"
 crossbeam-channel = "0.3.9"
 dirs = "2.0.2"
 fern = { version = "0.5.8", features = ["colored"] }
+fxhash = "0.2.1"
 image = "0.22.4"
 imgui = "0.2.1"
 log = { version = "0.4.8" }

--- a/src/mesh/analysis.rs
+++ b/src/mesh/analysis.rs
@@ -196,9 +196,9 @@ pub fn border_vertex_indices(edge_sharing: &EdgeSharingMap) -> HashSet<u32> {
 /// Finds continuous loops of border edges, starting from a random edge.
 ///
 /// The mesh may contain holes or islands, therefore it may have an unknown
-/// number of edge loops. If only two edge loops meet at a single vertex
-/// (e.g. if the mesh is non-manifold), this border edge chain is not included
-/// in the result.
+/// number of edge loops. If two or more edge loops meet at a single vertex, it
+/// is undefined whether they end up in the result as separate border edge
+/// loops, or are joined into a single border edge loop.
 pub fn border_edge_loops(edge_sharing: &EdgeSharingMap) -> Vec<Vec<OrientedEdge>> {
     let mut border_edges: Vec<_> = border_edges(edge_sharing).collect();
     let mut edge_loops: Vec<Vec<OrientedEdge>> = Vec::new();

--- a/src/mesh/analysis.rs
+++ b/src/mesh/analysis.rs
@@ -135,7 +135,6 @@ fn find_edges_with_valency<'a>(
     edge_sharing: &'a EdgeSharingMap,
     valency: usize,
 ) -> impl Iterator<Item = OrientedEdge> + 'a {
-    // TODO(yanchith): Look at whether this really needs to return the iterator.
     edge_sharing
         .values()
         .filter(move |shared_edges| {

--- a/src/mesh/analysis.rs
+++ b/src/mesh/analysis.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use nalgebra as na;
 use nalgebra::Point3;
@@ -84,7 +84,7 @@ impl Iterator for SharedEdgesOrientedEdgeIter {
     }
 }
 
-pub type EdgeSharingMap = HashMap<UnorientedEdge, SharedEdges>;
+pub type EdgeSharingMap = fxhash::FxHashMap<UnorientedEdge, SharedEdges>;
 
 // FIXME: Implement edge_sharing also for UnorientedEdges?
 
@@ -101,7 +101,7 @@ pub type EdgeSharingMap = HashMap<UnorientedEdge, SharedEdges>;
 pub fn edge_sharing<'a, I: IntoIterator<Item = &'a OrientedEdge>>(
     oriented_edges: I,
 ) -> EdgeSharingMap {
-    let mut edge_sharing_map: EdgeSharingMap = HashMap::new();
+    let mut edge_sharing_map = fxhash::FxHashMap::default();
     for edge in oriented_edges {
         let unoriented_edge = UnorientedEdge(*edge);
 

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -632,6 +632,14 @@ impl OrientedEdge {
         self.vertices.0 == vertex_index || self.vertices.1 == vertex_index
     }
 
+    pub fn shares_vertex(self, other: OrientedEdge) -> bool {
+        other.contains_vertex(self.vertices.0) || other.contains_vertex(self.vertices.1)
+    }
+
+    pub fn chains_to(self, other: OrientedEdge) -> bool {
+        self.vertices.1 == other.vertices.0
+    }
+
     pub fn to_reverted(self) -> Self {
         OrientedEdge::new(self.vertices.1, self.vertices.0)
     }


### PR DESCRIPTION
This PR achieves two things:

- First two commits optimize function `edge_sharing`, making it about 2.5x faster in wall time.
- Third commit refactors function `border_edge_loops` and fixes a bug that caused it to loop infinitely for some meshes.

Can be reviewed commit by commit, to see the changes applied one by one.
