### PR TITLE
Filter out empty models when importing obj file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
  "shaderc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 3.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tobj 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tobj 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "tobj"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2294,7 +2294,7 @@ dependencies = [
 "checksum tiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b7c2cfc4742bd8a32f2e614339dd8ce30dbcf676bb262bd63a2327bc5df57d"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinyfiledialogs 3.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aea8c7254421cef8ef896c9a4ef16d5047fbfdb72c733f7942389abed54a7d48"
-"checksum tobj 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "a3608198b5c2a119a5f05ae5d58a4b0f77ec5687a698efe574d95939605993cd"
+"checksum tobj 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b9d0bafde95a2f8f50dd3c10bc127b462efa8c3c0b60dfa276b7e032100e21d"
 "checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ ron = "0.5.1"
 serde = { version = "1.0.102", features = ["derive"] }
 smallvec = "0.6.10"
 tinyfiledialogs = "3.3.5"
-tobj = { version = "0.1.10", features = ["log"] }
+tobj = { version = "1.0", features = ["log"] }
 wgpu = { version = "0.4.0", features = ["vulkan"] }
 winit = "0.22.0"
 

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -13,12 +13,9 @@ use tobj;
 
 use crate::mesh::{Mesh, NormalStrategy, TriangleFace};
 
-// FIXME: ParsingError always comes from tobj. It could contain its LoadError,
-// for more granular error messages, but since it doesn't implement PartialEq,
-// we cannot use it for now.
 #[derive(Debug, PartialEq)]
 pub enum InvalidStructureError {
-    ParsingError,
+    ParsingError(tobj::LoadError),
     DuplicateIndices,
     BlankModel,
 }
@@ -26,7 +23,9 @@ pub enum InvalidStructureError {
 impl fmt::Display for InvalidStructureError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            InvalidStructureError::ParsingError => write!(f, "Parsing error."),
+            InvalidStructureError::ParsingError(tobj_err) => {
+                write!(f, "Parsing error: {}", tobj_err)
+            }
             InvalidStructureError::DuplicateIndices => {
                 write!(f, "Duplicate indices were found in one of the models.")
             }
@@ -69,8 +68,8 @@ impl From<io::Error> for ImporterError {
 }
 
 impl From<tobj::LoadError> for ImporterError {
-    fn from(_err: tobj::LoadError) -> Self {
-        ImporterError::InvalidStructure(InvalidStructureError::ParsingError)
+    fn from(err: tobj::LoadError) -> Self {
+        ImporterError::InvalidStructure(InvalidStructureError::ParsingError(err))
     }
 }
 

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -161,18 +161,7 @@ impl<C: ObjCache> Importer<C> {
                 let models = match self.cache.get_by_checksum(checksum) {
                     Some(models) => models.clone(),
                     None => {
-                        let (mut tobj_models, _) =
-                            obj_buf_into_tobj(&mut file_contents.as_slice())?;
-                        let mut index = 0;
-
-                        while index != tobj_models.len() {
-                            if tobj_models[index].mesh.positions.is_empty() {
-                                tobj_models.remove(index);
-                            } else {
-                                index += 1;
-                            }
-                        }
-
+                        let (tobj_models, _) = obj_buf_into_tobj(&mut file_contents.as_slice())?;
                         tobj_to_internal(tobj_models)
                     }
                 };
@@ -207,6 +196,10 @@ pub fn tobj_to_internal(tobj_models: Vec<tobj::Model>) -> Vec<Model> {
     let mut models = Vec::with_capacity(tobj_models.len());
 
     for model in tobj_models {
+        if model.mesh.indices.is_empty() {
+            continue;
+        }
+
         let vertex_positions: Vec<_> = model
             .mesh
             .positions
@@ -253,6 +246,8 @@ pub fn tobj_to_internal(tobj_models: Vec<tobj::Model>) -> Vec<Model> {
             mesh,
         });
     }
+
+    models.shrink_to_fit();
 
     models
 }

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -41,7 +41,7 @@ impl error::Error for InvalidStructureError {}
 pub enum ImporterError {
     FileNotFound,
     PermissionDenied,
-    InvalidStructureError(InvalidStructureError),
+    InvalidStructure(InvalidStructureError),
     Other,
 }
 
@@ -49,9 +49,7 @@ impl fmt::Display for ImporterError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ImporterError::FileNotFound => write!(f, "File was not found."),
-            ImporterError::InvalidStructureError(e) => {
-                write!(f, "The obj file is not valid: {}", e)
-            }
+            ImporterError::InvalidStructure(e) => write!(f, "The obj file is not valid: {}", e),
             ImporterError::PermissionDenied => write!(f, "Permission denied."),
             ImporterError::Other => write!(f, "Unexpected error happened."),
         }
@@ -72,13 +70,13 @@ impl From<io::Error> for ImporterError {
 
 impl From<tobj::LoadError> for ImporterError {
     fn from(_err: tobj::LoadError) -> Self {
-        ImporterError::InvalidStructureError(InvalidStructureError::ParsingError)
+        ImporterError::InvalidStructure(InvalidStructureError::ParsingError)
     }
 }
 
 impl From<InvalidStructureError> for ImporterError {
     fn from(err: InvalidStructureError) -> Self {
-        ImporterError::InvalidStructureError(err)
+        ImporterError::InvalidStructure(err)
     }
 }
 

--- a/tests/fixtures/empty_model.obj
+++ b/tests/fixtures/empty_model.obj
@@ -1,0 +1,11 @@
+v 0 0 0
+v 1 0 0
+v 0 1 0
+v 2 0 0
+v 3 0 0
+v 2 1 0
+
+o Triangle1
+f 1 2 3
+
+o Triangle2

--- a/tests/fixtures/invalid_geometry_duplicate_indices.obj
+++ b/tests/fixtures/invalid_geometry_duplicate_indices.obj
@@ -1,0 +1,12 @@
+v 0 0 0
+v 1 0 0
+v 0 1 0
+v 2 0 0
+v 3 0 0
+v 2 1 0
+
+o Triangle1
+f 1 2 3
+
+o Triangle2
+f 4 5 5

--- a/tests/importer.rs
+++ b/tests/importer.rs
@@ -59,7 +59,9 @@ fn test_importer_import_obj_returns_error_when_importing_invalid_obj_file() {
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructure(InvalidStructureError::ParsingError)
+        ImporterError::InvalidStructure(InvalidStructureError::ParsingError(
+            tobj::LoadError::PositionParseError
+        ))
     );
 }
 
@@ -122,7 +124,9 @@ fn test_importer_import_obj_returns_error_when_invalid_unicode_character_is_enco
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructure(InvalidStructureError::ParsingError)
+        ImporterError::InvalidStructure(InvalidStructureError::ParsingError(
+            tobj::LoadError::ReadError
+        ))
     );
 }
 

--- a/tests/importer.rs
+++ b/tests/importer.rs
@@ -1,6 +1,8 @@
 use std::fs;
 
-use hurban_selector::importer::{self, EndlessCache, Importer, ImporterError, InvalidStructure};
+use hurban_selector::importer::{
+    self, EndlessCache, Importer, ImporterError, InvalidStructureError,
+};
 
 fn import_obj(path: &str) -> Vec<importer::Model> {
     let file_contents = fs::read(&path).expect("File should be read to bytes");
@@ -57,7 +59,7 @@ fn test_importer_import_obj_returns_error_when_importing_invalid_obj_file() {
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructure(InvalidStructure::ParsingError)
+        ImporterError::InvalidStructureError(InvalidStructureError::ParsingError)
     );
 }
 
@@ -120,7 +122,7 @@ fn test_importer_import_obj_returns_error_when_invalid_unicode_character_is_enco
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructure(InvalidStructure::ParsingError)
+        ImporterError::InvalidStructureError(InvalidStructureError::ParsingError)
     );
 }
 
@@ -135,7 +137,7 @@ fn test_importer_import_obj_returns_error_when_empty_model_is_encountered() {
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructure(InvalidStructure::BlankModel)
+        ImporterError::InvalidStructureError(InvalidStructureError::BlankModel)
     );
 }
 
@@ -150,6 +152,6 @@ fn test_importer_import_obj_returns_error_when_duplicate_indices_are_encountered
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructure(InvalidStructure::DuplicateIndices)
+        ImporterError::InvalidStructureError(InvalidStructureError::DuplicateIndices)
     );
 }

--- a/tests/importer.rs
+++ b/tests/importer.rs
@@ -59,7 +59,7 @@ fn test_importer_import_obj_returns_error_when_importing_invalid_obj_file() {
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructureError(InvalidStructureError::ParsingError)
+        ImporterError::InvalidStructure(InvalidStructureError::ParsingError)
     );
 }
 
@@ -122,7 +122,7 @@ fn test_importer_import_obj_returns_error_when_invalid_unicode_character_is_enco
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructureError(InvalidStructureError::ParsingError)
+        ImporterError::InvalidStructure(InvalidStructureError::ParsingError)
     );
 }
 
@@ -137,7 +137,7 @@ fn test_importer_import_obj_returns_error_when_empty_model_is_encountered() {
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructureError(InvalidStructureError::BlankModel)
+        ImporterError::InvalidStructure(InvalidStructureError::BlankModel)
     );
 }
 
@@ -152,6 +152,6 @@ fn test_importer_import_obj_returns_error_when_duplicate_indices_are_encountered
 
     assert_eq!(
         error,
-        ImporterError::InvalidStructureError(InvalidStructureError::DuplicateIndices)
+        ImporterError::InvalidStructure(InvalidStructureError::DuplicateIndices)
     );
 }

--- a/tests/importer.rs
+++ b/tests/importer.rs
@@ -116,3 +116,15 @@ fn test_importer_import_obj_returns_error_when_invalid_unicode_character_is_enco
 
     assert_eq!(error, ImporterError::InvalidStructure);
 }
+
+#[test]
+fn test_importer_import_obj_filters_empty_models() {
+    let cache = EndlessCache::default();
+    let mut importer = Importer::new(cache);
+
+    let models = importer
+        .import_obj(&"tests/fixtures/empty_model.obj")
+        .expect("Valid obj should be loaded");
+
+    assert_eq!(models.len(), 1);
+}


### PR DESCRIPTION
I have added filtering of empty models to importer side. Is it okay like this or should I move this functionality to some separate function?