### PR TITLE
Restore previous numbering of variable names in the pipeline window

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,16 +805,20 @@ pub fn init_and_run(options: Options) -> ! {
                             .map(|(value_path, (_, mesh))| {
                                 if value_path.1 == 0 {
                                     // Do not suffix zero mesh-array index
-                                    let name = match session.var_name_for_ident(value_path.0) {
-                                        Some(name) => Cow::Borrowed(name),
+                                    let name = match session
+                                        .var_decl_stmt_index_and_var_name_for_ident(value_path.0)
+                                    {
+                                        Some((_, name)) => Cow::Borrowed(name),
                                         None => Cow::Owned(value_path.0.to_string()),
                                     };
 
                                     (name, mesh.as_ref())
                                 } else {
                                     // Suffix mesh-array index if nonzero
-                                    let name = match session.var_name_for_ident(value_path.0) {
-                                        Some(name) => {
+                                    let name = match session
+                                        .var_decl_stmt_index_and_var_name_for_ident(value_path.0)
+                                    {
+                                        Some((_, name)) => {
                                             Cow::Owned(format!("{} [{}]", name, value_path.1))
                                         }
                                         None => Cow::Owned(format!(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2068,13 +2068,11 @@ impl<'a> UiFrame<'a> {
                     .expect("Failed to find nth visible var to display preview value")
             })
             .map(|var_ident| {
-                format_var_name(
-                    session
-                        .var_name_for_ident(var_ident)
-                        .expect("Failed to find name for ident"),
-                    var_ident,
-                    ty == Ty::MeshArray,
-                )
+                let (var_decl_stmt_index, var_name) = session
+                    .var_decl_stmt_index_and_var_name_for_ident(var_ident)
+                    .expect("Failed to find name for ident");
+
+                format_var_name(var_decl_stmt_index, var_name, ty == Ty::MeshArray)
             })
             .unwrap_or_else(|| imgui::ImString::new("<Select one option>"));
 
@@ -2100,13 +2098,11 @@ impl<'a> UiFrame<'a> {
         ]);
         if let Some(combo_token) = combo.begin(ui) {
             for (index, var_ident) in visible_vars_iter.clone().enumerate() {
-                let text = format_var_name(
-                    session
-                        .var_name_for_ident(var_ident)
-                        .expect("Failed to find name for ident"),
-                    var_ident,
-                    ty == Ty::MeshArray,
-                );
+                let (var_decl_stmt_index, var_name) = session
+                    .var_decl_stmt_index_and_var_name_for_ident(var_ident)
+                    .expect("Failed to find name for ident");
+
+                let text = format_var_name(var_decl_stmt_index, var_name, ty == Ty::MeshArray);
                 let selected = if let Some(selected_var_index) = selected_var_index {
                     index == selected_var_index
                 } else {
@@ -2147,14 +2143,14 @@ impl<'a> UiFrame<'a> {
 }
 
 fn format_var_name(
-    name: &str,
-    ident: ast::VarIdent,
+    var_decl_stmt_index: usize,
+    var_name: &str,
     surround_with_brackets: bool,
 ) -> imgui::ImString {
     if surround_with_brackets {
-        imgui::im_str!("[{}] #{}", name, ident.0 + 1)
+        imgui::im_str!("[{}] #{}", var_name, var_decl_stmt_index + 1)
     } else {
-        imgui::im_str!("{} #{}", name, ident.0 + 1)
+        imgui::im_str!("{} #{}", var_name, var_decl_stmt_index + 1)
     }
 }
 


### PR DESCRIPTION
Previously, we used the statement index to generate part of the displayed
variable names in the combo boxes. In the UI however, we did rely on the fact
that the var declaration statement index was the same as the internal raw value
of the variable indentifier.

This patch removes that incorrect assumption and once again uses the statement
index to generate the displayed human readable name.