### PR TITLE
Prevent imgui_winit_support changing cursor icon if outside window

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,7 @@ pub fn init_and_run(options: Options) -> ! {
 
     let window = winit::window::WindowBuilder::new()
         .with_title(BASE_WINDOW_TITLE)
+        .with_inner_size(winit::dpi::LogicalSize::new(1280, 720))
         .with_maximized(true)
         .with_window_icon(Some(icon))
         .build(&event_loop)


### PR DESCRIPTION
For some reason, this problem only manifested on Windows. Maybe other OSes don't
allow apps changing the cursor in certain priority conditions?

Tested on:

- [x] Windows (fixes the problem)
- [x] macOS (worked fine before and after)
- [x] X11 (worked fine before and after)