### PR TITLE
General operations for one and two scalar fields, explicit inner volumes

### DIFF
--- a/src/interpreter_funcs/voxel_boolean_intersection.rs
+++ b/src/interpreter_funcs/voxel_boolean_intersection.rs
@@ -11,7 +11,9 @@ use crate::interpreter::{
     BooleanParamRefinement, Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo,
     LogMessage, ParamInfo, ParamRefinement, Ty, UintParamRefinement, Value,
 };
-use crate::mesh::voxel_cloud::{self, FalloffFunction, ScalarField};
+use crate::mesh::voxel_cloud::{
+    self, FalloffFunction, OneVoxelFunction, ScalarField, TwoVoxelFunction,
+};
 
 const VOXEL_COUNT_THRESHOLD: u32 = 100_000;
 
@@ -105,6 +107,7 @@ impl Func for FuncBooleanIntersection {
                 }),
                 optional: false,
             },
+            // FIXME: Consider changing to volume range for consistency.
             ParamInfo {
                 name: "Grow",
                 description: "The voxelization algorithm puts voxels on the surface of \
@@ -219,14 +222,28 @@ impl Func for FuncBooleanIntersection {
         let mut voxel_cloud1 = ScalarField::from_mesh(mesh1, &voxel_dimensions, 0.0, growth_u32);
         let mut voxel_cloud2 = ScalarField::from_mesh(mesh2, &voxel_dimensions, 0.0, growth_u32);
 
-        voxel_cloud1.compute_distance_field(&(0.0..=0.0), FalloffFunction::Linear(1.0));
-        voxel_cloud2.compute_distance_field(&(0.0..=0.0), FalloffFunction::Linear(1.0));
+        let volume_value_range = 0.0..=0.0;
 
-        let meshing_range = if fill {
-            (Bound::Unbounded, Bound::Included(growth_f32))
-        } else {
-            (Bound::Included(-growth_f32), Bound::Included(growth_f32))
-        };
+        voxel_cloud1.compute_distance_field(&volume_value_range, FalloffFunction::Linear(1.0));
+        voxel_cloud2.compute_distance_field(&volume_value_range, FalloffFunction::Linear(1.0));
+
+        if fill {
+            let mut voxel_cloud1_inside =
+                voxel_cloud1.extract_voxels_inside_volumes(&volume_value_range);
+
+            let mut voxel_cloud2_inside =
+                voxel_cloud2.extract_voxels_inside_volumes(&volume_value_range);
+
+            voxel_cloud1_inside.apply_one_voxel_function(OneVoxelFunction::SetConstant(0.0));
+            voxel_cloud2_inside.apply_one_voxel_function(OneVoxelFunction::SetConstant(0.0));
+
+            voxel_cloud1
+                .apply_two_voxel_function(&voxel_cloud1_inside, TwoVoxelFunction::ReplaceValues);
+            voxel_cloud2
+                .apply_two_voxel_function(&voxel_cloud2_inside, TwoVoxelFunction::ReplaceValues);
+        }
+
+        let meshing_range = (Bound::Included(-growth_f32), Bound::Included(growth_f32));
 
         voxel_cloud1.boolean_intersection(&meshing_range, &voxel_cloud2, &meshing_range);
 

--- a/src/interpreter_funcs/voxel_boolean_intersection.rs
+++ b/src/interpreter_funcs/voxel_boolean_intersection.rs
@@ -12,7 +12,7 @@ use crate::interpreter::{
     LogMessage, ParamInfo, ParamRefinement, Ty, UintParamRefinement, Value,
 };
 use crate::mesh::voxel_cloud::{
-    self, FalloffFunction, OneVoxelFunction, ScalarField, TwoVoxelFunction,
+    self, BinaryVoxelFunction, FalloffFunction, ScalarField, UnaryVoxelFunction,
 };
 
 const VOXEL_COUNT_THRESHOLD: u32 = 100_000;
@@ -224,8 +224,8 @@ impl Func for FuncBooleanIntersection {
 
         let volume_value_range = 0.0..=0.0;
 
-        voxel_cloud1.compute_distance_field(&volume_value_range, FalloffFunction::Linear(1.0));
-        voxel_cloud2.compute_distance_field(&volume_value_range, FalloffFunction::Linear(1.0));
+        voxel_cloud1.compute_distance_field(&volume_value_range, 1.0, FalloffFunction::Linear);
+        voxel_cloud2.compute_distance_field(&volume_value_range, 1.0, FalloffFunction::Linear);
 
         if fill {
             let mut voxel_cloud1_inside =
@@ -234,18 +234,26 @@ impl Func for FuncBooleanIntersection {
             let mut voxel_cloud2_inside =
                 voxel_cloud2.extract_voxels_inside_volumes(&volume_value_range);
 
-            voxel_cloud1_inside.apply_one_voxel_function(OneVoxelFunction::SetConstant(0.0));
-            voxel_cloud2_inside.apply_one_voxel_function(OneVoxelFunction::SetConstant(0.0));
+            voxel_cloud1_inside.apply_unary_voxel_function(UnaryVoxelFunction::SetConstant(0.0));
+            voxel_cloud2_inside.apply_unary_voxel_function(UnaryVoxelFunction::SetConstant(0.0));
 
-            voxel_cloud1
-                .apply_two_voxel_function(&voxel_cloud1_inside, TwoVoxelFunction::ReplaceValues);
-            voxel_cloud2
-                .apply_two_voxel_function(&voxel_cloud2_inside, TwoVoxelFunction::ReplaceValues);
+            voxel_cloud1.apply_binary_voxel_function(
+                &voxel_cloud1_inside,
+                BinaryVoxelFunction::ReplaceIfValue,
+            );
+            voxel_cloud2.apply_binary_voxel_function(
+                &voxel_cloud2_inside,
+                BinaryVoxelFunction::ReplaceIfValue,
+            );
         }
 
         let meshing_range = (Bound::Included(-growth_f32), Bound::Included(growth_f32));
 
-        voxel_cloud1.boolean_intersection(&meshing_range, &voxel_cloud2, &meshing_range);
+        voxel_cloud1.apply_binary_voxel_function(
+            &voxel_cloud2,
+            BinaryVoxelFunction::BooleanAnd(meshing_range, meshing_range),
+        );
+        // voxel_cloud1.boolean_intersection(&meshing_range, &voxel_cloud2, &meshing_range);
 
         if !voxel_cloud1.contains_voxels_within_range(&meshing_range) {
             let error = FuncError::new(FuncBooleanIntersectionError::EmptyScalarField);

--- a/src/interpreter_funcs/voxel_boolean_union.rs
+++ b/src/interpreter_funcs/voxel_boolean_union.rs
@@ -12,7 +12,9 @@ use crate::interpreter::{
     BooleanParamRefinement, Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo,
     LogMessage, ParamInfo, ParamRefinement, Ty, UintParamRefinement, Value,
 };
-use crate::mesh::voxel_cloud::{self, FalloffFunction, ScalarField};
+use crate::mesh::voxel_cloud::{
+    self, FalloffFunction, OneVoxelFunction, ScalarField, TwoVoxelFunction,
+};
 
 const VOXEL_COUNT_THRESHOLD: u32 = 100_000;
 
@@ -109,6 +111,7 @@ impl Func for FuncBooleanUnion {
                 }),
                 optional: false,
             },
+            // FIXME: Consider changing to volume range for consistency.
             ParamInfo {
                 name: "Grow",
                 description: "The voxelization algorithm puts voxels on the surface of \
@@ -221,14 +224,28 @@ impl Func for FuncBooleanUnion {
         let mut voxel_cloud1 = ScalarField::from_mesh(mesh1, &voxel_dimensions, 0.0, growth_u32);
         let mut voxel_cloud2 = ScalarField::from_mesh(mesh2, &voxel_dimensions, 0.0, growth_u32);
 
-        voxel_cloud1.compute_distance_field(&(0.0..=0.0), FalloffFunction::Linear(1.0));
-        voxel_cloud2.compute_distance_field(&(0.0..=0.0), FalloffFunction::Linear(1.0));
+        let volume_value_range = 0.0..=0.0;
 
-        let meshing_range = if fill {
-            (Bound::Unbounded, Bound::Included(growth_f32))
-        } else {
-            (Bound::Included(-growth_f32), Bound::Included(growth_f32))
-        };
+        voxel_cloud1.compute_distance_field(&volume_value_range, FalloffFunction::Linear(1.0));
+        voxel_cloud2.compute_distance_field(&volume_value_range, FalloffFunction::Linear(1.0));
+
+        if fill {
+            let mut voxel_cloud1_inside =
+                voxel_cloud1.extract_voxels_inside_volumes(&volume_value_range);
+
+            let mut voxel_cloud2_inside =
+                voxel_cloud2.extract_voxels_inside_volumes(&volume_value_range);
+
+            voxel_cloud1_inside.apply_one_voxel_function(OneVoxelFunction::SetConstant(0.0));
+            voxel_cloud2_inside.apply_one_voxel_function(OneVoxelFunction::SetConstant(0.0));
+
+            voxel_cloud1
+                .apply_two_voxel_function(&voxel_cloud1_inside, TwoVoxelFunction::ReplaceValues);
+            voxel_cloud2
+                .apply_two_voxel_function(&voxel_cloud2_inside, TwoVoxelFunction::ReplaceValues);
+        }
+
+        let meshing_range = (Bound::Included(-growth_f32), Bound::Included(growth_f32));
 
         voxel_cloud1.boolean_union(&meshing_range, &voxel_cloud2, &meshing_range);
 

--- a/src/interpreter_funcs/voxel_interpolated_union.rs
+++ b/src/interpreter_funcs/voxel_interpolated_union.rs
@@ -12,7 +12,7 @@ use crate::interpreter::{
     BooleanParamRefinement, Float3ParamRefinement, FloatParamRefinement, Func, FuncError,
     FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty, Value,
 };
-use crate::mesh::voxel_cloud::{self, FalloffFunction, ScalarField, TwoVoxelFunction};
+use crate::mesh::voxel_cloud::{self, BinaryVoxelFunction, FalloffFunction, ScalarField};
 
 const VOXEL_COUNT_THRESHOLD: u32 = 100_000;
 
@@ -234,13 +234,13 @@ impl Func for FuncInterpolatedUnion {
                 .copied(),
         ) {
             voxel_cloud1.resize_to_bounding_box_cartesian_space(&bounding_box);
-            voxel_cloud1.compute_distance_field(&volume_value_range, FalloffFunction::Linear(1.0));
+            voxel_cloud1.compute_distance_field(&volume_value_range, 1.0, FalloffFunction::Linear);
             voxel_cloud2.resize_to_bounding_box_cartesian_space(&bounding_box);
-            voxel_cloud2.compute_distance_field(&volume_value_range, FalloffFunction::Linear(1.0));
+            voxel_cloud2.compute_distance_field(&volume_value_range, 1.0, FalloffFunction::Linear);
 
-            voxel_cloud1.apply_two_voxel_function(
+            voxel_cloud1.apply_binary_voxel_function(
                 &voxel_cloud2,
-                TwoVoxelFunction::LinearInterpolation(interpolation_factor),
+                BinaryVoxelFunction::InterpolateLinear(interpolation_factor),
             );
         }
 

--- a/src/interpreter_funcs/voxel_interpolated_union.rs
+++ b/src/interpreter_funcs/voxel_interpolated_union.rs
@@ -12,7 +12,7 @@ use crate::interpreter::{
     BooleanParamRefinement, Float3ParamRefinement, FloatParamRefinement, Func, FuncError,
     FuncFlags, FuncInfo, LogMessage, ParamInfo, ParamRefinement, Ty, Value,
 };
-use crate::mesh::voxel_cloud::{self, FalloffFunction, ScalarField};
+use crate::mesh::voxel_cloud::{self, FalloffFunction, ScalarField, TwoVoxelFunction};
 
 const VOXEL_COUNT_THRESHOLD: u32 = 100_000;
 
@@ -238,7 +238,10 @@ impl Func for FuncInterpolatedUnion {
             voxel_cloud2.resize_to_bounding_box_cartesian_space(&bounding_box);
             voxel_cloud2.compute_distance_field(&volume_value_range, FalloffFunction::Linear(1.0));
 
-            voxel_cloud1.interpolate_to(&voxel_cloud2, interpolation_factor);
+            voxel_cloud1.apply_two_voxel_function(
+                &voxel_cloud2,
+                TwoVoxelFunction::LinearInterpolation(interpolation_factor),
+            );
         }
 
         if !voxel_cloud1.contains_voxels_within_range(&volume_value_range) {

--- a/src/interpreter_funcs/voxel_noise.rs
+++ b/src/interpreter_funcs/voxel_noise.rs
@@ -175,12 +175,12 @@ impl Func for FuncVoxelNoise {
         let voxel_dimensions = Vector3::from(args[2].unwrap_float3());
         let noise_scale = args[3].unwrap_float();
         let time_offset = args[4].unwrap_float();
-        let volume_range_raw = args[5].unwrap_float2();
+        let volume_value_range_raw = args[5].unwrap_float2();
         let marching_cubes = args[6].unwrap_boolean();
         let error_if_large = args[7].unwrap_boolean();
         let analyze_mesh = args[8].unwrap_boolean();
 
-        let meshing_range = volume_range_raw[0]..=volume_range_raw[1];
+        let meshing_range = volume_value_range_raw[0]..=volume_value_range_raw[1];
 
         if voxel_dimensions.iter().any(|dimension| *dimension <= 0.0) {
             let error = FuncError::new(FuncVoxelNoiseError::VoxelDimensionsZeroOrLess);

--- a/src/interpreter_funcs/voxelize.rs
+++ b/src/interpreter_funcs/voxelize.rs
@@ -11,7 +11,9 @@ use crate::interpreter::{
     BooleanParamRefinement, Float3ParamRefinement, Func, FuncError, FuncFlags, FuncInfo,
     LogMessage, ParamInfo, ParamRefinement, Ty, UintParamRefinement, Value,
 };
-use crate::mesh::voxel_cloud::{self, FalloffFunction, ScalarField};
+use crate::mesh::voxel_cloud::{
+    self, FalloffFunction, OneVoxelFunction, ScalarField, TwoVoxelFunction,
+};
 
 const VOXEL_COUNT_THRESHOLD: u32 = 100_000;
 
@@ -96,6 +98,7 @@ impl Func for FuncVoxelize {
                 }),
                 optional: false,
             },
+            // FIXME: Consider changing to volume range for consistency.
             ParamInfo {
                 name: "Grow",
                 description: "The voxelization algorithm puts voxels on the surface of \
@@ -203,7 +206,16 @@ impl Func for FuncVoxelize {
 
         let mut scalar_field = ScalarField::from_mesh(mesh, &voxel_dimensions, 0.0, growth_u32);
 
-        scalar_field.compute_distance_field(&(0.0..=0.0), FalloffFunction::Linear(1.0));
+        let volume_range = 0.0..=0.0;
+
+        scalar_field.compute_distance_field(&volume_range, FalloffFunction::Linear(1.0));
+
+        if fill {
+            let mut scalar_field_inside = scalar_field.extract_voxels_inside_volumes(&volume_range);
+            scalar_field_inside.apply_one_voxel_function(OneVoxelFunction::SetConstant(0.0));
+            scalar_field
+                .apply_two_voxel_function(&scalar_field_inside, TwoVoxelFunction::ReplaceValues);
+        }
 
         let meshing_range = if fill {
             (Bound::Unbounded, Bound::Included(growth_f32))

--- a/src/mesh/voxel_cloud.rs
+++ b/src/mesh/voxel_cloud.rs
@@ -98,7 +98,7 @@ impl OneVoxelFunction {
             }
             OneVoxelFunction::PowF(value) => voxel.map(|value_self| value_self.powf(value)),
             OneVoxelFunction::Replace(search_value, replacement_value) => voxel.map(|value_self| {
-                if value_self == search_value {
+                if approx::relative_eq!(value_self, search_value) {
                     replacement_value
                 } else {
                     value_self


### PR DESCRIPTION
In this PR

- Mathematical operations on values of a single scalar field are now a general function with an enum param, which defines the specific function to perform
- Mathematical operations on values of two scalar fields are now a general function with an enum param, which defines the specific function to perform
- Detection of voxels inside watertight volumes is now explicit

**UI problem: for Metaballs, the volume value range is `infinity..=infinity` due to the nature of the inverse square falloff function. Even though this is correct, it causes a UI problem when setting the volume range params. Suggestions?**

_Note: This is the last feature PR from me. There will be one more which cleans up naming code of the scalar field related fields._